### PR TITLE
Fix metadata test

### DIFF
--- a/cardano_node_tests/utils/dbsync_utils.py
+++ b/cardano_node_tests/utils/dbsync_utils.py
@@ -737,8 +737,11 @@ def check_pool_off_chain_fetch_error(
     metadata_url = (ledger_pool_data.get("metadata") or {}).get("url") or ""
 
     assert (
-        f"Error Offchain Pool: Connection failure error when fetching metadata from {metadata_url}"
+        f'Connection failure error when fetching metadata from PoolUrl "{metadata_url}"'
         in fetch_error_str
+    ) or (
+        f"Error Offchain Pool: Connection failure error when fetching metadata from {metadata_url}"
+        in fetch_error_str  # in db-sync > 13.2.0.1
     ), f"The error is not the expected one: {fetch_error_str}"
 
     return db_pool_off_chain_fetch_error[0]

--- a/cardano_node_tests/utils/dbsync_utils.py
+++ b/cardano_node_tests/utils/dbsync_utils.py
@@ -737,7 +737,7 @@ def check_pool_off_chain_fetch_error(
     metadata_url = (ledger_pool_data.get("metadata") or {}).get("url") or ""
 
     assert (
-        f'Connection failure error when fetching metadata from PoolUrl "{metadata_url}"'
+        f"Error Offchain Pool: Connection failure error when fetching metadata from {metadata_url}"
         in fetch_error_str
     ), f"The error is not the expected one: {fetch_error_str}"
 


### PR DESCRIPTION
Update expected fetch error string. 

Local tests passed:

```
pytest -k "test_stake_pool_not_avail_metadata" cardano_node_tests
==================================================================================================================================== test session starts ====================================================================================================================================
platform linux -- Python 3.10.12, pytest-7.4.0, pluggy-1.2.0 -- /nix/store/lx8vhp4fxclp494svlfis3sb2g8z4l9h-python3-3.10.12/bin/python3.10
cachedir: .pytest_cache
hypothesis profile 'default' -> database=DirectoryBasedExampleDatabase('/home/artur/Downloads/NewTests/cardano-node-tests/.hypothesis/examples')
metadata: {'Python': '3.10.12', 'Platform': 'Linux-5.15.0-101-generic-x86_64-with-glibc2.37', 'Packages': {'pytest': '7.4.0', 'pluggy': '1.2.0'}, 'Plugins': {'allure-pytest': '2.13.2', 'hypothesis': '6.82.6', 'html': '3.2.0', 'metadata': '3.0.0', 'order': '1.1.0', 'select': '0.1.2', 'xdist': '3.3.1'}, 'cardano-node': '8.9.0', 'cardano-node rev': '0d98405a60d57e1c8e13406d51cce0e34356bd64', 'cardano-node ghc': 'ghc-8.10', 'cardano-cli': '8.20.3.0', 'cardano-cli rev': '0d98405a60d57e1c8e13406d51cce0e34356bd64', 'cardano-cli ghc': 'ghc-8.10', 'CLUSTER_ERA': 'conway', 'TX_ERA': '', 'COMMAND_ERA': 'conway', 'SCRIPTS_DIRNAME': 'conway_fast', 'ENABLE_P2P': 'False', 'MIXED_P2P': 'False', 'NUM_POOLS': '3', 'DB_BACKEND': '', 'HAS_CC': 'True', 'cardano-node-tests rev': 'e8552b7da2bf615db84712ac8f77cc659509834b', 'cardano-node-tests url': 'https://github.com/IntersectMBO/cardano-node-tests/tree/e8552b7da2bf615db84712ac8f77cc659509834b', 'CARDANO_NODE_SOCKET_PATH': '/home/artur/Downloads/NewTests/cardano-node-tests/dev_workdir/state-cluster0/bft1.socket', 'cardano-cli exe': '/nix/store/wa9myiic5nldzx4j5v0gjdyqfwrrkf07-cardano-cli-exe-cardano-cli-8.20.3.0/bin/cardano-cli', 'cardano-node exe': '/nix/store/gl0hw4rdk5llvqlkqarqiw9qq6kkjwr8-cardano-node-exe-cardano-node-8.9.0/bin/cardano-node', 'cardano-submit-api exe': '/nix/store/m18903qig8bxpmfjw283k6b2cyfv8m4j-cardano-submit-api-exe-cardano-submit-api-3.2.2/bin/cardano-submit-api', 'network magic': 42, 'HAS_DBSYNC': 'True', 'db-sync': '13.2.0.1', 'db-sync rev': 'd249be066beb22a918ed60b4952a2370aca5a28a', 'db-sync ghc': 'ghc-8.10', 'db-sync exe': '/nix/store/fsq0gpjs0g177pnyg6idjalq4n0hmx9q-cardano-db-sync-exe-cardano-db-sync-13.2.0.1/bin/cardano-db-sync'}
rootdir: /home/artur/Downloads/NewTests/cardano-node-tests
configfile: pyproject.toml
plugins: allure-pytest-2.13.2, hypothesis-6.82.6, html-3.2.0, metadata-3.0.0, order-1.1.0, select-0.1.2, xdist-3.3.1
collected 1351 items / 1349 deselected / 2 selected                                                                                                                                                                                                                                         

cardano_node_tests/tests/test_pools.py::TestStakePool::test_stake_pool_not_avail_metadata[build_raw]@long 
-------------------------------------------------------------------------------------------------------------------------------------- live log setup ---------------------------------------------------------------------------------------------------------------------------------------
INFO     cardano_node_tests.tests.conftest:conftest.py:188 Changed CWD to '/home/artur/Downloads/NewTests/cardano-node-tests/dev_workdir/tmp/pytest-of-artur/pytest-5'.
--------------------------------------------------------------------------------------------------------------------------------------- live log call ---------------------------------------------------------------------------------------------------------------------------------------
INFO     cardano_node_tests.tests.test_pools:test_pools.py:102 Waiting up to 3 full epochs for stake pool to be registered.
WARNING  cardano_node_tests.utils.dbsync_utils:dbsync_utils.py:486 Sleeping 3s before repeating query for the 1 time.
WARNING  cardano_node_tests.utils.dbsync_utils:dbsync_utils.py:486 Sleeping 6s before repeating query for the 2 time.
WARNING  cardano_node_tests.utils.dbsync_utils:dbsync_utils.py:486 Sleeping 11s before repeating query for the 3 time.
WARNING  cardano_node_tests.utils.dbsync_utils:dbsync_utils.py:486 Sleeping 18s before repeating query for the 4 time.
WARNING  cardano_node_tests.utils.dbsync_utils:dbsync_utils.py:486 Sleeping 27s before repeating query for the 5 time.
WARNING  cardano_node_tests.utils.dbsync_utils:dbsync_utils.py:486 Sleeping 38s before repeating query for the 6 time.
WARNING  cardano_node_tests.utils.dbsync_utils:dbsync_utils.py:486 Sleeping 51s before repeating query for the 7 time.
WARNING  cardano_node_tests.utils.dbsync_utils:dbsync_utils.py:486 Sleeping 66s before repeating query for the 8 time.
WARNING  cardano_node_tests.utils.dbsync_utils:dbsync_utils.py:486 Sleeping 83s before repeating query for the 9 time.
PASSED                                                                                                                                                                                                                                                                                [ 50%]
cardano_node_tests/tests/test_pools.py::TestStakePool::test_stake_pool_not_avail_metadata[build]@long 
--------------------------------------------------------------------------------------------------------------------------------------- live log call ---------------------------------------------------------------------------------------------------------------------------------------
INFO     cardano_node_tests.tests.test_pools:test_pools.py:102 Waiting up to 3 full epochs for stake pool to be registered.
WARNING  cardano_node_tests.utils.dbsync_utils:dbsync_utils.py:486 Sleeping 3s before repeating query for the 1 time.
WARNING  cardano_node_tests.utils.dbsync_utils:dbsync_utils.py:486 Sleeping 6s before repeating query for the 2 time.
WARNING  cardano_node_tests.utils.dbsync_utils:dbsync_utils.py:486 Sleeping 11s before repeating query for the 3 time.
WARNING  cardano_node_tests.utils.dbsync_utils:dbsync_utils.py:486 Sleeping 18s before repeating query for the 4 time.
WARNING  cardano_node_tests.utils.dbsync_utils:dbsync_utils.py:486 Sleeping 27s before repeating query for the 5 time.
WARNING  cardano_node_tests.utils.dbsync_utils:dbsync_utils.py:486 Sleeping 38s before repeating query for the 6 time.
WARNING  cardano_node_tests.utils.dbsync_utils:dbsync_utils.py:486 Sleeping 51s before repeating query for the 7 time.
WARNING  cardano_node_tests.utils.dbsync_utils:dbsync_utils.py:486 Sleeping 66s before repeating query for the 8 time.
WARNING  cardano_node_tests.utils.dbsync_utils:dbsync_utils.py:486 Sleeping 83s before repeating query for the 9 time.
PASSED                                                                                                                                                                                                                                                                                [100%]
------------------------------------------------------------------------------------------------------------------------------------- live log teardown -------------------------------------------------------------------------------------------------------------------------------------
INFO     cardano_node_tests.utils.dbsync_conn:dbsync_conn.py:34 Closing connection to db-sync database dbsync0.

================================================================================================================ 2 passed, 1349 deselected, 2 warnings in 642.60s (0:10:42) =================================================================================================================

```