### PR TITLE
refactor(tests): remove redundant requirement start call

### DIFF
--- a/cardano_node_tests/tests/tests_conway/test_drep.py
+++ b/cardano_node_tests/tests/tests_conway/test_drep.py
@@ -460,7 +460,6 @@ class TestDReps:
 
         # Retire DRep
 
-        reqc.cli011.start(url=helpers.get_vcs_link())
         _url = helpers.get_vcs_link()
         [r.start(url=_url) for r in (reqc.cli011, reqc.cip023)]
         ret_cert = cluster.g_conway_governance.drep.gen_retirement_cert(


### PR DESCRIPTION
Removed the redundant start call for `reqc.cli011` in the test_drep.py file. The URL is now retrieved once and used for both reqc.cli011 and reqc.cip023.