### PR TITLE
Fix CC members tests

### DIFF
--- a/cardano_node_tests/utils/governance_utils.py
+++ b/cardano_node_tests/utils/governance_utils.py
@@ -620,6 +620,18 @@ def is_drep_active(
     return bool(drep_state[0][1].get("expiry", 0) > epoch)
 
 
+def is_cc_active(cc_member_state: tp.Dict[str, tp.Any]) -> bool:
+    """Check if CC member is active."""
+    if not cc_member_state:
+        return False
+    if cc_member_state["hotCredsAuthStatus"] != "MemberAuthorized":
+        return False
+    if cc_member_state["status"] != "Active":  # noqa: SIM103
+        return False
+
+    return True
+
+
 def create_dreps(
     name_template: str,
     num: int,


### PR DESCRIPTION
* don't resign default CC members
  - delete the standalone test that was deleting one of the default CC members
  - move the CC member resignation check to another test that adds new CC members
* resign only active CC mebers during cleanup

Also test `VotingOnExpiredGovAction` error.