### PR TITLE
feat(tests): add tests for minting without TxOut

### DIFF
--- a/cardano_node_tests/tests/issues.py
+++ b/cardano_node_tests/tests/issues.py
@@ -27,6 +27,12 @@ cli_299 = blockers.GH(
     repo="IntersectMBO/cardano-cli",
     message="Cannot de-register Plutus stake address.",
 )
+cli_614 = blockers.GH(
+    issue=614,
+    repo="IntersectMBO/cardano-cli",
+    fixed_in="9.3.0.1",  # Unknown yet, will be fixed sometime in the future
+    message="Overspent budget when minting assets and autobalancing a transaction.",
+)
 cli_650 = blockers.GH(
     issue=650,
     repo="IntersectMBO/cardano-cli",


### PR DESCRIPTION
- Added `test_minting_missing_txout` in `test_mint_build.py` to test minting a token with a Plutus script without providing TxOut for the token.
- Added `test_minting_ref_missing_txout` in `test_mint_build.py` to test minting a token with reference Plutus script without providing TxOut for the token.
- Updated imports in `test_mint_build.py` and `test_mint_build.py` to include necessary modules.
- Added issue `cli_614` to track overspending budget error during minting.