### PR TITLE
Update docker tests

### DIFF
--- a/.github/workflows/db_sync_docker_sync_test.yaml
+++ b/.github/workflows/db_sync_docker_sync_test.yaml
@@ -6,14 +6,22 @@ on:
       db_sync_branch:
         description: cardano-db-sync branch that will be used
         required: true
-        default: "13.0.5-extra-args"
+        default: "13.3.0.0"
+      node_image_version:
+        description: node image version to use
+        required: false
+        default: "cardano-node:9.0.0"
+      db_sync_image_version:
+        description: db-sync image version to use
+        required: false
+        default: "cardano-db-sync:13.3.0.0"
 
 jobs:
   setup_and_start_db_sync:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        env: [mainnet, preprod, preview]
+        env: [mainnet, preprod, preview, sanchonet]
       fail-fast: false
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
@@ -31,6 +39,11 @@ jobs:
           cd cardano-db-sync
           echo "DB_SYNC_REVISION=$(git rev-parse --short=40 HEAD)" >> $GITHUB_ENV
           echo "DB_SYNC_VERSION=$(echo ${{ inputs.db_sync_branch }} | grep -oE "(\w*[.]\w*)*")" >> $GITHUB_ENV
+          # Update the cardano-db-sync image version
+          sed -i "s|ghcr.io/intersectmbo/cardano-db-sync:[^ ]*|ghcr.io/intersectmbo/${{ inputs.db_sync_image_version }}|" docker-compose.yml
+          # Update the cardano-node image version
+          sed -i "s|ghcr.io/intersectmbo/cardano-node:[^ ]*|ghcr.io/intersectmbo/${{ inputs.node_image_version }}|" docker-compose.yml
+          cat docker-compose.yml
           sudo NETWORK=${{ matrix.env }} docker-compose up -d
 
       - name: Wait for 60 seconds
@@ -55,22 +68,37 @@ jobs:
           if grep -i ${{ env.DB_SYNC_VERSION }} "db_sync_no_flags_logs.txt"; then echo "Correct version"; else echo "WRONG Version !" && exit 1; fi
           if grep -i ${{ env.DB_SYNC_REVISION }} "db_sync_no_flags_logs.txt"; then echo "Correct SHA"; else echo "WRONG SHA !" && exit 1; fi
 
-      - name: Flags Check - Should be False
+      - name: Default Options Check
         run: |
           cd cardano-db-sync
-          if grep -i "Option disable-ledger: False" "db_sync_no_flags_logs.txt"; then echo "Flag disable-ledger set to False"; else echo "disable-ledger = True !" && exit 1; fi
-          if grep -i "Option disable-cache: False" "db_sync_no_flags_logs.txt"; then echo "Flag disable-cache set to False"; else echo "disable-cache = True !" && exit 1; fi
-          if grep -i "Option disable-epoch: False" "db_sync_no_flags_logs.txt"; then echo "Flag disable-epoch set to False"; else echo "disable-epoch = True !" && exit 1; fi
+          grep -i "soptEpochAndCacheEnabled = True" "db_sync_no_flags_logs.txt" > /dev/null && echo "Flag soptEpochAndCacheEnabled set to True" || (echo "soptEpochAndCacheEnabled is not set to True!" && exit 1)
+          grep -i "soptCache = True" "db_sync_no_flags_logs.txt" > /dev/null && echo "Flag soptCache set to True" || (echo "soptCache is not set to True!" && exit 1)
+          grep -i "pcmPruneTxOut = False" "db_sync_no_flags_logs.txt" > /dev/null && echo "Flag pcmPruneTxOut set to False" || (echo "pcmPruneTxOut is not set to False!" && exit 1)
+          grep -i "pcmConsumeOrPruneTxOut = False" "db_sync_no_flags_logs.txt" > /dev/null && echo "Flag pcmConsumeOrPruneTxOut set to False" || (echo "pcmConsumeOrPruneTxOut is not set to False!" && exit 1)
+          grep -i "pcmSkipTxIn = False" "db_sync_no_flags_logs.txt" > /dev/null && echo "Flag pcmSkipTxIn set to False" || (echo "pcmSkipTxIn is not set to False!" && exit 1)
+          grep -i "ioTxCBOR = False" "db_sync_no_flags_logs.txt" > /dev/null && echo "Flag ioTxCBOR set to False" || (echo "ioTxCBOR is not set to False!" && exit 1)
+          grep -i "ioInOut = True" "db_sync_no_flags_logs.txt" > /dev/null && echo "Flag ioInOut set to True" || (echo "ioInOut is not set to True!" && exit 1)
+          grep -i "ioUseLedger = True" "db_sync_no_flags_logs.txt" > /dev/null && echo "Flag ioUseLedger set to True" || (echo "ioUseLedger is not set to True!" && exit 1)
+          grep -i "ioShelley = True" "db_sync_no_flags_logs.txt" > /dev/null && echo "Flag ioShelley set to True" || (echo "ioShelley is not set to True!" && exit 1)
+          grep -i "ioRewards = True" "db_sync_no_flags_logs.txt" > /dev/null && echo "Flag ioRewards set to True" || (echo "ioRewards is not set to True!" && exit 1)
+          grep -i "ioMultiAssets = True" "db_sync_no_flags_logs.txt" > /dev/null && echo "Flag ioMultiAssets set to True" || (echo "ioMultiAssets is not set to True!" && exit 1)
+          grep -i "ioMetadata = True" "db_sync_no_flags_logs.txt" > /dev/null && echo "Flag ioMetadata set to True" || (echo "ioMetadata is not set to True!" && exit 1)
+          grep -i "ioKeepMetadataNames = Nothing" "db_sync_no_flags_logs.txt" > /dev/null && echo "Flag ioKeepMetadataNames set to Nothing" || (echo "ioKeepMetadataNames is not set to Nothing!" && exit 1)
+          grep -i "ioPlutusExtra = True" "db_sync_no_flags_logs.txt" > /dev/null && echo "Flag ioPlutusExtra set to True" || (echo "ioPlutusExtra is not set to True!" && exit 1)
+          grep -i "ioOffChainPoolData = True" "db_sync_no_flags_logs.txt" > /dev/null && echo "Flag ioOffChainPoolData set to True" || (echo "ioOffChainPoolData is not set to True!" && exit 1)
+          grep -i "ioPoolStats = False" "db_sync_no_flags_logs.txt" > /dev/null && echo "Flag ioPoolStats set to False" || (echo "ioPoolStats is not set to False!" && exit 1)
+          grep -i "ioGov = True" "db_sync_no_flags_logs.txt" > /dev/null && echo "Flag ioGov set to True" || (echo "ioGov is not set to True!" && exit 1)
+          grep -i "ioRemoveJsonbFromSchema = False" "db_sync_no_flags_logs.txt" > /dev/null && echo "Flag ioRemoveJsonbFromSchema set to False" || (echo "ioRemoveJsonbFromSchema is not set to False!" && exit 1)
 
       - name: Errors Check
         run: |
           cd cardano-db-sync
