### PR TITLE
Get proposed committee members by filtering out the existing members

### DIFF
--- a/cardano_node_tests/utils/dbsync_queries.py
+++ b/cardano_node_tests/utils/dbsync_queries.py
@@ -513,8 +513,9 @@ class NewCommitteeInfoDBRow:
 @dataclasses.dataclass(frozen=True)
 class NewCommitteeMemberDBRow:
     # pylint: disable-next=invalid-name
-    gov_id: int
-    committee_hash_id: str
+    id: int
+    committee_id: int
+    committee_hash: memoryview
     expiration_epoch: int
 
 
@@ -1352,8 +1353,9 @@ def query_committee_members(committee_id: int) -> tp.Generator[NewCommitteeMembe
     """Query committee members in db-sync."""
     query = (
         "SELECT"
-        " cm.id, cm.committee_hash_id, cm.expiration_epoch "
-        "FROM committee_member as cm "
+        " cm.id, cm.committee_id, ch.raw, cm.expiration_epoch "
+        "FROM committee_member AS cm "
+        "INNER JOIN committee_hash AS ch ON ch.id = cm.committee_hash_id "
         "WHERE cm.committee_id = %s;"
     )
 


### PR DESCRIPTION
The `committee_member` table lists both existing members and proposed members for each `committee_id`. Therefore to get only the proposed members, we need to filter out the existing members.

Also adding more infor to the existing asserts to help with debugging.