### PR TITLE
fix(tests): handle new error message in node 9.2.0+

### DIFF
--- a/cardano_node_tests/tests/issues.py
+++ b/cardano_node_tests/tests/issues.py
@@ -80,6 +80,12 @@ cli_860 = blockers.GH(
     fixed_in="9.10.0.0",  # Fixed in some release after 9.2.1.0
     message="Negative pparam proposal values overflow to positive.",
 )
+cli_904 = blockers.GH(
+    issue=904,
+    repo="IntersectMBO/cardano-cli",
+    fixed_in="9.5.0.0",  # Fixed in some release after 9.4.1.0
+    message="Negative pparam proposal values overflow to positive.",
+)
 
 consensus_973 = blockers.GH(
     issue=973,

--- a/cardano_node_tests/tests/test_tx_unbalanced.py
+++ b/cardano_node_tests/tests/test_tx_unbalanced.py
@@ -59,7 +59,10 @@ class TestUnbalanced:
             err_str = str(err)
 
         if amount < 0:
-            assert "Negative quantity" in err_str, err_str
+            assert (
+                "Negative quantity" in err_str
+                or "Illegal Value in TxOut" in err_str  # In node version 9.2.0+
+            ), err_str
         else:
             assert "Minimum UTxO threshold not met for tx output" in err_str, err_str
 
@@ -154,6 +157,7 @@ class TestUnbalanced:
             or "TxOutAdaOnly" in exc_val
             or "AdaAssetId,-1" in exc_val
             or "Negative quantity" in exc_val  # cardano-node >= 8.7.0
+            or "Illegal Value in TxOut" in exc_val  # cardano-node >= 9.2.0
         )
 
     @allure.link(helpers.get_vcs_link())
@@ -194,7 +198,10 @@ class TestUnbalanced:
                 tx_files=tx_files,
             )
         exc_val = str(excinfo.value)
-        assert "The net balance of the transaction is negative" in exc_val, exc_val
+        assert (
+            "The net balance of the transaction is negative" in exc_val
+            or "Illegal Value in TxOut" in exc_val  # In node 9.2.0+
+        ), exc_val
 
     @allure.link(helpers.get_vcs_link())
     @hypothesis.given(change_amount=st.integers(min_value=2_000_000, max_value=MAX_LOVELACE_AMOUNT))
@@ -469,4 +476,7 @@ class TestUnbalanced:
         with pytest.raises(clusterlib.CLIError) as excinfo_build:
             cluster.cli(build_args)
         err_str_build = str(excinfo_build.value)
-        assert "Negative quantity" in err_str_build, err_str_build
+        assert (
+            "Negative quantity" in err_str_build
+            or "Illegal Value in TxOut" in err_str_build  # In node 9.2.0+
+        ), err_str_build

--- a/cardano_node_tests/tests/test_tx_unbalanced.py
+++ b/cardano_node_tests/tests/test_tx_unbalanced.py
@@ -11,6 +11,7 @@ from cardano_clusterlib import clusterlib
 
 from cardano_node_tests.cluster_management import cluster_management
 from cardano_node_tests.tests import common
+from cardano_node_tests.tests import issues
 from cardano_node_tests.tests import tx_common
 from cardano_node_tests.utils import clusterlib_utils
 from cardano_node_tests.utils import helpers
@@ -159,6 +160,9 @@ class TestUnbalanced:
             or "Negative quantity" in exc_val  # cardano-node >= 8.7.0
             or "Illegal Value in TxOut" in exc_val  # cardano-node >= 9.2.0
         )
+
+        if "CallStack" in exc_val:
+            issues.cli_904.finish_test()
 
     @allure.link(helpers.get_vcs_link())
     @common.SKIPIF_BUILD_UNUSABLE


### PR DESCRIPTION
Updated test assertions to handle the new "Illegal Value in TxOut" error message introduced in cardano-node version 9.2.0. This ensures that the tests remain compatible with the latest node version.

- Added "Illegal Value in TxOut" to relevant assertions.
- Maintained compatibility with previous error messages.