### PR TITLE
Update Conway CIP073 coverage

### DIFF
--- a/cardano_node_tests/tests/tests_conway/test_committee.py
+++ b/cardano_node_tests/tests/tests_conway/test_committee.py
@@ -363,6 +363,7 @@ class TestCommittee:
         req_cip40 = requirements.Req(id="CIP040", group=requirements.GroupsKnown.CHANG_US)
         req_cip58 = requirements.Req(id="CIP058", group=requirements.GroupsKnown.CHANG_US)
         req_cip67 = requirements.Req(id="CIP067", group=requirements.GroupsKnown.CHANG_US)
+        req_cip73_3 = requirements.Req(id="intCIP073-03", group=requirements.GroupsKnown.CHANG_US)
 
         # Auth keys for CC members
         cc_auth_record1 = governance_utils.get_cc_member_auth_record(
@@ -782,8 +783,10 @@ class TestCommittee:
         conway_common.save_gov_state(
             gov_state=enact_add_gov_state, name_template=f"{temp_template}_enact_add_{_cur_epoch}"
         )
-        _check_add_state(gov_state=enact_add_gov_state["enactState"])
-        req_cip40.success()
+
+        req_cip73_3.start(url=helpers.get_vcs_link())
+        _check_add_state(enact_add_gov_state["enactState"])
+        [r.success() for r in (req_cip40, req_cip73_3)]
 
         # Check committee state after enactment
         enact_add_committee_state = cluster.g_conway_governance.query.committee_state()

--- a/cardano_node_tests/tests/tests_conway/test_constitution.py
+++ b/cardano_node_tests/tests/tests_conway/test_constitution.py
@@ -72,6 +72,8 @@ class TestConstitution:
         req_cip1b = requirements.Req(id="CIP001b", group=requirements.GroupsKnown.CHANG_US)
         req_cip31a = requirements.Req(id="intCIP031a-02", group=requirements.GroupsKnown.CHANG_US)
         req_cip42 = requirements.Req(id="CIP042", group=requirements.GroupsKnown.CHANG_US)
+        req_cip73_1 = requirements.Req(id="intCIP073-01", group=requirements.GroupsKnown.CHANG_US)
+        req_cip73_4 = requirements.Req(id="intCIP073-04", group=requirements.GroupsKnown.CHANG_US)
 
         # Create an action
 
@@ -211,9 +213,9 @@ class TestConstitution:
 
         next_rat_state = rat_gov_state["nextRatifyState"]
         _url = helpers.get_vcs_link()
-        [r.start(url=_url) for r in (req_cli1, req_cip1a, req_cip1b)]
+        [r.start(url=_url) for r in (req_cli1, req_cip1a, req_cip1b, req_cip73_1, req_cip73_4)]
         _check_state(next_rat_state["nextEnactState"])
-        [r.success() for r in (req_cli1, req_cip1a, req_cip1b)]
+        [r.success() for r in (req_cli1, req_cip1a, req_cip1b, req_cip73_1)]
         assert next_rat_state["ratificationDelayed"], "Ratification not delayed"
 
         # Check enactment
@@ -223,7 +225,7 @@ class TestConstitution:
             gov_state=enact_gov_state, name_template=f"{temp_template}_enact_{_cur_epoch}"
         )
         _check_state(enact_gov_state["enactState"])
-        req_cip42.success()
+        [r.success() for r in (req_cip42, req_cip73_4)]
 
         req_cli36.start(url=helpers.get_vcs_link())
         _check_cli_query()

--- a/src_docs/requirements_mapping.json
+++ b/src_docs/requirements_mapping.json
@@ -7,6 +7,7 @@
             "intCIP031a-04", "intCIP031a-05", "intCIP031a-06"
         ],
         "CIP032": ["intCIP032en", "intCIP032ex"],
-        "CIP034": ["intCIP034en", "intCIP034ex"]
+        "CIP034": ["intCIP034en", "intCIP034ex"],
+        "CIP073": ["intCIP073-01", "intCIP073-02", "intCIP073-03", "intCIP073-04"]
     }
 }


### PR DESCRIPTION
CIP073

> As a Stakeholder I want the ledger to adjust the local state query protocol to accommodate for new queries that provide insights about governance, at least:
> 
> - Governance actions currently staged for enactment (1)
> - Governance actions under ratification, with the total and percentage of yes stake, no stake and abstain stake (2)
> - The current constitutional committee (3), and constitution hash digest (4)

This is partial covered, it's missing point (2) that we have to confirm the proper behaviour