### PR TITLE
Update ruff-pre-commit to v0.6.3

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@ repos:
   - id: debug-statements
     language_version: python3
 - repo: https://github.com/charliermarsh/ruff-pre-commit
-  rev: v0.5.5
+  rev: v0.6.3
   hooks:
     - id: ruff
       args: [ --fix ]

--- a/cardano_node_tests/cluster_management/cluster_getter.py
+++ b/cardano_node_tests/cluster_management/cluster_getter.py
@@ -32,7 +32,7 @@ if configuration.IS_XDIST:
 else:
 
     def _xdist_sleep(
-        secs: float,  # noqa: ARG001
+        secs: float,
     ) -> None:
         """No need to sleep if tests are running on a single worker."""
 
@@ -818,8 +818,7 @@ class ClusterGetter:
             # sleep for a while to avoid too many checks in a short time
             _xdist_sleep(random.uniform(0.6, 1.2) * cget_status.sleep_delay)
             # pylint: disable=consider-using-max-builtin
-            if cget_status.sleep_delay < 1:
-                cget_status.sleep_delay = 1
+            cget_status.sleep_delay = max(cget_status.sleep_delay, 1)
 
             # nothing time consuming can go under this lock as all other workers will need to wait
             with locking.FileLockIfXdist(self.cluster_lock):

--- a/cardano_node_tests/tests/conftest.py
+++ b/cardano_node_tests/tests/conftest.py
@@ -308,10 +308,10 @@ def testenv_setup_teardown(
 
 @pytest.fixture(scope="session", autouse=True)
 def session_autouse(
-    init_pytest_temp_dirs: None,  # noqa: ARG001
-    change_dir: None,  # noqa: ARG001
-    close_dbconn: tp.Any,  # noqa: ARG001
-    testenv_setup_teardown: tp.Any,  # noqa: ARG001
+    init_pytest_temp_dirs: None,
+    change_dir: None,
+    close_dbconn: tp.Any,
+    testenv_setup_teardown: tp.Any,
 ) -> None:
     """Autouse session fixtures that are required for session setup and teardown."""
     # pylint: disable=unused-argument,unnecessary-pass
@@ -393,8 +393,8 @@ def respin_on_large_db(
 
 @pytest.fixture(autouse=True)
 def function_autouse(
-    cd_testfile_temp_dir: tp.Generator[pl.Path, None, None],  # noqa: ARG001
-    respin_on_large_db: tp.Generator[None, None, None],  # noqa: ARG001
+    cd_testfile_temp_dir: tp.Generator[pl.Path, None, None],
+    respin_on_large_db: tp.Generator[None, None, None],
 ) -> None:
     """Autouse function fixtures that are required for each test setup and teardown."""
     # pylint: disable=unused-argument,unnecessary-pass

--- a/cardano_node_tests/tests/tests_conway/test_guardrails.py
+++ b/cardano_node_tests/tests/tests_conway/test_guardrails.py
@@ -379,8 +379,7 @@ def _get_param_min_value(
         min_val = min_val_dict["minValue"]
         if not isinstance(min_val, int) and "numerator" in min_val:
             min_val = min_val["numerator"] / min_val["denominator"]
-        if min_val > max_of_min_values:
-            max_of_min_values = min_val
+        max_of_min_values = max(min_val, max_of_min_values)
     return max_of_min_values
 
 
@@ -405,8 +404,7 @@ def _get_param_max_value(
         max_val = max_val_dict["maxValue"]
         if not isinstance(max_val, int) and "numerator" in max_val:
             max_val = max_val["numerator"] / max_val["denominator"]
-        if max_val < min_of_max_values:
-            min_of_max_values = max_val
+        min_of_max_values = min(max_val, min_of_max_values)
     return min_of_max_values
 
 
@@ -584,8 +582,7 @@ def perform_predicates_check(
             if not isinstance(min_value, int) and "numerator" in min_value:
                 min_value = min_value["numerator"] / min_value["denominator"]
 
-            if min_value > max_of_min_values:
-                max_of_min_values = min_value
+            max_of_min_values = max(min_value, max_of_min_values)
 
             check_min_value_proposals(
                 cluster_with_constitution=cluster_with_constitution,
@@ -600,8 +597,7 @@ def perform_predicates_check(
             if not isinstance(max_value, int) and "numerator" in max_value:
                 max_value = max_value["numerator"] / max_value["denominator"]
 
-            if max_value < min_of_max_values:
-                min_of_max_values = max_value
+            min_of_max_values = min(max_value, min_of_max_values)
 
             check_max_value_proposals(
                 cluster_with_constitution=cluster_with_constitution,


### PR DESCRIPTION
Updated the ruff-pre-commit hook from version v0.5.5 to v0.6.3 in the .pre-commit-config.yaml file. This ensures we are using the latest features and fixes provided by the ruff-pre-commit tool.