-          if grep -i Error "db_sync_no_flags_logs.txt"; then echo "Found Error(s) !" && exit 1; fi
+          if grep Error "db_sync_no_flags_logs.txt"; then echo "Found Error(s) !" && exit 1; fi
 
       - name: Blocks Insertion Check
         run: |
           cd cardano-db-sync
-          if grep -i epochPluginInsertBlockDetails "db_sync_no_flags_logs.txt"; then echo "Blocks inserted into DB"; else echo "NO block insertion !" && exit 1; fi
+          if grep -E 'Insert (Alonzo|Mary|Shelley|Babbage|Byron|Conway) Block|insertByronBlock' "db_sync_no_flags_logs.txt"; then echo "Blocks inserted into DB"; else echo "NO block insertion !" && exit 1; fi
 
       - name: Cache Statistics Check
         run: |
@@ -87,48 +115,6 @@ jobs:
           echo "Waiting 10 seconds for startup"
           sleep 10
 
-      - name: Start docker-compose WITH flags
-        run: |
-          cd cardano-db-sync
-          sudo NETWORK=${{ matrix.env }} EXTRA_DB_SYNC_ARGS="--disable-ledger --disable-cache --disable-epoch" docker-compose up -d
-
-      - name: Wait for 60 seconds
-        run: |
-          echo "Waiting 60 seconds for startup"
-          sleep 60
-
-      - name: Print db-sync Logs
-        run: |
-          cd cardano-db-sync
-          echo "db-sync logs:"
-          sudo docker-compose logs cardano-db-sync | tee db_sync_flags_logs.txt
-
-      - name: Errors Check
-        run: |
-          cd cardano-db-sync
-          if grep -i Error "db_sync_flags_logs.txt"; then echo "Found Error(s) !" && exit 1; fi
-
-      - name: Epoch Plugin Check - Should be Gone
-        run: |
-          cd cardano-db-sync
-          if grep -i epochPluginInsertBlockDetails "db_sync_flags_logs.txt"; then echo "Epoch Plugin should be blocked !" && exit 1; fi
-
-      - name: Cache Statistics Check - Should be Gone
-        run: |
-          cd cardano-db-sync
-          if grep -i "Cache Statistics" "db_sync_flags_logs.txt"; then echo "Error - Found Cache Statistics !" && exit 1; fi
-
-      - name: Block Insertion Check
-        run: |
-          cd cardano-db-sync
-          if grep -i insert "db_sync_flags_logs.txt"; then echo "Blocks inserted into DB"; else echo "NO block insertion !" && exit 1; fi
-
-      - name: Flags Check - Should be True
-        run: |
-          cd cardano-db-sync
-          if grep -i "Option disable-ledger: True" "db_sync_flags_logs.txt"; then echo "Flag disable-ledger set to True"; else echo "disable-ledger = False !" && exit 1; fi
-          if grep -i "Option disable-cache: True" "db_sync_flags_logs.txt"; then echo "Flag disable-cache set to True"; else echo "disable-cache = False !" && exit 1; fi
-          if grep -i "Option disable-epoch: True" "db_sync_flags_logs.txt"; then echo "Flag disable-epoch set to True"; else echo "disable-epoch = False !" && exit 1; fi
 
       - name: Upload Logs
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
The old way of passing flags will not work with new configuration changes for cardano-db-sync.
As long as there is no new way for passing custom config files to docker compose - remove old tests for flags that will be broken.