### PR TITLE
Add `EnableFutureGenesis` flag to db-sync config

### DIFF
--- a/cardano_node_tests/cluster_scripts/conway/dbsync-config.yaml
+++ b/cardano_node_tests/cluster_scripts/conway/dbsync-config.yaml
@@ -4,6 +4,7 @@ NetworkName: localnet
 
 EnableLogMetrics: False
 EnableLogging: True
+EnableFutureGenesis: True
 
 # The default port is 8080
 # PrometheusPort: 8080

--- a/cardano_node_tests/cluster_scripts/conway_fast/dbsync-config.yaml
+++ b/cardano_node_tests/cluster_scripts/conway_fast/dbsync-config.yaml
@@ -4,6 +4,7 @@ NetworkName: localnet
 
 EnableLogMetrics: False
 EnableLogging: True
+EnableFutureGenesis: True
 
 # The default port is 8080
 # PrometheusPort: 8080


### PR DESCRIPTION
- EnableFutureGenesis flag - when false or missing, the conway genesis file is ignored