### PR TITLE
refactor: remove protocol mode checks and arguments

### DIFF
--- a/cardano_node_tests/tests/test_cli.py
+++ b/cardano_node_tests/tests/test_cli.py
@@ -49,9 +49,6 @@ class TestCLI:
     @pytest.mark.testnets
     def test_protocol_mode(self, cluster: clusterlib.ClusterLib):
         """Check the default protocol mode - command works even without specifying protocol mode."""
-        if cluster.protocol != clusterlib.Protocols.CARDANO:
-            pytest.skip("runs on cluster in full cardano mode")
-
         common.get_test_id(cluster)
 
         cluster.cli(
@@ -672,9 +669,6 @@ class TestQueryUTxO:
     @allure.link(helpers.get_vcs_link())
     def test_whole_utxo(self, cluster: clusterlib.ClusterLib):
         """Check that it is possible to return the whole UTxO on local cluster."""
-        if cluster.protocol != clusterlib.Protocols.CARDANO:
-            pytest.skip("runs on cluster in full cardano mode")
-
         common.get_test_id(cluster)
 
         cluster.cli(

--- a/cardano_node_tests/tests/test_tx_negative.py
+++ b/cardano_node_tests/tests/test_tx_negative.py
@@ -702,7 +702,6 @@ class TestNegative:
                     str(cluster.network_magic + 100),
                     "--tx-file",
                     str(out_file_signed),
-                    f"--{cluster.protocol}-mode",
                 ]
             )
         assert "HandshakeError" in str(excinfo.value)

--- a/cardano_node_tests/utils/cluster_nodes.py
+++ b/cardano_node_tests/utils/cluster_nodes.py
@@ -77,7 +77,7 @@ class ClusterType:
         raise NotImplementedError(msg)
 
     def get_cluster_obj(
-        self, protocol: str = "", slots_offset: int = 0, command_era: str = ""
+        self, slots_offset: int = 0, command_era: str = ""
     ) -> clusterlib.ClusterLib:
         """Return instance of `ClusterLib` (cluster_obj)."""
         msg = f"Not implemented for cluster type '{self.type}'."
@@ -142,13 +142,12 @@ class LocalCluster(ClusterType):
         return offset
 
     def get_cluster_obj(
-        self, protocol: str = "", slots_offset: int = 0, command_era: str = ""
+        self, slots_offset: int = 0, command_era: str = ""
     ) -> clusterlib.ClusterLib:
         """Return instance of `ClusterLib` (cluster_obj)."""
         cluster_env = get_cluster_env()
         cluster_obj = clusterlib.ClusterLib(
             state_dir=cluster_env.state_dir,
-            protocol=protocol or clusterlib.Protocols.CARDANO,
             slots_offset=slots_offset or self._get_slots_offset(cluster_env.state_dir),
             command_era=command_era or cluster_env.command_era or clusterlib.CommandEras.LATEST,
         )
@@ -291,13 +290,12 @@ class TestnetCluster(ClusterType):
         return offset
 
     def get_cluster_obj(
-        self, protocol: str = "", slots_offset: int = 0, command_era: str = ""
+        self, slots_offset: int = 0, command_era: str = ""
     ) -> clusterlib.ClusterLib:
         """Return instance of `ClusterLib` (cluster_obj)."""
         cluster_env = get_cluster_env()
         cluster_obj = clusterlib.ClusterLib(
             state_dir=cluster_env.state_dir,
-            protocol=protocol or clusterlib.Protocols.CARDANO,
             slots_offset=slots_offset or self._get_slots_offset(cluster_env.state_dir),
             command_era=command_era or cluster_env.command_era or clusterlib.CommandEras.LATEST,
         )

--- a/cardano_node_tests/utils/clusterlib_utils.py
+++ b/cardano_node_tests/utils/clusterlib_utils.py
@@ -955,7 +955,6 @@ def _get_ledger_state_cmd(
         "query",
         "ledger-state",
         *cluster_obj.magic_args,
-        f"--{cluster_obj.protocol}-mode",
     ]
     ledger_state_cmd = " ".join(cardano_cli_args)
 
@@ -1220,7 +1219,6 @@ def create_script_context(
             "--generate-tx",
             str(tx_file),
             version_arg,
-            f"--{cluster_obj.protocol}-mode",
             *cluster_obj.magic_args,
             "--out-file",
             str(redeemer_file),


### PR DESCRIPTION
The only usable protocol in Conway is full Cardano mode.

This commit removes the protocol mode checks and arguments from the test cases and utility functions. The protocol mode is no longer required, simplifying the code and reducing redundancy.

- Removed protocol checks in test_cli.py and test_tx_negative.py
- Removed protocol arguments in cluster_nodes.py and clusterlib_utils.py