### PR TITLE
fix(tests): update fee assertion in test_tx_fees.py

### DIFF
--- a/cardano_node_tests/tests/test_tx_fees.py
+++ b/cardano_node_tests/tests/test_tx_fees.py
@@ -99,7 +99,7 @@ class TestFee:
                 tx_files=tx_files,
                 fee=fee,
             )
-        assert "option --fee: cannot parse value" in str(excinfo.value)
+        assert "option --fee:" in str(excinfo.value)
 
     @allure.link(helpers.get_vcs_link())
     @pytest.mark.parametrize("fee_change", (0, 1.1, 1.5, 2))


### PR DESCRIPTION
The assertion message for the fee option has been updated to check for a more general error message so it matches both old and new error messages.