### PR TITLE
Update to fix issues introduced by db-sync sancho-4-2-0 changes

### DIFF
--- a/cardano_node_tests/tests/test_dbsync.py
+++ b/cardano_node_tests/tests/test_dbsync.py
@@ -66,6 +66,7 @@ class TestDBSync:
         "reserve",
         "reserved_pool_ticker",
         "reward",
+        "reward_rest",
         "schema_version",
         "script",
         "slot_leader",

--- a/cardano_node_tests/utils/dbsync_utils.py
+++ b/cardano_node_tests/utils/dbsync_utils.py
@@ -39,7 +39,7 @@ def get_address_reward(
             )
         )
 
-    for db_row in dbsync_queries.query_address_instant_reward(
+    for db_row in dbsync_queries.query_address_reward_rest(
         address=address, epoch_from=epoch_from, epoch_to=epoch_to
     ):
         rewards.append(


### PR DESCRIPTION
Update to fix issues introduced by db-sync sancho-4-2-0 changes.

Full test log:
[testrun-full.txt](https://github.com/IntersectMBO/cardano-node-tests/files/15065862/testrun-full.txt)

HTML report:
[testrun-report.tar.gz](https://github.com/IntersectMBO/cardano-node-tests/files/15065899/testrun-report.tar.gz)

Before changes results looked like this:

```
SKIPPED [2] cardano_node_tests/tests/tests_plutus/test_delegation.py:687: PlutusV1 doesn't support reference scripts
SKIPPED [1] cardano_node_tests/tests/test_cli.py:965: The 'total_stake' scenario not available with this cardano-cli version.
< ... >
XFAIL cardano_node_tests/tests/tests_plutus/test_spend_raw.py::TestLocking::test_context_equivalence - reason: <GHIssue: IntersectMBO/plutus-apps#1107>: PlutusScriptV1 custom redeemer.
FAILED cardano_node_tests/tests/test_staking_rewards.py::TestRewards::test_2_pools_same_reward_addr@long - psycopg2.errors.UndefinedTable: relation "instant_reward" does not exist
FAILED cardano_node_tests/tests/test_delegation.py::TestDelegateAddr::test_undelegate@long - psycopg2.errors.UndefinedTable: relation "instant_reward" does not exist
FAILED cardano_node_tests/tests/test_mir_certs.py::TestMIRCerts::test_build_transfer_to_treasury - psycopg2.errors.UndefinedColumn: column "deposits" does not exist
FAILED cardano_node_tests/tests/test_mir_certs.py::TestMIRCerts::test_build_transfer_to_reserves - psycopg2.errors.UndefinedColumn: column "deposits" does not exist
FAILED cardano_node_tests/tests/test_mir_certs.py::TestMIRCerts::test_pay_unregistered_stake_addr_from[reserves-addr_known] - psycopg2.errors.UndefinedColumn: column "deposits" does not exist
FAILED cardano_node_tests/tests/test_staking_rewards.py::TestRewards::test_reward_addr_delegation@long - psycopg2.errors.UndefinedTable: relation "instant_reward" does not exist
FAILED cardano_node_tests/tests/test_staking_rewards.py::TestRewards::test_redelegation@long - psycopg2.errors.UndefinedTable: relation "instant_reward" does not exist
FAILED cardano_node_tests/tests/test_mir_certs.py::TestMIRCerts::test_pay_unregistered_stake_addr_from[treasury-addr_unknown] - psycopg2.errors.UndefinedColumn: column "deposits" does not exist
FAILED cardano_node_tests/tests/test_mir_certs.py::TestMIRCerts::test_transfer_to_treasury - psycopg2.errors.UndefinedColumn: column "deposits" does not exist
FAILED cardano_node_tests/tests/test_mir_certs.py::TestMIRCerts::test_transfer_to_reserves - psycopg2.errors.UndefinedColumn: column "deposits" does not exist
FAILED cardano_node_tests/tests/test_mir_certs.py::TestMIRCerts::test_pay_unregistered_stake_addr_from[reserves-addr_unknown] - psycopg2.errors.UndefinedColumn: column "deposits" does not exist
FAILED cardano_node_tests/tests/test_staking_rewards.py::TestRewards::test_reward_amount@long - psycopg2.errors.UndefinedTable: relation "instant_reward" does not exist
FAILED cardano_node_tests/tests/test_mir_certs.py::TestMIRCerts::test_pay_unregistered_stake_addr_from[treasury-addr_known] - psycopg2.errors.UndefinedColumn: column "deposits" does not exist
```
