### PR TITLE
feat(tests): add create_pparams_file in TestCLI

### DIFF
--- a/cardano_node_tests/tests/test_cli.py
+++ b/cardano_node_tests/tests/test_cli.py
@@ -67,6 +67,7 @@ class TestCLI:
         """Check the `calculate-min-fee` command."""
         common.get_test_id(cluster)
         max_fee = 172_000
+        cluster.create_pparams_file()
 
         try:
             out = (


### PR DESCRIPTION
Add a call to `cluster.create_pparams_file()` in the `calculate-min-fee` test method of the `TestCLI` class. This ensures that the protocol parameters file is created before running the test, which is necessary for the test to execute correctly and for the expected error message to be returned.