### PR TITLE
fix(tests): correct comments and decorators in tests

### DIFF
--- a/cardano_node_tests/tests/test_rollback.py
+++ b/cardano_node_tests/tests/test_rollback.py
@@ -436,7 +436,7 @@ class TestRollback:
         )
 
         # After both clusters has produced more than `securityParam` number of blocks while the
-        # topology was fragmented, it is not possible to bring the the clusters back
+        # topology was fragmented, it is not possible to bring the network back
         # into global consensus.
         self.node_wait_for_block(cluster_obj=cluster, node="pool1", block_no=final_block)
         self.node_wait_for_block(cluster_obj=cluster, node=LAST_POOL_NAME, block_no=final_block)

--- a/cardano_node_tests/tests/tests_conway/test_committee.py
+++ b/cardano_node_tests/tests/tests_conway/test_committee.py
@@ -143,8 +143,8 @@ class TestCommittee:
     @allure.link(helpers.get_vcs_link())
     @submit_utils.PARAM_SUBMIT_METHOD
     @common.PARAM_USE_BUILD_CMD
-    @pytest.mark.dbsync
     @pytest.mark.parametrize("threshold_type", ("fraction", "decimal"))
+    @pytest.mark.dbsync
     @pytest.mark.smoke
     def test_update_committee_action(
         self,


### PR DESCRIPTION
Corrected a typo in a comment in `test_rollback.py` and adjusted the position of the `@pytest.mark.dbsync` decorator in `test_committee.py` for better readability.