### PR TITLE
fix(tests): update cardano-cli issue 49 and handle new error message

### DIFF
--- a/cardano_node_tests/tests/issues.py
+++ b/cardano_node_tests/tests/issues.py
@@ -13,7 +13,12 @@ api_484 = blockers.GH(
     message="Repeated certificates stripped from Conway transaction.",
 )
 
-cli_49 = blockers.GH(issue=49, repo="IntersectMBO/cardano-cli", message="Not sending pings.")
+cli_49 = blockers.GH(
+    issue=49,
+    fixed_in="9.4.1.1",  # Fixed in version after 9.4.1.0
+    repo="IntersectMBO/cardano-cli",
+    message="Not sending pings.",
+)
 cli_268 = blockers.GH(
     issue=268, repo="IntersectMBO/cardano-cli", message="Internal query mismatch."
 )

--- a/cardano_node_tests/tests/test_cli.py
+++ b/cardano_node_tests/tests/test_cli.py
@@ -1322,6 +1322,9 @@ class TestPing:
         err_str = cli_out.stderr.rstrip().decode("utf-8")
         if "UnknownVersionInRsp" in err_str:
             issues.node_5324.finish_test()
+        # cardano-ping reports user friendly error on misconfiguration on cardano-cli 9.4.1.1+
+        if "Unix sockets only support queries" in err_str:
+            return
 
         out_str = cli_out.stdout.rstrip().decode("utf-8")
         if not (out_str and out_str[0] == "{"):


### PR DESCRIPTION
- Updated cardano-cli issue 49
- Added handling for new error message in test_cli.py for cardano-cli version 9.4.1.1+