### PR TITLE
fix(start-cluster): correct genesis.json file path

### DIFF
--- a/cardano_node_tests/cluster_scripts/conway/start-cluster
+++ b/cardano_node_tests/cluster_scripts/conway/start-cluster
@@ -35,7 +35,7 @@ SECURITY_PARAM="$(jq '.securityParam' < "$SCRIPT_DIR/genesis.spec.json")"
 NETWORK_MAGIC="$(jq '.networkMagic' < "$SCRIPT_DIR/genesis.spec.json")"
 MAX_SUPPLY="$(jq '.maxLovelaceSupply' < "$SCRIPT_DIR/genesis.spec.json")"
 SLOT_LENGTH="$(jq '.slotLength' < "$SCRIPT_DIR/genesis.spec.json")"
-EPOCH_SEC="$(jq '.epochLength * .slotLength | ceil' < "$STATE_CLUSTER/shelley/genesis.json")"
+EPOCH_SEC="$(jq '.epochLength * .slotLength | ceil' < "$SCRIPT_DIR/genesis.spec.json")"
 
 if [ -n "${MIXED_P2P:-""}" ]; then
   export ENABLE_P2P=1


### PR DESCRIPTION
The path for the genesis.json file was incorrect in the start-cluster script. This change updates the path, ensuring the script reads the correct genesis.json file.