### PR TITLE
feat: update cluster era references to Conway

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ The easiest way to run the tests is by using Github Actions.
 ---
 **NOTE** <!-- markdownlint-disable-line MD036 -->
 
-When using `CI_BYRON_CLUSTER`, it takes ~ 30 minutes for local cluster instance to get from Byron to Babbage. If it seems that tests are stuck, they are likely just waiting for local cluster instances to be fully started.
+When using `CI_BYRON_CLUSTER`, it takes ~ 30 minutes for local cluster instance to get from Byron to Conway. If it seems that tests are stuck, they are likely just waiting for local cluster instances to be fully started.
 
 ---
 
@@ -51,13 +51,13 @@ Sometimes it is useful to run individual tests and keep the local cluster runnin
 1. prepare testing environment
 
     ```sh
-    source ./prepare_test_env.sh babbage  # 'conway' is also supported
+    source ./prepare_test_env.sh conway
     ```
 
 1. start the cluster instance
 
     ```sh
-    ./dev_workdir/babbage_fast/start-cluster
+    ./dev_workdir/conway_fast/start-cluster
     ```
 
 1. run some test
@@ -71,7 +71,7 @@ Sometimes it is useful to run individual tests and keep the local cluster runnin
 1. stop the cluster instance
 
     ```sh
-    ./dev_workdir/babbage_fast/stop-cluster
+    ./dev_workdir/conway_fast/stop-cluster
     ```
 
 ## Variables for configuring testrun
@@ -83,7 +83,7 @@ Tests execution can be configured using env variables.
 * `MARKEXPR` – specifies marker expression for pytest (default: unset)
 * `TEST_THREADS` – specifies the number of pytest workers (default: 20)
 * `CLUSTERS_COUNT` – number of cluster instances that will be started (default: 9)
-* `CLUSTER_ERA` – cluster era for Cardano node – used for selecting the correct cluster start script (default: babbage)
+* `CLUSTER_ERA` – cluster era for Cardano node – used for selecting the correct cluster start script (default: conway)
 * `COMMAND_ERA` – era for cardano-cli commands – can be used for creating Shelley-era (Allegra-era, ...) transactions (default: unset)
 * `NUM_POOLS` – number of stake pools created in each cluster instance (default: 3)
 * `ENABLE_P2P` – use P2P networking instead of the default legacy networking (default: unset)
@@ -96,7 +96,7 @@ Tests execution can be configured using env variables.
 
 When running tests using the `./.github/regression.sh` script, you can also use
 
-* `CI_BYRON_CLUSTER` - start local cluster in Byron era, and progress to later eras by HFs (same effect as `SCRIPTS_DIRNAME=babbage`)
+* `CI_BYRON_CLUSTER` - start local cluster in Byron era, and progress to later eras by HFs (same effect as `SCRIPTS_DIRNAME=conway`)
 * `NODE_REV` - revison of `cardano-node` (default: 'master')
 * `DBSYNC_REV` - revison of `cardano-db-sync` (default: unset; db-sync is not used by default)
 * `CARDANO_CLI_REV` - revison of `cardano-cli` (default: unset; cardano-cli bundled in cardano-node repo is used by default)
@@ -110,10 +110,10 @@ For example:
     NUM_POOLS=6 MIXED_P2P=1 ./.github/regression.sh
     ```
 
-* running tests on local cluster intances using 15 pytest workers, Babbage cluster era, cluster scripts that start a cluster directly in Babbage era, and selecting only tests without 'long' marker that also match the given `-k` pytest argument
+* running tests on local cluster intances using 15 pytest workers, Conway cluster era, cluster scripts that start a cluster directly in Conway era, and selecting only tests without 'long' marker that also match the given `-k` pytest argument
 
     ```sh
-    TEST_THREADS=15 CLUSTER_ERA=babbage SCRIPTS_DIRNAME=babbage_fast PYTEST_ARGS="-k 'test_stake_pool_low_cost or test_reward_amount'" MARKEXPR="not long" ./.github/regression.sh
+    TEST_THREADS=15 CLUSTER_ERA=conway SCRIPTS_DIRNAME=conway_fast PYTEST_ARGS="-k 'test_stake_pool_low_cost or test_reward_amount'" MARKEXPR="not long" ./.github/regression.sh
     ```
 
 * running tests on Shelley-qa testnet with '8.0.0' release of `cardano-node`
@@ -137,7 +137,7 @@ Create a Python virtual environment (requires Python v3.8 or newer) and install 
 
 ### Running development cluster
 
-When running tests, the testing framework starts and stops cluster instances as needed. That is not ideal for test development, as starting a cluster instance can take up to several epochs (to get from Byron to Babbage). To keep the Cardano cluster running in between test runs, one needs to start it in 'development mode':
+When running tests, the testing framework starts and stops cluster instances as needed. That is not ideal for test development, as starting a cluster instance can take up to several epochs (to get from Byron to Conway). To keep the Cardano cluster running in between test runs, one needs to start it in 'development mode':
 
 1. cd to 'cardano-node' repo
 
@@ -191,16 +191,16 @@ When running tests, the testing framework starts and stops cluster instances as 
     mkdir -p "${CARDANO_NODE_SOCKET_PATH%/*}"
     ```
 
-1. prepare cluster scripts for starting local cluster directly in Babbage era
+1. prepare cluster scripts for starting local cluster directly in Conway era
 
     ```sh
-    prepare-cluster-scripts -c -d dev_workdir/babbage_fast -s cardano_node_tests/cluster_scripts/babbage_fast/
+    prepare-cluster-scripts -c -d dev_workdir/conway_fast -s cardano_node_tests/cluster_scripts/conway_fast/
     ```
 
 1. start the cluster instance in development mode
 
     ```sh
-    ./dev_workdir/babbage_fast/start-cluster
+    ./dev_workdir/conway_fast/start-cluster
     ```
 
 After the cluster starts, keys and configuration files are available in the `./dev_workdir/state-cluster0` directory. The pool-related files and keys are located in the `nodes` subdirectory, genesis keys in the `shelley` and `byron` subdirectories, and payment address with initial funds and related keys in the `byron` subdirectory. The local faucet address and related key files are stored in the `addrs_data` subdirectory.
@@ -216,7 +216,7 @@ To restart the running cluster (eg, after upgrading `cardano-node` and `cardano-
 ---
 **NOTE** <!-- markdownlint-disable-line MD036 -->
 
-Restaring the running development cluster is useful mainly when using the "babbage" start scripts (not the "babbage_fast" version). It takes ~ 30 minutes for the local cluster instance to get from Byron to Babbage. Starting local cluster using the "babbage_fast" version takes less than 1 minute.
+Restaring the running development cluster is useful mainly when using the "conway" start scripts (not the "conway_fast" version). It takes ~ 30 minutes for the local cluster instance to get from Byron to Conway. Starting local cluster using the "conway_fast" version takes less than 1 minute.
 
 ---
 
@@ -247,10 +247,11 @@ same version of node and cli: ✔
 socket path set: ✔
 socket path correct: ✔
 socket path exists: ✔
-cluster era: babbage
-transaction era: babbage
+cluster era: default
+command era: latest
 using dbsync (optional): ✔
 dbsync available: ✔
+'psql' available: ✔
 P2P network (optional): -
 ```
 


### PR DESCRIPTION
This commit updates all references from Babbage to Conway in the README.md file. This includes instructions for preparing the testing environment, starting and stopping the cluster instance, configuring test runs, and running the development cluster. The changes ensure consistency with the latest cluster era.