### PR TITLE
fix(tests): handle new error message in guardrails test

### DIFF
--- a/cardano_node_tests/tests/tests_conway/test_guardrails.py
+++ b/cardano_node_tests/tests/tests_conway/test_guardrails.py
@@ -308,7 +308,10 @@ def check_invalid_proposals(  # noqa: C901
     except Exception as excp:
         err_msg = str(excp)
 
-    if "expecting digit" in err_msg:
+    if (
+        "expecting digit" in err_msg
+        or "expecting white space or digit" in err_msg  # In node 9.2.0+
+    ):
         # In case cli throws error beforehand due to invalid input
         assert 'unexpected "-"' in err_msg, err_msg
     elif "toUnitIntervalOrError" in err_msg or "toNonNegativeIntervalOrErr" in err_msg:


### PR DESCRIPTION
Updated the `check_invalid_proposals` function to handle a new error message "expecting white space or digit" introduced in node 9.2.0+. This ensures the test correctly identifies invalid proposals.