### PR TITLE
Make the treasury update check more detailed

### DIFF
--- a/cardano_node_tests/tests/tests_conway/test_treasury_donation.py
+++ b/cardano_node_tests/tests/tests_conway/test_treasury_donation.py
@@ -24,21 +24,16 @@ pytestmark = pytest.mark.skipif(
 
 
 @pytest.fixture
-def cluster_treasury(
+def cluster_pots(
     cluster_manager: cluster_management.ClusterManager,
 ) -> clusterlib.ClusterLib:
-    return cluster_manager.get(
-        lock_resources=[
-            cluster_management.Resources.RESERVES,
-            cluster_management.Resources.TREASURY,
-        ]
-    )
+    return cluster_manager.get(lock_resources=cluster_management.Resources.POTS)
 
 
 @pytest.fixture
-def payment_addr(
+def payment_addr_pots(
     cluster_manager: cluster_management.ClusterManager,
-    cluster_treasury: clusterlib.ClusterLib,
+    cluster_pots: clusterlib.ClusterLib,
 ) -> clusterlib.AddressRecord:
     """Create new payment address."""
     with cluster_manager.cache_fixture() as fixture_cache:
@@ -47,14 +42,14 @@ def payment_addr(
 
         addr = clusterlib_utils.create_payment_addr_records(
             f"addr_treasury_donation_ci{cluster_manager.cluster_instance_num}_0",
-            cluster_obj=cluster_treasury,
+            cluster_obj=cluster_pots,
         )[0]
         fixture_cache.value = addr
 
     # Fund source address
     clusterlib_utils.fund_from_faucet(
         addr,
-        cluster_obj=cluster_treasury,
+        cluster_obj=cluster_pots,
         faucet_data=cluster_manager.cache.addrs_data["user1"],
     )
     return addr
@@ -68,8 +63,8 @@ class TestTreasuryDonation:
     @common.PARAM_USE_BUILD_CMD
     def test_transfer_treasury_donation(
         self,
-        cluster_treasury: clusterlib.ClusterLib,
-        payment_addr: clusterlib.AddressRecord,
+        cluster_pots: clusterlib.ClusterLib,
+        payment_addr_pots: clusterlib.AddressRecord,
         use_build_cmd: bool,
     ):
         """Send funds from payment address to the treasury.
@@ -78,7 +73,7 @@ class TestTreasuryDonation:
         * check expected balances for both source addresses and treasury
         * check transactions and ADA pots in db-sync
         """
-        cluster = cluster_treasury
+        cluster = cluster_pots
         temp_template = common.get_test_id(cluster)
 
         amount = 2_000_000
@@ -93,19 +88,16 @@ class TestTreasuryDonation:
         )
         cur_epoch = cluster.g_query.get_epoch()
 
-        pot_bef_trs_donat = list(
-            dbsync_queries.query_ada_pots(epoch_from=cur_epoch, epoch_to=cur_epoch)
-        )
-        pot_bef_tx = pot_bef_trs_donat[0]
+        pot_bef_tx = next(dbsync_queries.query_ada_pots(epoch_from=cur_epoch, epoch_to=cur_epoch))
         assert pot_bef_tx.epoch_no == cur_epoch
 
         treasury_val = cluster.g_conway_governance.query.treasury()
-        tx_files = clusterlib.TxFiles(signing_key_files=[payment_addr.skey_file])
+        tx_files = clusterlib.TxFiles(signing_key_files=[payment_addr_pots.skey_file])
 
         tx_output = clusterlib_utils.build_and_submit_tx(
             cluster_obj=cluster,
             name_template=temp_template,
-            src_address=payment_addr.address,
+            src_address=payment_addr_pots.address,
             current_treasury_value=treasury_val,
             treasury_donation=amount,
             # Use submit-api when available and when we are using `transaction build`.
@@ -114,44 +106,43 @@ class TestTreasuryDonation:
             submit_method=submit_utils.SubmitMethods.API
             if use_build_cmd and submit_utils.is_submit_api_available()
             else submit_utils.SubmitMethods.CLI,
-            change_address=payment_addr.address,
+            change_address=payment_addr_pots.address,
             use_build_cmd=use_build_cmd,
             tx_files=tx_files,
         )
 
         out_utxos = cluster.g_query.get_utxo(tx_raw_output=tx_output)
         assert (
-            clusterlib.filter_utxos(utxos=out_utxos, address=payment_addr.address)[0].amount
+            clusterlib.filter_utxos(utxos=out_utxos, address=payment_addr_pots.address)[0].amount
             == clusterlib.calculate_utxos_balance(tx_output.txins) - tx_output.fee - amount
-        ), f"Incorrect balance for source address `{payment_addr.address}`"
+        ), f"Incorrect balance for source address `{payment_addr_pots.address}`"
 
         common.check_missing_utxos(cluster_obj=cluster, utxos=out_utxos)
 
         dbsync_utils.check_tx(cluster_obj=cluster, tx_raw_output=tx_output)
         assert (
-            cluster.g_query.get_address_balance(payment_addr.address)
-            == dbsync_utils.get_utxo(address=payment_addr.address).amount_sum
-        ), f"Unexpected balance for source address `{payment_addr.address}` in db-sync"
+            cluster.g_query.get_address_balance(payment_addr_pots.address)
+            == dbsync_utils.get_utxo(address=payment_addr_pots.address).amount_sum
+        ), f"Unexpected balance for source address `{payment_addr_pots.address}` in db-sync"
 
         donation_txid = cluster.g_transaction.get_txid(tx_body_file=tx_output.out_file)
         db_tx_data = dbsync_utils.get_tx_record(txhash=donation_txid)
         assert db_tx_data.treasury_donation == amount
 
         cur_epoch = cluster.wait_for_new_epoch(padding_seconds=10)
-        pot_aft_trs_donat = list(
-            dbsync_queries.query_ada_pots(epoch_from=cur_epoch, epoch_to=cur_epoch)
-        )
-        pot_aft_tx = pot_aft_trs_donat[0]
+        pot_aft_tx = next(dbsync_queries.query_ada_pots(epoch_from=cur_epoch, epoch_to=cur_epoch))
         assert pot_aft_tx.epoch_no == cur_epoch
 
-        current_treasury = (
-            pot_bef_tx.treasury
+        updated_treasury = (
+            pot_bef_tx.treasury  # Old treasury balance
+            + pot_bef_tx.fees  # Fees that were added to treasury
             + pot_bef_tx.reserves
+            - pot_aft_tx.reserves  # Delta of reserves: percentage of reserves is moved to treasury
             + pot_bef_tx.rewards
-            + pot_bef_tx.fees
-            - pot_aft_tx.reserves
-            - pot_aft_tx.rewards
+            - pot_aft_tx.rewards  # Delta of rewards: rewards are paid from treasury
+            + pot_bef_tx.deposits_stake
+            - pot_aft_tx.deposits_stake
+            + pot_bef_tx.deposits_proposal
+            - pot_aft_tx.deposits_proposal  # Delta of deposits that are returned to rewards pot
         )
-        # Any unclaimed ADA (rewards, deposits) go to the treasury, so we can't expect
-        # the precise amount, we can only expect the minimal amount.
-        assert pot_aft_tx.treasury >= current_treasury + amount
+        assert pot_aft_tx.treasury == updated_treasury + amount


### PR DESCRIPTION
Now that all tests mark their usage of the "reward" pot, we can make the assumption that no other tests are chaging the pot and we can make more detailed checks.