### PR TITLE
fix(tests): update error assertion for node 9.2.0+

### DIFF
--- a/cardano_node_tests/tests/test_native_tokens.py
+++ b/cardano_node_tests/tests/test_native_tokens.py
@@ -2096,8 +2096,10 @@ class TestTransfer:
                     logging.disable(logging.NOTSET)
 
             exc_val = str(excinfo.value)
-            assert "Non-Ada assets are unbalanced" in exc_val or re.search(
-                r"Negative quantity \(-[0-9]*\) in transaction output", exc_val
+            assert (
+                "Non-Ada assets are unbalanced" in exc_val
+                or "Illegal Value in TxOut" in exc_val  # In node 9.2.0+
+                or re.search(r"Negative quantity \(-[0-9]*\) in transaction output", exc_val)
             ), exc_val
         else:
             with pytest.raises(clusterlib.CLIError) as excinfo:


### PR DESCRIPTION
Updated the error assertion in `TestTransfer` to include the new error message "Illegal Value in TxOut" introduced in node version 9.2.0+. This ensures compatibility with the latest node version while maintaining backward compatibility with previous error messages.