### PR TITLE
Update tag_8_1_1.rst

### DIFF
--- a/src_docs/source/test_results/node/tag_8_1_1.rst
+++ b/src_docs/source/test_results/node/tag_8_1_1.rst
@@ -33,7 +33,7 @@ Regression testing on a local cluster
      - |:heavy_check_mark:|
    * - P2P OFF - `Babbage with Shelley TX <https://cardano-tests-reports-3-74-115-22.nip.io/01-regression-tests/8.1.1-shelley_legacy_01/>`__
      - |:heavy_check_mark:|
-   * - Plutus Functionality using `Antaeus <https://github.com/input-output-hk/antaeus/tree/cardano-node_8-1-1>`__ - `Multi-era (without V3 scripts) <https://cardano-tests-reports-3-74-115-22.nip.io/antaeus/8.1.1/>`__
+   * - Plutus Functionality using `Antaeus <https://github.com/input-output-hk/antaeus/tree/cardano-node_8-1-1>`__ - `Multi-era (with V3 scripts) <https://cardano-tests-reports-3-74-115-22.nip.io/antaeus/8.1.1/>`__
      - |:heavy_check_mark:|
 
 .. list-table:: Other Testing


### PR DESCRIPTION
PlutusV3 scripts were possible in 8.1.1. Although they used the V1 TxInfo, it still proved the Scott-encoding and new builtins function correctly.