### PR TITLE
fix(tests): update magic_args for missing arg scenario

### DIFF
--- a/cardano_node_tests/tests/test_env_network_id.py
+++ b/cardano_node_tests/tests/test_env_network_id.py
@@ -49,7 +49,7 @@ def _setup_scenarios(
         os.environ["CARDANO_NODE_NETWORK_ID"] = "424242"
 
     if arg_scenario == "arg_missing":
-        cluster_obj.magic_args = []
+        cluster_obj.magic_args = ["--cardano-mode"]
     elif arg_scenario == "arg_wrong":
         cluster_obj.magic_args = ["--testnet-magic", "424242"]
 


### PR DESCRIPTION
Updated the `magic_args` for the `arg_missing` scenario in the `test_env_network_id.py` test file to include `--cardano-mode`. This assures that the expected error message is returned.