### PR TITLE
Add drep de/registration db-sync checks

### DIFF
--- a/cardano_node_tests/utils/dbsync_types.py
+++ b/cardano_node_tests/utils/dbsync_types.py
@@ -193,3 +193,17 @@ class CommitteeDeregistrationRecord:
     cert_index: int
     voting_anchor_id: int
     cold_key: str
+
+
+@dataclasses.dataclass(frozen=True, order=True)
+class DrepRegistrationRecord:
+    # pylint: disable-next=invalid-name
+    id: int
+    tx_id: int
+    cert_index: int
+    deposit: int
+    drep_hash_id: int
+    voting_anchor_id: int
+    hash_hex: str
+    hash_bech32: str
+    has_script: bool


### PR DESCRIPTION
For `Dreps`  there is only one table `drep_registration` that contains both:
- registrations 
- deregistrations

```sql
select dr.id, dr.tx_id, dr.cert_index, dr.deposit, dr.drep_hash_id, dr.voting_anchor_id, dh.raw, dh.view, dh.has_script from drep_registration as dr inner join drep_hash  dh on dh.id = dr.drep_hash_id where dh.raw = '\x27497d7db01ce343862ad3d58c6f6eb8b9321d830be394c0f295fd1c'
 id | tx_id | cert_index | deposit  | drep_hash_id | voting_anchor_id |                            raw                             |                           view                           | has_script 
----+-------+------------+----------+--------------+------------------+------------------------------------------------------------+----------------------------------------------------------+------------
 97 |   127 |          0 |  2000000 |           97 |                1 | \x27497d7db01ce343862ad3d58c6f6eb8b9321d830be394c0f295fd1c | drep1yayh6ldsrn358p32602ccmmwhzuny8vrp03efs8jjh73c470pk3 | f
 98 |   128 |          0 | -2000000 |           97 |                  | \x27497d7db01ce343862ad3d58c6f6eb8b9321d830be394c0f295fd1c | drep1yayh6ldsrn358p32602ccmmwhzuny8vrp03efs8jjh73c470pk3 | f
(2 rows)
```
so they can be distinguished by e.g. deposits.
Records with the same `drep_hash_id` (ordered by `tx_id`) but negative amounts for deposit mean that `drep` was deregistered.