### PR TITLE
refactor: update testnet pool IDs and remove unused ones

### DIFF
--- a/cardano_node_tests/tests/delegation.py
+++ b/cardano_node_tests/tests/delegation.py
@@ -13,10 +13,17 @@ from cardano_node_tests.cluster_management import resources_management
 from cardano_node_tests.tests import common
 from cardano_node_tests.utils import cluster_nodes
 from cardano_node_tests.utils import clusterlib_utils
-from cardano_node_tests.utils import configuration
 from cardano_node_tests.utils import dbsync_types
 
 LOGGER = logging.getLogger(__name__)
+
+PREVIEW_POOL_IDS = (
+    "pool1ynfnjspgckgxjf2zeye8s33jz3e3ndk9pcwp0qzaupzvvd8ukwt",  # GRADA
+    "pool18pn6p9ef58u4ga3wagp44qhzm8f6zncl57g6qgh0pk3yytwz54h",  # ADACT
+    "pool1vhdl0z496gxlkfpdzxhk80t4363puea6awp6hd0w0qwnw75auae",  # RABIT
+    "pool1vzqtn3mtfvvuy8ghksy34gs9g97tszj5f8mr3sn7asy5vk577ec",  # PSBT
+    "pool1y0uxkqyplyx6ld25e976t0s35va3ysqcscatwvy2sd2cwcareq7",  # HODLr
+)
 
 
 @dataclasses.dataclass(frozen=True, order=True)
@@ -62,11 +69,11 @@ def cluster_and_pool(
     if cluster_type.type == cluster_nodes.ClusterType.TESTNET:
         cluster_obj: clusterlib.ClusterLib = cluster_manager.get(use_resources=use_resources)
 
-        # getting ledger state on official testnet is too expensive,
+        # Getting ledger state on official testnet is too expensive,
         # use one of hardcoded pool IDs if possible
-        if cluster_type.testnet_type == cluster_nodes.Testnets.testnet:  # type: ignore
+        if cluster_type.testnet_type == cluster_nodes.Testnets.preview:
             stake_pools = cluster_obj.g_query.get_stake_pools()
-            for pool_id in configuration.TESTNET_POOL_IDS:
+            for pool_id in PREVIEW_POOL_IDS:
                 if pool_id in stake_pools:
                     return cluster_obj, pool_id
 

--- a/cardano_node_tests/utils/cluster_nodes.py
+++ b/cardano_node_tests/utils/cluster_nodes.py
@@ -44,9 +44,6 @@ class ServiceStatus:
 
 class Testnets:
     # pylint: disable=invalid-name
-    shelley_qa: tp.Final[str] = "shelley_qa"
-    testnet: tp.Final[str] = "testnet"
-    staging: tp.Final[str] = "staging"
     preview: tp.Final[str] = "preview"
     preprod: tp.Final[str] = "preprod"
     mainnet: tp.Final[str] = "mainnet"
@@ -185,12 +182,9 @@ class TestnetCluster(ClusterType):
     """Testnet cluster type (full cardano mode)."""
 
     TESTNETS: tp.ClassVar[tp.Dict[int, dict]] = {
-        1563999616: {"type": Testnets.testnet, "shelley_start": "2020-07-28T20:20:16Z"},
-        1506450213: {"type": Testnets.staging, "shelley_start": "2020-08-01T18:23:33Z"},
         1506203091: {"type": Testnets.mainnet, "shelley_start": "2020-07-29T21:44:51Z"},
         1654041600: {"type": Testnets.preprod, "byron_epochs": 4},
         1666656000: {"type": Testnets.preview, "byron_epochs": 0},
-        1689206400: {"type": Testnets.shelley_qa, "byron_epochs": 0},
     }
 
     NODES: tp.ClassVar[tp.Set[str]] = {"relay1"}

--- a/cardano_node_tests/utils/configuration.py
+++ b/cardano_node_tests/utils/configuration.py
@@ -49,12 +49,6 @@ if UTXO_BACKEND not in ("", "mem", "disk"):
     msg = f"Invalid UTXO_BACKEND: {UTXO_BACKEND}"
     raise RuntimeError(msg)
 
-TESTNET_POOL_IDS = (
-    "pool18yslg3q320jex6gsmetukxvzm7a20qd90wsll9anlkrfua38flr",
-    "pool15sfcpy4tps5073gmra0e6tm2dgtrn004yr437qmeh44sgjlg2ex",
-    "pool1csh8x6227uphxz67nr8qhmd8c7nsyct2ptn7t0yjkhqu7neauwu",
-)
-
 # resolve CARDANO_NODE_SOCKET_PATH
 STARTUP_CARDANO_NODE_SOCKET_PATH = (
     pl.Path(os.environ["CARDANO_NODE_SOCKET_PATH"]).expanduser().resolve()


### PR DESCRIPTION
- Removed obsolete testnet types from cluster_nodes.py
- Removed unused testnet pool IDs from configuration.py
- Added new preview pool IDs in delegation.py
- Updated references to use the new preview pool IDs