### PR TITLE
feat: add TX_SUBMISSION_DELAY to cluster scripts

### DIFF
--- a/cardano_node_tests/cluster_scripts/conway/start-cluster
+++ b/cardano_node_tests/cluster_scripts/conway/start-cluster
@@ -25,6 +25,7 @@ fi
 NUM_BFT_NODES=1
 NUM_POOLS=%%NUM_POOLS%%
 NUM_CC=5
+TX_SUBMISSION_DELAY=60
 PROPOSAL_DELAY=5
 SUBMIT_DELAY=5
 POOL_PLEDGE=1000000000000
@@ -605,8 +606,8 @@ for _ in {1..5}; do
 done
 [ -S "$CARDANO_NODE_SOCKET_PATH" ] || { echo "Failed to start the bft node, line $LINENO" >&2; exit 1; }  # assert
 
-# give nodes time to establish connections with each other
-sleep 5
+echo "Sleeping for initial Tx submission delay of $TX_SUBMISSION_DELAY seconds"
+sleep "$TX_SUBMISSION_DELAY"
 
 echo "Moving funds out of Byron genesis"
 for i in $(seq 1 $NUM_BFT_NODES); do
@@ -615,9 +616,9 @@ for i in $(seq 1 $NUM_BFT_NODES); do
     --tx "$STATE_CLUSTER/byron/tx$i.tx"
 done
 
-# length of Byron era is hardcoded to 200 sec (and we already slept for at least 5 sec)
-echo "Waiting 195 sec for Shelley era to start"
-sleep 195
+echo "Waiting for Shelley era to start"
+# length of Byron era is hardcoded to 200 sec
+sleep "$((200 - TX_SUBMISSION_DELAY))"
 
 
 #

--- a/cardano_node_tests/cluster_scripts/conway_fast/start-cluster
+++ b/cardano_node_tests/cluster_scripts/conway_fast/start-cluster
@@ -26,7 +26,7 @@ fi
 NUM_BFT_NODES=1
 NUM_POOLS=%%NUM_POOLS%%
 NUM_CC=5
-SETTLE_DELAY=20
+TX_SUBMISSION_DELAY=60
 SUBMIT_DELAY=5
 POOL_PLEDGE=1000000000000
 BYRON_INIT_SUPPLY=10020000000
@@ -503,8 +503,8 @@ if [ -n "${DBSYNC_REPO:-""}" ]; then
   supervisorctl -s http://127.0.0.1:%%SUPERVISOR_PORT%% start dbsync
 fi
 
-echo "Sleeping for $SETTLE_DELAY seconds to allow the chain to progress..."
-sleep "$SETTLE_DELAY"
+echo "Sleeping for initial Tx submission delay of $TX_SUBMISSION_DELAY seconds"
+sleep "$TX_SUBMISSION_DELAY"
 
 echo "Re-registering pools"
 

--- a/cardano_node_tests/cluster_scripts/mainnet_fast/start-cluster
+++ b/cardano_node_tests/cluster_scripts/mainnet_fast/start-cluster
@@ -23,7 +23,7 @@ fi
 
 NUM_BFT_NODES=1
 NUM_POOLS=%%NUM_POOLS%%
-SETTLE_DELAY=20
+TX_SUBMISSION_DELAY=60
 POOL_PLEDGE=1000000000000
 BYRON_INIT_SUPPLY=10020000000
 
@@ -518,8 +518,8 @@ if [ -n "${DBSYNC_REPO:-""}" ]; then
   supervisorctl -s http://127.0.0.1:%%SUPERVISOR_PORT%% start dbsync
 fi
 
-echo "Sleeping for $SETTLE_DELAY seconds to allow the chain to progress..."
-sleep "$SETTLE_DELAY"
+echo "Sleeping for initial Tx submission delay of $TX_SUBMISSION_DELAY seconds"
+sleep "$TX_SUBMISSION_DELAY"
 
 echo "Re-registering pools"
 

--- a/cardano_node_tests/tests/test_kes.py
+++ b/cardano_node_tests/tests/test_kes.py
@@ -234,7 +234,7 @@ class TestKES:
                 shutil.copy(refreshed_opcert_file, refreshed_pool_rec["pool_operational_cert"])
                 refreshed_nodes_kes_period[n] = kes_period
 
-            cluster_nodes.restart_all_nodes()
+            cluster_nodes.restart_all_nodes(delay=5)
             return refreshed_nodes_kes_period
 
         this_epoch = cluster.g_query.get_epoch()
@@ -424,7 +424,7 @@ class TestKES:
                 # restart the node with the new operational certificate (restart all nodes so
                 # the connection is established again)
                 shutil.copy(invalid_opcert_file, opcert_file)
-                cluster_nodes.restart_all_nodes()
+                cluster_nodes.restart_all_nodes(delay=5)
 
                 LOGGER.info("Checking blocks production for 4 epochs.")
                 this_epoch = cluster.g_query.get_epoch()
@@ -475,7 +475,7 @@ class TestKES:
                         # copy the new certificate and restart the node (restart all nodes so
                         # the connection is established again)
                         shutil.copy(overincrement_opcert_file, opcert_file)
