### PR TITLE
refactor: replace `type` with `command -v` for checks

### DIFF
--- a/.github/cli_coverage.sh
+++ b/.github/cli_coverage.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 tests_repo="$(readlink -m "${0%/*}/..")"
 
 get_coverage() {
-  if [ ! -e "$tests_repo/.cli_coverage" ] || ! hash cardano-cli; then
+  if [ ! -e "$tests_repo/.cli_coverage" ] || ! command -v cardano-cli >/dev/null 2>&1; then
     return 1
   fi
   oldpwd="$PWD"

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ init_lint:
 .PHONY: lint
 lint:
 	pre-commit run -a
-	if type pytype >/dev/null 2>&1; then pytype cardano_node_tests; fi
+	if command -v pytype >/dev/null 2>&1; then pytype cardano_node_tests; fi
 
 
 # generate sphinx documentation

--- a/cardano_node_tests/cluster_scripts/babbage/start-cluster
+++ b/cardano_node_tests/cluster_scripts/babbage/start-cluster
@@ -110,7 +110,7 @@ wait_for_epoch() {
 }
 
 enable_submit_api() {
-  type cardano-submit-api >/dev/null 2>&1 || return 1
+  command -v cardano-submit-api >/dev/null 2>&1 || return 1
 
   # TODO: `--metrics-port` is not available in older cardano-node releases, see node issue #4280
   # If the metrics port is not available, we can start the `cardano-submit-api` only on the first

--- a/cardano_node_tests/cluster_scripts/babbage_fast/start-cluster
+++ b/cardano_node_tests/cluster_scripts/babbage_fast/start-cluster
@@ -76,7 +76,7 @@ cardano_cli_log() {
 }
 
 enable_submit_api() {
-  type cardano-submit-api >/dev/null 2>&1 || return 1
+  command -v cardano-submit-api >/dev/null 2>&1 || return 1
 
   # TODO: `--metrics-port` is not available in older cardano-node releases, see node issue #4280
   # If the metrics port is not available, we can start the `cardano-submit-api` only on the first

--- a/cardano_node_tests/cluster_scripts/mainnet_fast/start-cluster
+++ b/cardano_node_tests/cluster_scripts/mainnet_fast/start-cluster
@@ -77,7 +77,7 @@ cardano_cli_log() {
 }
 
 enable_submit_api() {
-  type cardano-submit-api >/dev/null 2>&1 || return 1
+  command -v cardano-submit-api >/dev/null 2>&1 || return 1
 
   # TODO: `--metrics-port` is not available in older cardano-node releases, see node issue #4280
   # If the metrics port is not available, we can start the `cardano-submit-api` only on the first

--- a/cardano_node_tests/cluster_scripts/testnets/start-cluster
+++ b/cardano_node_tests/cluster_scripts/testnets/start-cluster
@@ -78,7 +78,7 @@ EoF
 fi
 
 # enable cardano-submit-api service
-if type cardano-submit-api >/dev/null 2>&1 && [ -e "$TESTNET_CONF_DIR/submit-api-config.json" ]; then
+if command -v cardano-submit-api >/dev/null 2>&1 && [ -e "$TESTNET_CONF_DIR/submit-api-config.json" ]; then
   # copy cardano-submit-api config file
   cp "$TESTNET_CONF_DIR/submit-api-config.json" "$STATE_CLUSTER/submit-api-config.json"
 
@@ -174,7 +174,7 @@ done
 [ "$sync_progress" = "100.00" ] || { echo "Failed to sync the realy node, line $LINENO" >&2; exit 1; }  # assert
 
 # start cardano-submit-api
-if type cardano-submit-api >/dev/null 2>&1 && [ -e "$STATE_CLUSTER/submit-api-config.json" ]; then
+if command -v cardano-submit-api >/dev/null 2>&1 && [ -e "$STATE_CLUSTER/submit-api-config.json" ]; then
   echo "Starting cardano-submit-api"
   supervisorctl -s http://127.0.0.1:%%SUPERVISOR_PORT%% start submit_api
 fi

--- a/poetry_update_deps.sh
+++ b/poetry_update_deps.sh
@@ -8,7 +8,7 @@ if [ -n "${IN_NIX_SHELL:-""}" ]; then
   echo "This script is not supposed to run inside nix shell." >&2
   abort_install=1
 fi
-if ! type poetry >/dev/null 2>&1; then
+if ! command -v poetry >/dev/null 2>&1; then
   echo "Poetry is not installed. Please install it first." >&2
   abort_install=1
 fi

--- a/setup_dev_venv.sh
+++ b/setup_dev_venv.sh
@@ -12,7 +12,7 @@ if [ -n "${IN_NIX_SHELL:-""}" ]; then
   echo "This script is not supposed to run inside nix shell." >&2
   abort_install=1
 fi
-if ! type poetry >/dev/null 2>&1; then
+if ! command -v poetry >/dev/null 2>&1; then
   echo "Poetry is not installed. Please install it first." >&2
   abort_install=1
 fi
@@ -38,7 +38,7 @@ if [ -n "${VIRTUAL_ENV:-""}" ]; then
 fi
 
 # use the same python version as in nix shell
-if ! type "python$PYTHON_VERSION" >/dev/null 2>&1; then
+if ! command -v "python$PYTHON_VERSION" >/dev/null 2>&1; then
   echo "Python $PYTHON_VERSION is not installed. Please install it first." >&2
   abort_install=1
 fi


### PR DESCRIPTION
Replaced all instances of `type` with `command -v` for checking command existence in various scripts. This change improves compatibility and consistency across different shell environments.