### PR TITLE
feat: update default cluster era to conway

### DIFF
--- a/.github/regression.sh
+++ b/.github/regression.sh
@@ -6,7 +6,7 @@ set -xeuo pipefail
 nix --version
 df -h .
 
-DEFAULT_CLUSTER_ERA="babbage"
+DEFAULT_CLUSTER_ERA="conway"
 
 REPODIR="$(readlink -m "${0%/*}/..")"
 cd "$REPODIR"

--- a/.github/workflows/regression.yaml
+++ b/.github/workflows/regression.yaml
@@ -10,10 +10,10 @@ on:
         type: choice
         description: "Cluster era"
         options:
-        - babbage
         - conway 9
         - conway 10
-        default: babbage
+        - babbage
+        default: conway 9
       tx_era:
         type: choice
         description: "Tx era"

--- a/cardano_node_tests/tests/test_tx_basic.py
+++ b/cardano_node_tests/tests/test_tx_basic.py
@@ -143,12 +143,12 @@ class TestBasicTransactions:
 
         if is_era_explicit:
             default_tx_era = VERSIONS.MAP[VERSIONS.DEFAULT_TX_ERA]
-            if cluster.tx_era != default_tx_era:
+            if cluster.command_era != default_tx_era:
                 cluster_default = cluster_nodes.get_cluster_type().get_cluster_obj(
-                    tx_era=default_tx_era
+                    command_era=default_tx_era
                 )
         elif cluster.tx_era:
-            cluster_default = cluster_nodes.get_cluster_type().get_cluster_obj(tx_era="")
+            cluster_default = cluster_nodes.get_cluster_type().get_cluster_obj(command_era="")
 
         return cluster_default
 

--- a/cardano_node_tests/utils/configuration.py
+++ b/cardano_node_tests/utils/configuration.py
@@ -119,6 +119,6 @@ if SCRIPTS_DIRNAME:
 elif BOOTSTRAP_DIR:
     SCRIPTS_DIRNAME = "testnets"
 else:
-    SCRIPTS_DIRNAME = f"{CLUSTER_ERA or 'babbage'}_fast"
+    SCRIPTS_DIRNAME = f"{CLUSTER_ERA or 'conway'}_fast"
 
 SCRIPTS_DIR = pl.Path(__file__).parent.parent / "cluster_scripts" / SCRIPTS_DIRNAME

--- a/cardano_node_tests/utils/versions.py
+++ b/cardano_node_tests/utils/versions.py
@@ -19,8 +19,8 @@ class Versions:
     BABBAGE: tp.Final[int] = 8
     CONWAY: tp.Final[int] = 9
 
-    DEFAULT_CLUSTER_ERA: tp.Final[int] = 8
-    DEFAULT_TX_ERA: tp.Final[int] = 8
+    DEFAULT_CLUSTER_ERA: tp.Final[int] = 9
+    DEFAULT_TX_ERA: tp.Final[int] = 9
     LAST_KNOWN_ERA: tp.Final[int] = 9
 
     MAP: tp.ClassVar[tp.Dict[int, str]] = {


### PR DESCRIPTION
This commit updates the default cluster era from "babbage" to "conway" across various scripts and configuration files. The changes include modifying the default values in regression scripts, workflow files, test cases, and configuration utilities to reflect the new default cluster era.