### PR TITLE
fix: handle conway era in regression script

### DIFF
--- a/.github/regression.sh
+++ b/.github/regression.sh
@@ -104,11 +104,11 @@ fi
 export CLUSTER_ERA
 
 TX_ERA="${TX_ERA:-""}"
-if [ "$TX_ERA" = "default" ]; then
-  export TX_ERA=""
-elif [ "$TX_ERA" = "conway" ]; then
+if [ "$TX_ERA" = "conway" ] || [ "$CLUSTER_ERA" = "conway" ]; then
   unset TX_ERA
   export COMMAND_ERA="conway"
+elif [ "$TX_ERA" = "default" ]; then
+  export TX_ERA=""
 fi
 
 if [ -n "${BOOTSTRAP_DIR:-""}" ]; then


### PR DESCRIPTION
Updated the regression script to handle the conway era correctly. Now, if either TX_ERA or CLUSTER_ERA is set to "conway", TX_ERA will be unset and COMMAND_ERA will be set to "conway". This ensures proper handling of the conway era in the script.