-                        cluster_nodes.restart_all_nodes()
+                        cluster_nodes.restart_all_nodes(delay=5)
 
                         kes_period_info = cluster.g_query.get_kes_period_info(
                             overincrement_opcert_file
@@ -530,7 +530,7 @@ class TestKES:
             # copy the new certificate and restart the node (restart all nodes so
             # the connection is established again)
             shutil.copy(valid_opcert_file, opcert_file)
-            cluster_nodes.restart_all_nodes()
+            cluster_nodes.restart_all_nodes(delay=5)
 
             LOGGER.info("Checking blocks production for up to 6 epochs.")
             updated_epoch = cluster.g_query.get_epoch()
@@ -699,7 +699,7 @@ class TestKES:
 
             # start the node with the new operational certificate (restart all nodes so
             # the connection is established again)
-            cluster_nodes.restart_all_nodes()
+            cluster_nodes.restart_all_nodes(delay=5)
 
             LOGGER.info("Checking blocks production for up to 6 epochs.")
             updated_epoch = cluster.g_query.get_epoch()

--- a/cardano_node_tests/tests/test_reconnect.py
+++ b/cardano_node_tests/tests/test_reconnect.py
@@ -273,7 +273,7 @@ class TestNodeReconnect:
                 LOGGER.info(f"Running restart number {restart_no}")
 
                 # Restart node2
-                cluster_nodes.restart_nodes([node2])
+                cluster_nodes.restart_nodes([node2], delay=5)
                 self._node_synced(cluster_obj=cluster, node=node2)
 
                 for check_no in range(1, 11):

--- a/cardano_node_tests/utils/cluster_nodes.py
+++ b/cardano_node_tests/utils/cluster_nodes.py
@@ -392,7 +392,9 @@ def get_cluster_env() -> ClusterEnv:
     return cluster_env
 
 
-def reload_supervisor_config(instance_num: tp.Optional[int] = None) -> None:
+def reload_supervisor_config(
+    instance_num: tp.Optional[int] = None, delay: int = configuration.TX_SUBMISSION_DELAY
+) -> None:
     """Reload supervisor configuration."""
     LOGGER.info("Reloading supervisor configuration.")
 
@@ -409,7 +411,8 @@ def reload_supervisor_config(instance_num: tp.Optional[int] = None) -> None:
         ) from exc
 
     # Wait for potential nodes restart
-    time.sleep(5)
+    if delay > 0:
+        time.sleep(delay)
 
 
 def start_cluster(cmd: str, args: tp.List[str]) -> clusterlib.ClusterLib:
@@ -422,7 +425,9 @@ def start_cluster(cmd: str, args: tp.List[str]) -> clusterlib.ClusterLib:
     return get_cluster_type().get_cluster_obj()
 
 
-def restart_all_nodes(instance_num: tp.Optional[int] = None) -> None:
+def restart_all_nodes(
+    instance_num: tp.Optional[int] = None, delay: int = configuration.TX_SUBMISSION_DELAY
+) -> None:
     """Restart all Cardano nodes of the running cluster."""
     LOGGER.info("Restarting all cluster nodes.")
 
@@ -438,8 +443,9 @@ def restart_all_nodes(instance_num: tp.Optional[int] = None) -> None:
             msg
         ) from exc
 
-    # wait for nodes to start
-    time.sleep(5)
+    # Wait for nodes to start
+    if delay > 0:
+        time.sleep(delay)
 
 
 def services_action(
@@ -476,13 +482,18 @@ def stop_nodes(node_names: tp.List[str], instance_num: tp.Optional[int] = None) 
     services_action(service_names=service_names, action="stop", instance_num=instance_num)
 
 
-def restart_nodes(node_names: tp.List[str], instance_num: tp.Optional[int] = None) -> None:
+def restart_nodes(
+    node_names: tp.List[str],
+    instance_num: tp.Optional[int] = None,
+    delay: int = configuration.TX_SUBMISSION_DELAY,
+) -> None:
     """Restart list of Cardano nodes of the running cluster."""
     service_names = [f"nodes:{n}" for n in node_names]
     services_action(service_names=service_names, action="restart", instance_num=instance_num)
 
-    # wait for nodes to start
-    time.sleep(5)
+    # Wait for nodes to start
+    if delay > 0:
+        time.sleep(delay)
 
 
 def services_status(

--- a/cardano_node_tests/utils/configuration.py
+++ b/cardano_node_tests/utils/configuration.py
@@ -28,6 +28,7 @@ _check_cardano_node_socket_path()
 LAUNCH_PATH = pl.Path.cwd()
 
 NETWORK_MAGIC_LOCAL = 42
+TX_SUBMISSION_DELAY = 60
 DBSYNC_DB = "dbsync"
 IS_XDIST = bool(os.environ.get("PYTEST_XDIST_TESTRUNUID"))
 


### PR DESCRIPTION
Node now delays initial request for transactions from a client to conserve network resources in case he disconnects relatively quickly for reasons in the referenced issue.

- Introduced TX_SUBMISSION_DELAY variable
- Updated start-cluster scripts to use TX_SUBMISSION_DELAY instead of hardcoded sleep values.
- Modified test_kes.py and test_reconnect.py to pass delay parameter when restarting nodes.
- Updated cluster_nodes.py to accept delay parameter for node restart functions.
- Added TX_SUBMISSION_DELAY to configuration.py with a default value of 60 seconds.