### PR TITLE
refactor: review "testnets" marker

### DIFF
--- a/cardano_node_tests/tests/test_addr_registration.py
+++ b/cardano_node_tests/tests/test_addr_registration.py
@@ -61,13 +61,13 @@ def pool_users_disposable(
     return pool_users
 
 
-@pytest.mark.testnets
 @pytest.mark.smoke
 class TestRegisterAddr:
     """Tests for stake address registration and deregistration."""
 
     @allure.link(helpers.get_vcs_link())
     @common.PARAM_USE_BUILD_CMD
+    @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_deregister_registered(
         self,
@@ -194,6 +194,7 @@ class TestRegisterAddr:
 
     @allure.link(helpers.get_vcs_link())
     @common.PARAM_USE_BUILD_CMD
+    @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_addr_registration_deregistration(
         self,
@@ -286,6 +287,7 @@ class TestRegisterAddr:
     @allure.link(helpers.get_vcs_link())
     @submit_utils.PARAM_SUBMIT_METHOD
     @common.PARAM_USE_BUILD_CMD
+    @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_addr_registration_certificate_order(
         self,
@@ -376,12 +378,12 @@ class TestRegisterAddr:
             assert user_registered.stake.address in tx_db_record.stake_deregistration
 
 
-@pytest.mark.testnets
 @pytest.mark.smoke
 class TestNegative:
     """Tests that are expected to fail."""
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.testnets
     def test_registration_cert_with_wrong_key(
         self,
         cluster: clusterlib.ClusterLib,
@@ -404,6 +406,7 @@ class TestNegative:
         assert "Expected: StakeVerificationKeyShelley" in err_msg, err_msg
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.testnets
     def test_register_addr_with_wrong_key(
         self,
         cluster: clusterlib.ClusterLib,
@@ -441,6 +444,7 @@ class TestNegative:
 
     @allure.link(helpers.get_vcs_link())
     @common.PARAM_USE_BUILD_CMD
+    @pytest.mark.testnets
     def test_deregister_not_registered_addr(
         self,
         cluster: clusterlib.ClusterLib,

--- a/cardano_node_tests/tests/test_delegation.py
+++ b/cardano_node_tests/tests/test_delegation.py
@@ -396,7 +396,6 @@ class TestDelegateAddr:
     @pytest.mark.order(7)
     @pytest.mark.dbsync
     @pytest.mark.long
-    @pytest.mark.testnets
     def test_deregister_delegated(
         self,
         cluster_manager: cluster_management.ClusterManager,
@@ -563,7 +562,6 @@ class TestDelegateAddr:
     @pytest.mark.order(7)
     @pytest.mark.dbsync
     @pytest.mark.long
-    @pytest.mark.testnets
     def test_undelegate(
         self,
         cluster_manager: cluster_management.ClusterManager,
@@ -850,12 +848,12 @@ class TestDelegateAddr:
             assert pool_id == tx_db_deleg.stake_delegation[0].pool_id
 
 
-@pytest.mark.testnets
 @pytest.mark.smoke
 class TestNegative:
     """Tests that are expected to fail."""
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.testnets
     def test_delegation_cert_with_wrong_key(
         self,
         cluster_and_pool: tp.Tuple[clusterlib.ClusterLib, str],
@@ -882,6 +880,7 @@ class TestNegative:
         ), err_msg
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.testnets
     def test_delegate_addr_with_wrong_key(
         self,
         cluster_and_pool: tp.Tuple[clusterlib.ClusterLib, str],
@@ -943,6 +942,7 @@ class TestNegative:
 
     @allure.link(helpers.get_vcs_link())
     @common.PARAM_USE_BUILD_CMD
+    @pytest.mark.testnets
     def test_delegate_unknown_addr(
         self,
         cluster_and_pool: tp.Tuple[clusterlib.ClusterLib, str],
@@ -1001,6 +1001,7 @@ class TestNegative:
 
     @allure.link(helpers.get_vcs_link())
     @common.PARAM_USE_BUILD_CMD
+    @pytest.mark.testnets
     def test_delegate_deregistered_addr(
         self,
         cluster_and_pool: tp.Tuple[clusterlib.ClusterLib, str],
@@ -1104,6 +1105,7 @@ class TestNegative:
         ), err_msg
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.testnets
     def test_delegatee_not_registered(
         self,
         cluster: clusterlib.ClusterLib,

--- a/cardano_node_tests/tests/test_env_network_id.py
+++ b/cardano_node_tests/tests/test_env_network_id.py
@@ -124,11 +124,11 @@ def payment_addrs(
 
 
 @pytest.mark.smoke
-@pytest.mark.testnets
 class TestNetworkIdEnv:
     """Tests for `CARDANO_NODE_NETWORK_ID`."""
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.testnets
     def test_query_protocol_state(
         self,
         skip_on_no_env: None,  # noqa: ARG002
@@ -142,6 +142,7 @@ class TestNetworkIdEnv:
         assert "lastSlot" in state
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.testnets
     def test_query_stake_distribution(
         self,
         skip_on_no_env: None,  # noqa: ARG002
@@ -155,6 +156,7 @@ class TestNetworkIdEnv:
         assert next(iter(distrib)).startswith("pool")
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.testnets
     def test_query_protocol_params(
         self,
         skip_on_no_env: None,  # noqa: ARG002
@@ -168,6 +170,7 @@ class TestNetworkIdEnv:
         assert "protocolVersion" in protocol_params
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.testnets
     def test_query_pool_state(
         self,
         skip_on_no_env: None,  # noqa: ARG002
@@ -180,6 +183,7 @@ class TestNetworkIdEnv:
         cluster.g_query.get_pool_state(stake_pool_id=POOL_ID)
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.testnets
     def test_query_stake_addr_info(
         self,
         skip_on_no_env: None,  # noqa: ARG002
@@ -193,6 +197,7 @@ class TestNetworkIdEnv:
 
     @allure.link(helpers.get_vcs_link())
     @common.SKIPIF_BUILD_UNUSABLE
+    @pytest.mark.testnets
     def test_build_transfer_funds(
         self,
         skip_on_no_env: None,  # noqa: ARG002
@@ -243,7 +248,6 @@ class TestNetworkIdEnv:
 
 
 @pytest.mark.smoke
-@pytest.mark.testnets
 class TestNegativeNetworkIdEnv:
     """Negative tests for `CARDANO_NODE_NETWORK_ID`."""
 
@@ -260,6 +264,7 @@ class TestNegativeNetworkIdEnv:
     @allure.link(helpers.get_vcs_link())
     @PARAM_ENV_SCENARIO
     @PARAM_ARG_SCENARIO
+    @pytest.mark.testnets
     def test_neg_query_protocol_state(
         self,
         skip_on_no_env: None,  # noqa: ARG002
@@ -289,6 +294,7 @@ class TestNegativeNetworkIdEnv:
     @allure.link(helpers.get_vcs_link())
     @PARAM_ENV_SCENARIO
     @PARAM_ARG_SCENARIO
+    @pytest.mark.testnets
     def test_neg_query_stake_distribution(
         self,
         skip_on_no_env: None,  # noqa: ARG002
@@ -317,6 +323,7 @@ class TestNegativeNetworkIdEnv:
     @allure.link(helpers.get_vcs_link())
     @PARAM_ENV_SCENARIO
     @PARAM_ARG_SCENARIO
+    @pytest.mark.testnets
     def test_neg_query_protocol_params(
         self,
         skip_on_no_env: None,  # noqa: ARG002
@@ -345,6 +352,7 @@ class TestNegativeNetworkIdEnv:
     @allure.link(helpers.get_vcs_link())
     @PARAM_ENV_SCENARIO
     @PARAM_ARG_SCENARIO
+    @pytest.mark.testnets
     def test_neg_query_pool_state(
         self,
         skip_on_no_env: None,  # noqa: ARG002
@@ -373,6 +381,7 @@ class TestNegativeNetworkIdEnv:
     @allure.link(helpers.get_vcs_link())
     @PARAM_ENV_SCENARIO
     @PARAM_ARG_SCENARIO
+    @pytest.mark.testnets
     def test_neg_query_stake_addr_info(
         self,
         skip_on_no_env: None,  # noqa: ARG002
@@ -402,6 +411,7 @@ class TestNegativeNetworkIdEnv:
     @common.SKIPIF_BUILD_UNUSABLE
     @PARAM_ENV_SCENARIO
     @PARAM_ARG_SCENARIO
+    @pytest.mark.testnets
     def test_neg_build_transfer_funds(
         self,
         skip_on_no_env: None,  # noqa: ARG002

--- a/cardano_node_tests/tests/test_native_tokens.py
+++ b/cardano_node_tests/tests/test_native_tokens.py
@@ -139,7 +139,6 @@ def multisig_script_policyid(
 
 
 @common.SKIPIF_TOKENS_UNUSABLE
-@pytest.mark.testnets
 class TestMinting:
     """Tests for minting and burning tokens."""
 
@@ -148,6 +147,7 @@ class TestMinting:
     @common.PARAM_USE_BUILD_CMD
     @pytest.mark.parametrize("aname_type", ("asset_name", "empty_asset_name"))
     @pytest.mark.smoke
+    @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_minting_and_burning_witnesses(
         self,
@@ -253,6 +253,7 @@ class TestMinting:
     @common.PARAM_USE_BUILD_CMD
     @pytest.mark.parametrize("aname_type", ("asset_name", "empty_asset_name"))
     @pytest.mark.smoke
+    @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_minting_and_burning_sign(
         self,
@@ -346,6 +347,7 @@ class TestMinting:
     @submit_utils.PARAM_SUBMIT_METHOD
     @common.PARAM_USE_BUILD_CMD
     @pytest.mark.smoke
+    @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_minting_multiple_scripts(
         self,
@@ -465,6 +467,7 @@ class TestMinting:
     @submit_utils.PARAM_SUBMIT_METHOD
     @common.PARAM_USE_BUILD_CMD
     @pytest.mark.smoke
+    @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_minting_burning_diff_tokens_single_tx(
         self,
@@ -578,6 +581,7 @@ class TestMinting:
     @submit_utils.PARAM_SUBMIT_METHOD
     @common.PARAM_USE_BUILD_CMD
     @pytest.mark.smoke
+    @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_minting_burning_same_token_single_tx(
         self,
@@ -699,6 +703,7 @@ class TestMinting:
     @common.PARAM_USE_BUILD_CMD
     @pytest.mark.parametrize("tokens_db", MINT_BURN_WITNESS_PARAMS)
     @pytest.mark.smoke
+    @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_bundle_minting_and_burning_witnesses(
         self,
@@ -842,6 +847,7 @@ class TestMinting:
     @common.PARAM_USE_BUILD_CMD
     @pytest.mark.parametrize("tokens_db", MINT_BURN_SIGN_PARAMS)
     @pytest.mark.smoke
+    @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_bundle_minting_and_burning_sign(
         self,
@@ -981,6 +987,7 @@ class TestMinting:
     @submit_utils.PARAM_SUBMIT_METHOD
     @common.PARAM_USE_BUILD_CMD
     @pytest.mark.smoke
+    @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_minting_and_partial_burning(
         self,
@@ -1079,6 +1086,7 @@ class TestMinting:
     @submit_utils.PARAM_SUBMIT_METHOD
     @common.PARAM_USE_BUILD_CMD
     @pytest.mark.smoke
+    @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_minting_unicode_asset_name(
         self,
@@ -1163,13 +1171,13 @@ class TestMinting:
 
 
 @common.SKIPIF_TOKENS_UNUSABLE
-@pytest.mark.testnets
 @pytest.mark.smoke
 class TestPolicies:
     """Tests for minting and burning tokens using minting policies."""
 
     @allure.link(helpers.get_vcs_link())
     @common.PARAM_USE_BUILD_CMD
+    @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_valid_policy_after(
         self,
@@ -1260,6 +1268,7 @@ class TestPolicies:
 
     @allure.link(helpers.get_vcs_link())
     @common.PARAM_USE_BUILD_CMD
+    @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_valid_policy_before(
         self,
@@ -1351,6 +1360,7 @@ class TestPolicies:
         dbsync_utils.check_tx(cluster_obj=cluster, tx_raw_output=tx_out_burn)
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.testnets
     def test_policy_before_past(
         self, cluster: clusterlib.ClusterLib, issuers_addrs: tp.List[clusterlib.AddressRecord]
     ):
@@ -1420,6 +1430,7 @@ class TestPolicies:
             assert not token_utxo, "The token was minted unexpectedly"
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.testnets
     def test_policy_before_future(
         self, cluster: clusterlib.ClusterLib, issuers_addrs: tp.List[clusterlib.AddressRecord]
     ):
@@ -1481,6 +1492,7 @@ class TestPolicies:
             assert not token_utxo, "The token was minted unexpectedly"
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.testnets
     def test_policy_after_future(
         self, cluster: clusterlib.ClusterLib, issuers_addrs: tp.List[clusterlib.AddressRecord]
     ):
@@ -1553,6 +1565,7 @@ class TestPolicies:
             assert not token_utxo, "The token was minted unexpectedly"
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.testnets
     def test_policy_after_past(
         self, cluster: clusterlib.ClusterLib, issuers_addrs: tp.List[clusterlib.AddressRecord]
     ):
@@ -1615,7 +1628,6 @@ class TestPolicies:
 
 
 @common.SKIPIF_TOKENS_UNUSABLE
-@pytest.mark.testnets
 @pytest.mark.smoke
 class TestTransfer:
     """Tests for transferring tokens."""
@@ -1683,6 +1695,7 @@ class TestTransfer:
     @allure.link(helpers.get_vcs_link())
     @common.PARAM_USE_BUILD_CMD
     @pytest.mark.parametrize("amount", (1, 10, 200, 2_000, 100_000))
+    @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_transfer_tokens(
         self,
@@ -1814,6 +1827,7 @@ class TestTransfer:
 
     @allure.link(helpers.get_vcs_link())
     @common.PARAM_USE_BUILD_CMD
+    @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_transfer_multiple_tokens(
         self,
@@ -1996,6 +2010,7 @@ class TestTransfer:
         cluster_nodes.get_cluster_type().type != cluster_nodes.ClusterType.LOCAL,
         reason="runs only on local cluster",
     )
+    @pytest.mark.testnets
     def test_transfer_no_ada(
         self,
         cluster: clusterlib.ClusterLib,
@@ -2049,6 +2064,7 @@ class TestTransfer:
     @hypothesis.example(token_amount=MAX_TOKEN_AMOUNT)
     @common.hypothesis_settings(max_examples=200)
     @common.PARAM_USE_BUILD_CMD
+    @pytest.mark.testnets
     def test_transfer_invalid_token_amount(
         self,
         cluster: clusterlib.ClusterLib,
@@ -2120,7 +2136,6 @@ class TestTransfer:
 
 
 @common.SKIPIF_TOKENS_UNUSABLE
-@pytest.mark.testnets
 @pytest.mark.smoke
 class TestNegative:
     """Negative tests for minting tokens."""
@@ -2187,6 +2202,7 @@ class TestNegative:
         )
     )
     @common.hypothesis_settings(max_examples=300)
+    @pytest.mark.testnets
     def test_long_name(
         self,
         cluster: clusterlib.ClusterLib,
@@ -2232,6 +2248,7 @@ class TestNegative:
     @hypothesis.given(token_amount=st.integers(min_value=MAX_TOKEN_AMOUNT + 1))
     @hypothesis.example(token_amount=MAX_TOKEN_AMOUNT + 1)
     @common.hypothesis_settings(max_examples=300)
+    @pytest.mark.testnets
     def test_minting_amount_above_the_allowed(
         self,
         cluster: clusterlib.ClusterLib,
@@ -2270,12 +2287,12 @@ class TestNegative:
 
 
 @common.SKIPIF_WRONG_ERA
-@pytest.mark.testnets
 @pytest.mark.smoke
 class TestCLITxOutSyntax:
     """Tests of syntax for specifying muti-asset values and txouts."""
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_multiasset_txouts_syntax(
         self, cluster: clusterlib.ClusterLib, issuers_addrs: tp.List[clusterlib.AddressRecord]
@@ -2413,7 +2430,6 @@ class TestCLITxOutSyntax:
         dbsync_utils.check_tx(cluster_obj=cluster, tx_raw_output=tx_raw_output)
 
 
-@pytest.mark.testnets
 @pytest.mark.smoke
 @pytest.mark.skipif(
     VERSIONS.transaction_era < VERSIONS.BABBAGE,
@@ -2425,6 +2441,7 @@ class TestReferenceUTxO:
     @allure.link(helpers.get_vcs_link())
     @common.PARAM_USE_BUILD_CMD
     @pytest.mark.parametrize("script_version", ("simple_v1", "simple_v2"))
+    @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_script_reference_utxo(
         self,

--- a/cardano_node_tests/tests/test_pools.py
+++ b/cardano_node_tests/tests/test_pools.py
@@ -1916,7 +1916,6 @@ class TestPoolCost:
 
 
 @pytest.mark.smoke
-@pytest.mark.testnets
 class TestNegative:
     """Stake pool tests that are expected to fail."""
 
@@ -1985,6 +1984,7 @@ class TestNegative:
         return pool_name, pool_metadata_hash, node_vrf, node_cold
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.testnets
     def test_pool_registration_cert_wrong_vrf(
         self,
         cluster: clusterlib.ClusterLib,
@@ -2010,6 +2010,7 @@ class TestNegative:
         assert "Expected: VrfVerificationKey_PraosVRF" in str(excinfo.value)
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.testnets
     def test_pool_registration_cert_wrong_cold(
         self,
         cluster: clusterlib.ClusterLib,
@@ -2035,6 +2036,7 @@ class TestNegative:
         assert "Expected: StakePoolVerificationKey" in str(excinfo.value)
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.testnets
     def test_pool_registration_cert_wrong_stake(
         self,
         cluster: clusterlib.ClusterLib,
@@ -2060,6 +2062,7 @@ class TestNegative:
         assert "Expected: StakeVerificationKeyShelley" in str(excinfo.value)
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.testnets
     def test_pool_registration_missing_cold_skey(
         self,
         cluster: clusterlib.ClusterLib,
@@ -2099,6 +2102,7 @@ class TestNegative:
         assert "MissingVKeyWitnessesUTXOW" in str(excinfo.value)
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.testnets
     def test_pool_registration_missing_payment_skey(
         self,
         cluster: clusterlib.ClusterLib,
@@ -2137,6 +2141,7 @@ class TestNegative:
 
     @allure.link(helpers.get_vcs_link())
     @common.PARAM_USE_BUILD_CMD
+    @pytest.mark.testnets
     def test_pool_deregistration_not_registered(
         self,
         cluster: clusterlib.ClusterLib,
@@ -2186,6 +2191,7 @@ class TestNegative:
         assert "StakePoolNotRegisteredOnKeyPOOL" in str(excinfo.value)
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.testnets
     def test_stake_pool_metadata_no_name(
         self,
         cluster: clusterlib.ClusterLib,
@@ -2210,6 +2216,7 @@ class TestNegative:
         assert 'key "name" not found' in str(excinfo.value)
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.testnets
     def test_stake_pool_metadata_no_description(
         self,
         cluster: clusterlib.ClusterLib,
@@ -2234,6 +2241,7 @@ class TestNegative:
         assert 'key "description" not found' in str(excinfo.value)
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.testnets
     def test_stake_pool_metadata_no_ticker(
         self,
         cluster: clusterlib.ClusterLib,
@@ -2258,6 +2266,7 @@ class TestNegative:
         assert 'key "ticker" not found' in str(excinfo.value)
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.testnets
     def test_stake_pool_metadata_no_homepage(
         self,
         cluster: clusterlib.ClusterLib,
@@ -2284,6 +2293,7 @@ class TestNegative:
     @allure.link(helpers.get_vcs_link())
     @hypothesis.given(pool_name=st.text(min_size=51))
     @common.hypothesis_settings()
+    @pytest.mark.testnets
     def test_stake_pool_metadata_long_name(
         self,
         cluster: clusterlib.ClusterLib,
@@ -2316,6 +2326,7 @@ class TestNegative:
     @allure.link(helpers.get_vcs_link())
     @hypothesis.given(pool_description=st.text(min_size=256, max_size=1000))
     @common.hypothesis_settings()
+    @pytest.mark.testnets
     def test_stake_pool_metadata_long_description(
         self,
         cluster: clusterlib.ClusterLib,
@@ -2348,6 +2359,7 @@ class TestNegative:
     @allure.link(helpers.get_vcs_link())
     @hypothesis.given(pool_ticker=st.text())
     @common.hypothesis_settings()
+    @pytest.mark.testnets
     def test_stake_pool_metadata_long_ticker(
         self,
         cluster: clusterlib.ClusterLib,
@@ -2382,6 +2394,7 @@ class TestNegative:
     @allure.link(helpers.get_vcs_link())
     @hypothesis.given(pool_homepage=st.text(min_size=425, max_size=1000))
     @common.hypothesis_settings()
+    @pytest.mark.testnets
     def test_stake_pool_metadata_long_homepage(
         self,
         cluster: clusterlib.ClusterLib,
@@ -2412,6 +2425,7 @@ class TestNegative:
         metadata_url=st.text(alphabet=st.characters(blacklist_categories=["C"]), min_size=25)
     )
     @common.hypothesis_settings()
+    @pytest.mark.testnets
     def test_stake_pool_long_metadata_url(
         self,
         cluster: clusterlib.ClusterLib,

--- a/cardano_node_tests/tests/test_protocol.py
+++ b/cardano_node_tests/tests/test_protocol.py
@@ -82,12 +82,12 @@ PROTOCOL_PARAM_KEYS_MISSING_8_12_0 = frozenset(
 
 
 @common.SKIPIF_WRONG_ERA
-@pytest.mark.testnets
 @pytest.mark.smoke
 class TestProtocol:
     """Basic tests for protocol."""
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.testnets
     def test_protocol_state_keys(self, cluster: clusterlib.ClusterLib):
         """Check output of `query protocol-state`."""
         temp_template = common.get_test_id(cluster)
@@ -107,6 +107,7 @@ class TestProtocol:
         assert set(protocol_state) == PROTOCOL_STATE_KEYS
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.testnets
     def test_protocol_state_outfile(self, cluster: clusterlib.ClusterLib):
         """Check output file produced by `query protocol-state`."""
         common.get_test_id(cluster)
@@ -121,6 +122,7 @@ class TestProtocol:
         assert set(protocol_state) == PROTOCOL_STATE_KEYS
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.testnets
     def test_protocol_params(self, cluster: clusterlib.ClusterLib):
         """Check output of `query protocol-parameters`."""
         common.get_test_id(cluster)

--- a/cardano_node_tests/tests/test_scripts.py
+++ b/cardano_node_tests/tests/test_scripts.py
@@ -135,7 +135,6 @@ def multisig_tx(
     return tx_raw_output
 
 
-@pytest.mark.testnets
 @pytest.mark.smoke
 class TestBasic:
     """Basic tests for multisig transactions."""
@@ -168,6 +167,7 @@ class TestBasic:
         return addrs
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.testnets
     def test_script_addr_length(
         self, cluster: clusterlib.ClusterLib, payment_addrs: tp.List[clusterlib.AddressRecord]
     ):
@@ -197,6 +197,7 @@ class TestBasic:
     @allure.link(helpers.get_vcs_link())
     @submit_utils.PARAM_SUBMIT_METHOD
     @common.PARAM_USE_BUILD_CMD
+    @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_multisig_all(
         self,
@@ -254,6 +255,7 @@ class TestBasic:
     @allure.link(helpers.get_vcs_link())
     @submit_utils.PARAM_SUBMIT_METHOD
     @common.PARAM_USE_BUILD_CMD
+    @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_multisig_any(
         self,
@@ -348,6 +350,7 @@ class TestBasic:
     @allure.link(helpers.get_vcs_link())
     @submit_utils.PARAM_SUBMIT_METHOD
     @common.PARAM_USE_BUILD_CMD
+    @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_multisig_atleast(
         self,
@@ -417,6 +420,7 @@ class TestBasic:
     @allure.link(helpers.get_vcs_link())
     @submit_utils.PARAM_SUBMIT_METHOD
     @common.PARAM_USE_BUILD_CMD
+    @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_normal_tx_to_script_addr(
         self,
@@ -475,6 +479,7 @@ class TestBasic:
     @allure.link(helpers.get_vcs_link())
     @submit_utils.PARAM_SUBMIT_METHOD
     @common.PARAM_USE_BUILD_CMD
+    @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_normal_tx_from_script_addr(
         self,
@@ -552,6 +557,7 @@ class TestBasic:
         dbsync_utils.check_tx(cluster_obj=cluster, tx_raw_output=tx_out_from)
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_multisig_empty_all(
         self, cluster: clusterlib.ClusterLib, payment_addrs: tp.List[clusterlib.AddressRecord]
@@ -604,6 +610,7 @@ class TestBasic:
         dbsync_utils.check_tx(cluster_obj=cluster, tx_raw_output=tx_out_from)
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_multisig_no_required_atleast(
         self, cluster: clusterlib.ClusterLib, payment_addrs: tp.List[clusterlib.AddressRecord]
@@ -664,7 +671,6 @@ class TestBasic:
         dbsync_utils.check_tx(cluster_obj=cluster, tx_raw_output=tx_out_from)
 
 
-@pytest.mark.testnets
 @pytest.mark.smoke
 class TestNegative:
     """Transaction tests that are expected to fail."""
@@ -699,6 +705,7 @@ class TestNegative:
         return addrs
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_multisig_all_missing_skey(
         self, cluster: clusterlib.ClusterLib, payment_addrs: tp.List[clusterlib.AddressRecord]
@@ -751,6 +758,7 @@ class TestNegative:
         dbsync_utils.check_tx(cluster_obj=cluster, tx_raw_output=tx_raw_output)
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_multisig_any_unlisted_skey(
         self, cluster: clusterlib.ClusterLib, payment_addrs: tp.List[clusterlib.AddressRecord]
@@ -803,6 +811,7 @@ class TestNegative:
         dbsync_utils.check_tx(cluster_obj=cluster, tx_raw_output=tx_raw_output)
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_multisig_atleast_low_num_of_skeys(
         self, cluster: clusterlib.ClusterLib, payment_addrs: tp.List[clusterlib.AddressRecord]
@@ -860,7 +869,6 @@ class TestNegative:
         dbsync_utils.check_tx(cluster_obj=cluster, tx_raw_output=tx_raw_output)
 
 
-@pytest.mark.testnets
 @pytest.mark.smoke
 @pytest.mark.skipif(
     VERSIONS.transaction_era < VERSIONS.ALLEGRA,
@@ -1043,6 +1051,7 @@ class TestTimeLocking:
     @pytest.mark.parametrize(
         "use_tx_validity", (True, False), ids=("tx_validity", "no_tx_validity")
     )
+    @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_script_after(
         self,
@@ -1114,6 +1123,7 @@ class TestTimeLocking:
     @pytest.mark.parametrize(
         "use_tx_validity", (True, False), ids=("tx_validity", "no_tx_validity")
     )
+    @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_script_before(
         self,
@@ -1181,6 +1191,7 @@ class TestTimeLocking:
     @allure.link(helpers.get_vcs_link())
     @common.PARAM_USE_BUILD_CMD
     @pytest.mark.parametrize("slot_type", ("before", "after"))
+    @pytest.mark.testnets
     def test_tx_missing_validity(
         self,
         cluster: clusterlib.ClusterLib,
@@ -1248,6 +1259,7 @@ class TestTimeLocking:
 
     @allure.link(helpers.get_vcs_link())
     @common.PARAM_USE_BUILD_CMD
+    @pytest.mark.testnets
     def test_tx_negative_validity(
         self,
         cluster: clusterlib.ClusterLib,
@@ -1327,6 +1339,7 @@ class TestTimeLocking:
     )
     @hypothesis.given(data=st.data())
     @common.hypothesis_settings(max_examples=50)
+    @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_before_past(
         self,
@@ -1394,6 +1407,7 @@ class TestTimeLocking:
     )
     @hypothesis.given(slot_no=st.integers(min_value=1, max_value=10_000))
     @common.hypothesis_settings(max_examples=50)
+    @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_before_future(
         self,
@@ -1442,6 +1456,7 @@ class TestTimeLocking:
     )
     @hypothesis.given(data=st.data())
     @common.hypothesis_settings(max_examples=50)
+    @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_after_future(
         self,
@@ -1509,6 +1524,7 @@ class TestTimeLocking:
     )
     @hypothesis.given(data=st.data())
     @common.hypothesis_settings(max_examples=50)
+    @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_after_past(
         self,
@@ -1552,7 +1568,6 @@ class TestTimeLocking:
         dbsync_utils.check_tx(cluster_obj=cluster, tx_raw_output=tx_output)
 
 
-@pytest.mark.testnets
 @pytest.mark.smoke
 @pytest.mark.skipif(
     VERSIONS.transaction_era < VERSIONS.ALLEGRA,
@@ -1593,6 +1608,7 @@ class TestAuxiliaryScripts:
     @allure.link(helpers.get_vcs_link())
     @submit_utils.PARAM_SUBMIT_METHOD
     @common.PARAM_USE_BUILD_CMD
+    @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_tx_script_metadata_json(
         self,
@@ -1648,6 +1664,7 @@ class TestAuxiliaryScripts:
     @allure.link(helpers.get_vcs_link())
     @submit_utils.PARAM_SUBMIT_METHOD
     @common.PARAM_USE_BUILD_CMD
+    @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_tx_script_metadata_cbor(
         self,
@@ -1704,6 +1721,7 @@ class TestAuxiliaryScripts:
     @allure.link(helpers.get_vcs_link())
     @submit_utils.PARAM_SUBMIT_METHOD
     @common.PARAM_USE_BUILD_CMD
+    @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_tx_script_no_metadata(
         self,
@@ -1750,6 +1768,7 @@ class TestAuxiliaryScripts:
 
     @allure.link(helpers.get_vcs_link())
     @common.PARAM_USE_BUILD_CMD
+    @pytest.mark.testnets
     def test_tx_script_invalid(
         self,
         cluster: clusterlib.ClusterLib,
@@ -1784,7 +1803,6 @@ class TestAuxiliaryScripts:
         assert 'Error in $: key "type" not found' in err_str, err_str
 
 
-@pytest.mark.testnets
 @pytest.mark.smoke
 class TestIncrementalSigning:
     """Tests for incremental signing."""
@@ -1826,6 +1844,7 @@ class TestIncrementalSigning:
     @submit_utils.PARAM_SUBMIT_METHOD
     @common.PARAM_USE_BUILD_CMD
     @pytest.mark.parametrize("tx_is", ("witnessed", "signed"))
+    @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_incremental_signing(
         self,
@@ -1980,7 +1999,6 @@ class TestIncrementalSigning:
         dbsync_utils.check_tx(cluster_obj=cluster, tx_raw_output=tx_out_from)
 
 
-@pytest.mark.testnets
 @pytest.mark.smoke
 @pytest.mark.skipif(
     VERSIONS.transaction_era < VERSIONS.ALONZO,
@@ -2022,6 +2040,7 @@ class TestDatum:
     @submit_utils.PARAM_SUBMIT_METHOD
     @common.PARAM_USE_BUILD_CMD
     @pytest.mark.parametrize("script_version", ("simple_v1", "simple_v2"))
+    @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_script_utxo_datum(
         self,
@@ -2092,7 +2111,6 @@ class TestDatum:
         dbsync_utils.check_tx(cluster_obj=cluster, tx_raw_output=tx_output)
 
 
-@pytest.mark.testnets
 @pytest.mark.smoke
 @pytest.mark.skipif(
     VERSIONS.transaction_era < VERSIONS.BABBAGE,
@@ -2132,6 +2150,7 @@ class TestReferenceUTxO:
     @submit_utils.PARAM_SUBMIT_METHOD
     @common.PARAM_USE_BUILD_CMD
     @pytest.mark.parametrize("script_version", ("simple_v1", "simple_v2"))
+    @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_script_reference_utxo(
         self,
@@ -2274,6 +2293,7 @@ class TestReferenceUTxO:
     @common.PARAM_USE_BUILD_CMD
     @pytest.mark.parametrize("script_version", ("simple_v1", "simple_v2"))
     @pytest.mark.parametrize("address_type", ("shelley", "byron"))
+    @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_spend_reference_script(
         self,
@@ -2361,7 +2381,6 @@ class TestReferenceUTxO:
         # TODO: check reference script in db-sync (the `tx_out_spend`)
 
 
-@pytest.mark.testnets
 @pytest.mark.smoke
 @pytest.mark.skipif(
     VERSIONS.transaction_era < VERSIONS.ALLEGRA,
@@ -2404,6 +2423,7 @@ class TestNested:
     @common.PARAM_USE_BUILD_CMD
     @pytest.mark.parametrize("type_top", ("all", "any"))
     @pytest.mark.parametrize("type_nested", ("all", "any"))
+    @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_nested_script(
         self,
@@ -2506,6 +2526,7 @@ class TestNested:
     @allure.link(helpers.get_vcs_link())
     @submit_utils.PARAM_SUBMIT_METHOD
     @common.PARAM_USE_BUILD_CMD
+    @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_nested_optional_all(
         self,
@@ -2589,6 +2610,7 @@ class TestNested:
     @pytest.mark.parametrize(
         "scenario", ("all1", "all2", "all3", "all4", "all5", "all6", "any1", "any2", "any3", "any4")
     )
+    @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_invalid(  # noqa: C901
         self,
@@ -2791,7 +2813,6 @@ class TestNested:
         dbsync_utils.check_tx(cluster_obj=cluster, tx_raw_output=tx_raw_output)
 
 
-@pytest.mark.testnets
 @pytest.mark.smoke
 class TestCompatibility:
     """Tests for checking compatibility with previous Tx eras."""
@@ -2828,6 +2849,7 @@ class TestCompatibility:
         reason="runs only with Shelley TX",
     )
     @submit_utils.PARAM_SUBMIT_METHOD
+    @pytest.mark.testnets
     def test_script_v2(
         self,
         cluster: clusterlib.ClusterLib,
@@ -2891,6 +2913,7 @@ class TestCompatibility:
         reason="runs only with Shelley TX",
     )
     @submit_utils.PARAM_SUBMIT_METHOD
+    @pytest.mark.testnets
     def test_auxiliary_scripts(
         self,
         cluster: clusterlib.ClusterLib,

--- a/cardano_node_tests/tests/test_socket_path.py
+++ b/cardano_node_tests/tests/test_socket_path.py
@@ -116,12 +116,12 @@ def payment_addrs(
 
 
 @pytest.mark.smoke
-@pytest.mark.testnets
 class TestSocketPath:
     """Tests for `cardano-cli ... --socket-path`."""
 
     @allure.link(helpers.get_vcs_link())
     @PARAM_ENV_SCENARIO
+    @pytest.mark.testnets
     def test_query_protocol_state(
         self,
         set_socket_path: None,  # noqa: ARG002
@@ -139,6 +139,7 @@ class TestSocketPath:
 
     @allure.link(helpers.get_vcs_link())
     @PARAM_ENV_SCENARIO
+    @pytest.mark.testnets
     def test_query_stake_distribution(
         self,
         set_socket_path: None,  # noqa: ARG002
@@ -156,6 +157,7 @@ class TestSocketPath:
 
     @allure.link(helpers.get_vcs_link())
     @PARAM_ENV_SCENARIO
+    @pytest.mark.testnets
     def test_query_protocol_params(
         self,
         set_socket_path: None,  # noqa: ARG002
@@ -173,6 +175,7 @@ class TestSocketPath:
 
     @allure.link(helpers.get_vcs_link())
     @PARAM_ENV_SCENARIO
+    @pytest.mark.testnets
     def test_query_pool_state(
         self,
         set_socket_path: None,  # noqa: ARG002
@@ -189,6 +192,7 @@ class TestSocketPath:
 
     @allure.link(helpers.get_vcs_link())
     @PARAM_ENV_SCENARIO
+    @pytest.mark.testnets
     def test_query_stake_addr_info(
         self,
         set_socket_path: None,  # noqa: ARG002
@@ -206,6 +210,7 @@ class TestSocketPath:
     @allure.link(helpers.get_vcs_link())
     @common.SKIPIF_BUILD_UNUSABLE
     @PARAM_ENV_SCENARIO
+    @pytest.mark.testnets
     def test_build_transfer_funds(
         self,
         set_socket_path: None,  # noqa: ARG002

--- a/cardano_node_tests/tests/test_tx_basic.py
+++ b/cardano_node_tests/tests/test_tx_basic.py
@@ -28,7 +28,6 @@ from cardano_node_tests.utils.versions import VERSIONS
 LOGGER = logging.getLogger(__name__)
 
 
-@pytest.mark.testnets
 @pytest.mark.smoke
 class TestBasicTransactions:
     """Test basic transactions - transferring funds, transaction IDs."""
@@ -162,6 +161,7 @@ class TestBasicTransactions:
     @pytest.mark.parametrize(
         "src_addr_type", ("shelley", "byron"), ids=("src_shelley", "src_byron")
     )
+    @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_transfer_funds(
         self,
@@ -222,6 +222,7 @@ class TestBasicTransactions:
     @allure.link(helpers.get_vcs_link())
     @common.SKIPIF_BUILD_UNUSABLE
     @submit_utils.PARAM_SUBMIT_METHOD
+    @pytest.mark.testnets
     def test_byron_fee_too_small(
         self,
         cluster: clusterlib.ClusterLib,
@@ -270,6 +271,7 @@ class TestBasicTransactions:
     @allure.link(helpers.get_vcs_link())
     @common.SKIPIF_BUILD_UNUSABLE
     @submit_utils.PARAM_SUBMIT_METHOD
+    @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_build_no_change(
         self,
@@ -354,6 +356,7 @@ class TestBasicTransactions:
 
     @allure.link(helpers.get_vcs_link())
     @submit_utils.PARAM_SUBMIT_METHOD
+    @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_transfer_all_funds(
         self,
@@ -423,6 +426,7 @@ class TestBasicTransactions:
     @allure.link(helpers.get_vcs_link())
     @submit_utils.PARAM_SUBMIT_METHOD
     @common.PARAM_USE_BUILD_CMD
+    @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_funds_to_valid_address(
         self,
@@ -482,6 +486,7 @@ class TestBasicTransactions:
     @allure.link(helpers.get_vcs_link())
     @submit_utils.PARAM_SUBMIT_METHOD
     @common.PARAM_USE_BUILD_CMD
+    @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_get_txid(
         self,
@@ -536,6 +541,7 @@ class TestBasicTransactions:
 
     @allure.link(helpers.get_vcs_link())
     @submit_utils.PARAM_SUBMIT_METHOD
+    @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_extra_signing_keys(
         self,
@@ -599,6 +605,7 @@ class TestBasicTransactions:
 
     @allure.link(helpers.get_vcs_link())
     @submit_utils.PARAM_SUBMIT_METHOD
+    @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_duplicate_signing_keys(
         self,
@@ -662,6 +669,7 @@ class TestBasicTransactions:
     @allure.link(helpers.get_vcs_link())
     @submit_utils.PARAM_SUBMIT_METHOD
     @pytest.mark.parametrize("file_type", ("tx_body", "tx"))
+    @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_sign_wrong_file(
         self,
@@ -730,6 +738,7 @@ class TestBasicTransactions:
 
     @allure.link(helpers.get_vcs_link())
     @submit_utils.PARAM_SUBMIT_METHOD
+    @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_no_txout(
         self,
@@ -779,6 +788,7 @@ class TestBasicTransactions:
         dbsync_utils.check_tx(cluster_obj=cluster, tx_raw_output=tx_raw_output)
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.testnets
     def test_missing_tx_out(
         self,
         cluster: clusterlib.ClusterLib,
@@ -817,6 +827,7 @@ class TestBasicTransactions:
         reason="doesn't run with Shelley TX on node < 8.7.0",
     )
     @submit_utils.PARAM_SUBMIT_METHOD
+    @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_missing_ttl(
         self,
@@ -877,6 +888,7 @@ class TestBasicTransactions:
 
     @allure.link(helpers.get_vcs_link())
     @submit_utils.PARAM_SUBMIT_METHOD
+    @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_multiple_same_txins(
         self,
@@ -940,6 +952,7 @@ class TestBasicTransactions:
 
     @allure.link(helpers.get_vcs_link())
     @common.SKIPIF_BUILD_UNUSABLE
+    @pytest.mark.testnets
     def test_build_multiple_same_txins(
         self,
         cluster: clusterlib.ClusterLib,
@@ -987,6 +1000,7 @@ class TestBasicTransactions:
     )
     @submit_utils.PARAM_SUBMIT_METHOD
     @pytest.mark.dbsync
+    @pytest.mark.testnets
     def test_utxo_with_datum_hash(
         self,
         cluster: clusterlib.ClusterLib,
@@ -1053,6 +1067,7 @@ class TestBasicTransactions:
     @allure.link(helpers.get_vcs_link())
     @submit_utils.PARAM_SUBMIT_METHOD
     @pytest.mark.dbsync
+    @pytest.mark.testnets
     def test_far_future_ttl(
         self,
         cluster: clusterlib.ClusterLib,
@@ -1111,6 +1126,7 @@ class TestBasicTransactions:
         ids=("explicit_tx_era", "implicit_tx_era"),
         indirect=True,
     )
+    @pytest.mark.testnets
     def test_default_tx_era(
         self,
         cluster: clusterlib.ClusterLib,
@@ -1148,7 +1164,6 @@ class TestBasicTransactions:
         tx_view.check_tx_view(cluster_obj=cluster, tx_raw_output=tx_output)
 
 
-@pytest.mark.testnets
 @pytest.mark.smoke
 class TestMultiInOut:
     """Test transactions with multiple txins and/or txouts."""
@@ -1270,6 +1285,7 @@ class TestMultiInOut:
 
     @allure.link(helpers.get_vcs_link())
     @submit_utils.PARAM_SUBMIT_METHOD
+    @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_10_transactions(
         self,
@@ -1324,6 +1340,7 @@ class TestMultiInOut:
     @common.PARAM_USE_BUILD_CMD
     @submit_utils.PARAM_SUBMIT_METHOD
     @pytest.mark.parametrize("amount", (1_500_000, 2_000_000, 10_000_000))
+    @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_transaction_to_10_addrs_from_1_addr(
         self,
@@ -1354,6 +1371,7 @@ class TestMultiInOut:
     @common.PARAM_USE_BUILD_CMD
     @submit_utils.PARAM_SUBMIT_METHOD
     @pytest.mark.parametrize("amount", (1_500_000, 2_000_000, 10_000_000))
+    @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_transaction_to_1_addr_from_10_addrs(
         self,
@@ -1384,6 +1402,7 @@ class TestMultiInOut:
     @common.PARAM_USE_BUILD_CMD
     @submit_utils.PARAM_SUBMIT_METHOD
     @pytest.mark.parametrize("amount", (1_500_000, 2_000_000, 10_000_000))
+    @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_transaction_to_10_addrs_from_10_addrs(
         self,
@@ -1414,6 +1433,7 @@ class TestMultiInOut:
     @common.PARAM_USE_BUILD_CMD
     @submit_utils.PARAM_SUBMIT_METHOD
     @pytest.mark.parametrize("amount", (1_500_000, 2_000_000, 5_000_000))
+    @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_transaction_to_100_addrs_from_50_addrs(
         self,
@@ -1441,7 +1461,6 @@ class TestMultiInOut:
         )
 
 
-@pytest.mark.testnets
 @pytest.mark.smoke
 class TestIncrementalSigning:
     """Test incremental signing of transactions."""
@@ -1479,6 +1498,7 @@ class TestIncrementalSigning:
     @common.PARAM_USE_BUILD_CMD
     @submit_utils.PARAM_SUBMIT_METHOD
     @pytest.mark.parametrize("tx_is", ("witnessed", "signed"))
+    @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_incremental_signing(
         self,

--- a/cardano_node_tests/tests/test_tx_fees.py
+++ b/cardano_node_tests/tests/test_tx_fees.py
@@ -38,7 +38,6 @@ else:
     TO_10_FROM_10_PARAMS = [(1, 309_557), (100, 309_997), (11_000, 310_437), (100_000, 311_317)]
 
 
-@pytest.mark.testnets
 @pytest.mark.smoke
 class TestFee:
     """General fees tests."""
@@ -73,6 +72,7 @@ class TestFee:
     @allure.link(helpers.get_vcs_link())
     @hypothesis.given(fee=st.integers(max_value=-1))
     @common.hypothesis_settings()
+    @pytest.mark.testnets
     def test_negative_fee(
         self,
         cluster: clusterlib.ClusterLib,
@@ -103,6 +103,7 @@ class TestFee:
 
     @allure.link(helpers.get_vcs_link())
     @pytest.mark.parametrize("fee_change", (0, 1.1, 1.5, 2))
+    @pytest.mark.testnets
     def test_smaller_fee(
         self,
         cluster: clusterlib.ClusterLib,
@@ -145,6 +146,7 @@ class TestFee:
 
     @allure.link(helpers.get_vcs_link())
     @pytest.mark.parametrize("fee_add", (0, 1_000, 100_000, 1_000_000))
+    @pytest.mark.testnets
     def test_expected_or_higher_fee(
         self,
         cluster: clusterlib.ClusterLib,

--- a/cardano_node_tests/tests/test_tx_mempool.py
+++ b/cardano_node_tests/tests/test_tx_mempool.py
@@ -15,7 +15,6 @@ from cardano_node_tests.utils import helpers
 LOGGER = logging.getLogger(__name__)
 
 
-@pytest.mark.testnets
 class TestMempool:
     """Tests for transactions in mempool."""
 
@@ -43,6 +42,7 @@ class TestMempool:
         return addrs
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.testnets
     def test_query_mempool_txin(
         self,
         cluster_singleton: clusterlib.ClusterLib,

--- a/cardano_node_tests/tests/test_tx_metadata.py
+++ b/cardano_node_tests/tests/test_tx_metadata.py
@@ -20,7 +20,6 @@ LOGGER = logging.getLogger(__name__)
 DATA_DIR = pl.Path(__file__).parent / "data"
 
 
-@pytest.mark.testnets
 @pytest.mark.smoke
 class TestMetadata:
     """Tests for transactions with metadata."""
@@ -59,6 +58,7 @@ class TestMetadata:
         return addr
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.testnets
     def test_tx_wrong_json_metadata_format(
         self, cluster: clusterlib.ClusterLib, payment_addr: clusterlib.AddressRecord
     ):
@@ -85,6 +85,7 @@ class TestMetadata:
 
     @allure.link(helpers.get_vcs_link())
     @common.SKIPIF_BUILD_UNUSABLE
+    @pytest.mark.testnets
     def test_build_tx_wrong_json_metadata_format(
         self, cluster: clusterlib.ClusterLib, payment_addr: clusterlib.AddressRecord
     ):
@@ -112,6 +113,7 @@ class TestMetadata:
         assert "The JSON metadata top level must be a map" in str_err, str_err
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.testnets
     def test_tx_invalid_json_metadata(
         self, cluster: clusterlib.ClusterLib, payment_addr: clusterlib.AddressRecord
     ):
@@ -141,6 +143,7 @@ class TestMetadata:
 
     @allure.link(helpers.get_vcs_link())
     @common.SKIPIF_BUILD_UNUSABLE
+    @pytest.mark.testnets
     def test_build_tx_invalid_json_metadata(
         self, cluster: clusterlib.ClusterLib, payment_addr: clusterlib.AddressRecord
     ):
@@ -172,6 +175,7 @@ class TestMetadata:
         ), str_err
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.testnets
     def test_tx_too_long_metadata_json(
         self, cluster: clusterlib.ClusterLib, payment_addr: clusterlib.AddressRecord
     ):
@@ -197,6 +201,7 @@ class TestMetadata:
 
     @allure.link(helpers.get_vcs_link())
     @common.SKIPIF_BUILD_UNUSABLE
+    @pytest.mark.testnets
     def test_build_tx_too_long_metadata_json(
         self, cluster: clusterlib.ClusterLib, payment_addr: clusterlib.AddressRecord
     ):
@@ -225,6 +230,7 @@ class TestMetadata:
         ), str_err
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_tx_metadata_json(
         self, cluster: clusterlib.ClusterLib, payment_addr: clusterlib.AddressRecord
@@ -266,6 +272,7 @@ class TestMetadata:
 
     @allure.link(helpers.get_vcs_link())
     @common.SKIPIF_BUILD_UNUSABLE
+    @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_build_tx_metadata_json(
         self, cluster: clusterlib.ClusterLib, payment_addr: clusterlib.AddressRecord
@@ -316,6 +323,7 @@ class TestMetadata:
             ), "Metadata in db-sync doesn't match the original metadata"
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_tx_metadata_cbor(
         self, cluster: clusterlib.ClusterLib, payment_addr: clusterlib.AddressRecord
@@ -354,6 +362,7 @@ class TestMetadata:
 
     @allure.link(helpers.get_vcs_link())
     @common.SKIPIF_BUILD_UNUSABLE
+    @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_build_tx_metadata_cbor(
         self, cluster: clusterlib.ClusterLib, payment_addr: clusterlib.AddressRecord
@@ -403,6 +412,7 @@ class TestMetadata:
             ), "Metadata in db-sync doesn't match the original metadata"
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_tx_metadata_both(
         self, cluster: clusterlib.ClusterLib, payment_addr: clusterlib.AddressRecord
@@ -453,6 +463,7 @@ class TestMetadata:
 
     @allure.link(helpers.get_vcs_link())
     @common.SKIPIF_BUILD_UNUSABLE
+    @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_build_tx_metadata_both(
         self, cluster: clusterlib.ClusterLib, payment_addr: clusterlib.AddressRecord
@@ -513,6 +524,7 @@ class TestMetadata:
             ), "Metadata in db-sync doesn't match the original metadata"
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.testnets
     def test_tx_duplicate_metadata_keys(
         self, cluster: clusterlib.ClusterLib, payment_addr: clusterlib.AddressRecord
     ):
@@ -560,6 +572,7 @@ class TestMetadata:
             ), "Metadata in db-sync doesn't match the original metadata"
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_tx_metadata_no_txout(
         self,

--- a/cardano_node_tests/tests/test_tx_negative.py
+++ b/cardano_node_tests/tests/test_tx_negative.py
@@ -34,7 +34,6 @@ LOGGER = logging.getLogger(__name__)
 ADDR_ALPHABET = list(f"{string.ascii_lowercase}{string.digits}")
 
 
-@pytest.mark.testnets
 @pytest.mark.smoke
 class TestNegative:
     """Transaction tests that are expected to fail."""
@@ -305,6 +304,7 @@ class TestNegative:
 
     @allure.link(helpers.get_vcs_link())
     @common.PARAM_USE_BUILD_CMD
+    @pytest.mark.testnets
     def test_past_ttl(
         self,
         cluster: clusterlib.ClusterLib,
@@ -330,6 +330,7 @@ class TestNegative:
         reason="runs only with Allegra+ TX",
     )
     @common.PARAM_USE_BUILD_CMD
+    @pytest.mark.testnets
     def test_before_negative_overflow(
         self,
         cluster: clusterlib.ClusterLib,
@@ -380,6 +381,7 @@ class TestNegative:
         reason="runs only with Allegra+ TX",
     )
     @common.PARAM_USE_BUILD_CMD
+    @pytest.mark.testnets
     def test_before_positive_overflow(
         self,
         cluster: clusterlib.ClusterLib,
@@ -431,6 +433,7 @@ class TestNegative:
         reason="runs only with Allegra+ TX",
     )
     @common.PARAM_USE_BUILD_CMD
+    @pytest.mark.testnets
     def test_before_too_high(
         self,
         cluster: clusterlib.ClusterLib,
@@ -467,6 +470,7 @@ class TestNegative:
     @hypothesis.example(before_value=common.MAX_INT64)
     @common.hypothesis_settings(max_examples=200)
     @common.PARAM_USE_BUILD_CMD
+    @pytest.mark.testnets
     def test_pbt_before_negative_overflow(
         self,
         cluster: clusterlib.ClusterLib,
@@ -512,6 +516,7 @@ class TestNegative:
     @hypothesis.example(before_value=common.MAX_UINT64)
     @common.hypothesis_settings(max_examples=200)
     @common.PARAM_USE_BUILD_CMD
+    @pytest.mark.testnets
     def test_pbt_before_positive_overflow(
         self,
         cluster: clusterlib.ClusterLib,
@@ -558,6 +563,7 @@ class TestNegative:
     @hypothesis.example(before_value=common.MAX_UINT64)
     @common.hypothesis_settings(max_examples=200)
     @common.PARAM_USE_BUILD_CMD
+    @pytest.mark.testnets
     def test_pbt_before_too_high(
         self,
         cluster: clusterlib.ClusterLib,
@@ -583,6 +589,7 @@ class TestNegative:
         assert slot_no == before_value, f"SlotNo: {slot_no}, `before_value`: {before_value}"
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.testnets
     def test_duplicated_tx(
         self,
         cluster: clusterlib.ClusterLib,
@@ -639,6 +646,7 @@ class TestNegative:
         assert "ValueNotConservedUTxO" in str(excinfo.value)
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.testnets
     def test_wrong_network_magic(
         self,
         cluster: clusterlib.ClusterLib,
@@ -707,6 +715,7 @@ class TestNegative:
         assert "HandshakeError" in str(excinfo.value)
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.testnets
     def test_wrong_signing_key(
         self,
         cluster: clusterlib.ClusterLib,
@@ -733,6 +742,7 @@ class TestNegative:
         assert "MissingVKeyWitnessesUTXOW" in str(excinfo.value)
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.testnets
     def test_wrong_tx_era(
         self,
         cluster: clusterlib.ClusterLib,
@@ -764,6 +774,7 @@ class TestNegative:
 
     @allure.link(helpers.get_vcs_link())
     @common.PARAM_USE_BUILD_CMD
+    @pytest.mark.testnets
     def test_send_funds_to_reward_address(
         self,
         cluster: clusterlib.ClusterLib,
@@ -787,6 +798,7 @@ class TestNegative:
 
     @allure.link(helpers.get_vcs_link())
     @common.PARAM_USE_BUILD_CMD
+    @pytest.mark.testnets
     def test_send_funds_to_utxo_address(
         self,
         cluster: clusterlib.ClusterLib,
@@ -812,6 +824,7 @@ class TestNegative:
     @allure.link(helpers.get_vcs_link())
     @hypothesis.given(addr=st.text(alphabet=ADDR_ALPHABET, min_size=98, max_size=98))
     @common.hypothesis_settings(300)
+    @pytest.mark.testnets
     def test_send_funds_to_invalid_address(
         self,
         cluster: clusterlib.ClusterLib,
@@ -833,6 +846,7 @@ class TestNegative:
     @common.SKIPIF_BUILD_UNUSABLE
     @hypothesis.given(addr=st.text(alphabet=ADDR_ALPHABET, min_size=98, max_size=98))
     @common.hypothesis_settings(300)
+    @pytest.mark.testnets
     def test_build_send_funds_to_invalid_address(
         self,
         cluster: clusterlib.ClusterLib,
@@ -859,6 +873,7 @@ class TestNegative:
     @allure.link(helpers.get_vcs_link())
     @hypothesis.given(addr=st.text(alphabet=ADDR_ALPHABET, min_size=50, max_size=250))
     @common.hypothesis_settings(300)
+    @pytest.mark.testnets
     def test_send_funds_to_invalid_length_address(
         self,
         cluster: clusterlib.ClusterLib,
@@ -880,6 +895,7 @@ class TestNegative:
     @common.SKIPIF_BUILD_UNUSABLE
     @hypothesis.given(addr=st.text(alphabet=ADDR_ALPHABET, min_size=50, max_size=250))
     @common.hypothesis_settings(300)
+    @pytest.mark.testnets
     def test_build_send_funds_to_invalid_length_address(
         self,
         cluster: clusterlib.ClusterLib,
@@ -908,6 +924,7 @@ class TestNegative:
         addr=st.text(alphabet=st.characters(blacklist_categories=["C"]), min_size=98, max_size=98)
     )
     @common.hypothesis_settings(300)
+    @pytest.mark.testnets
     def test_send_funds_to_invalid_chars_address(
         self,
         cluster: clusterlib.ClusterLib,
@@ -931,6 +948,7 @@ class TestNegative:
         addr=st.text(alphabet=st.characters(blacklist_categories=["C"]), min_size=98, max_size=98)
     )
     @common.hypothesis_settings(300)
+    @pytest.mark.testnets
     def test_build_send_funds_to_invalid_chars_address(
         self,
         cluster: clusterlib.ClusterLib,
@@ -957,6 +975,7 @@ class TestNegative:
     @allure.link(helpers.get_vcs_link())
     @hypothesis.given(addr=st.text(alphabet=ADDR_ALPHABET, min_size=98, max_size=98))
     @common.hypothesis_settings(300)
+    @pytest.mark.testnets
     def test_send_funds_from_invalid_address(
         self,
         cluster: clusterlib.ClusterLib,
@@ -978,6 +997,7 @@ class TestNegative:
     @common.SKIPIF_BUILD_UNUSABLE
     @hypothesis.given(addr=st.text(alphabet=ADDR_ALPHABET, min_size=98, max_size=98))
     @common.hypothesis_settings(300)
+    @pytest.mark.testnets
     def test_build_send_funds_from_invalid_address(
         self,
         cluster: clusterlib.ClusterLib,
@@ -1004,6 +1024,7 @@ class TestNegative:
     @allure.link(helpers.get_vcs_link())
     @hypothesis.given(addr=st.text(alphabet=ADDR_ALPHABET, min_size=50, max_size=250))
     @common.hypothesis_settings(300)
+    @pytest.mark.testnets
     def test_send_funds_from_invalid_length_address(
         self,
         cluster: clusterlib.ClusterLib,
@@ -1025,6 +1046,7 @@ class TestNegative:
     @common.SKIPIF_BUILD_UNUSABLE
     @hypothesis.given(addr=st.text(alphabet=ADDR_ALPHABET, min_size=50, max_size=250))
     @common.hypothesis_settings(300)
+    @pytest.mark.testnets
     def test_build_send_funds_from_invalid_length_address(
         self,
         cluster: clusterlib.ClusterLib,
@@ -1053,6 +1075,7 @@ class TestNegative:
         addr=st.text(alphabet=st.characters(blacklist_categories=["C"]), min_size=98, max_size=98)
     )
     @common.hypothesis_settings(300)
+    @pytest.mark.testnets
     def test_send_funds_from_invalid_chars_address(
         self,
         cluster: clusterlib.ClusterLib,
@@ -1076,6 +1099,7 @@ class TestNegative:
         addr=st.text(alphabet=st.characters(blacklist_categories=["C"]), min_size=98, max_size=98)
     )
     @common.hypothesis_settings(300)
+    @pytest.mark.testnets
     def test_build_send_funds_from_invalid_chars_address(
         self,
         cluster: clusterlib.ClusterLib,
@@ -1103,6 +1127,7 @@ class TestNegative:
     @common.SKIPIF_BUILD_UNUSABLE
     @hypothesis.given(addr=st.text(alphabet=ADDR_ALPHABET, min_size=98, max_size=98))
     @common.hypothesis_settings(300)
+    @pytest.mark.testnets
     def test_build_send_funds_invalid_change_address(
         self,
         cluster: clusterlib.ClusterLib,
@@ -1128,6 +1153,7 @@ class TestNegative:
         addr=st.text(alphabet=st.characters(blacklist_categories=["C"]), min_size=98, max_size=98)
     )
     @common.hypothesis_settings(300)
+    @pytest.mark.testnets
     def test_build_send_funds_invalid_chars_change_address(
         self,
         cluster: clusterlib.ClusterLib,
@@ -1151,6 +1177,7 @@ class TestNegative:
     @common.SKIPIF_BUILD_UNUSABLE
     @hypothesis.given(addr=st.text(alphabet=ADDR_ALPHABET, min_size=50, max_size=250))
     @common.hypothesis_settings(300)
+    @pytest.mark.testnets
     def test_build_send_funds_invalid_length_change_address(
         self,
         cluster: clusterlib.ClusterLib,
@@ -1172,6 +1199,7 @@ class TestNegative:
 
     @allure.link(helpers.get_vcs_link())
     @common.PARAM_USE_BUILD_CMD
+    @pytest.mark.testnets
     def test_nonexistent_utxo_ix(
         self,
         cluster: clusterlib.ClusterLib,
@@ -1204,6 +1232,7 @@ class TestNegative:
 
     @allure.link(helpers.get_vcs_link())
     @common.PARAM_USE_BUILD_CMD
+    @pytest.mark.testnets
     def test_nonexistent_utxo_hash(
         self,
         cluster: clusterlib.ClusterLib,
@@ -1238,6 +1267,7 @@ class TestNegative:
     @allure.link(helpers.get_vcs_link())
     @hypothesis.given(utxo_hash=st.text(alphabet=ADDR_ALPHABET, min_size=10, max_size=550))
     @common.hypothesis_settings(300)
+    @pytest.mark.testnets
     def test_invalid_length_utxo_hash(
         self,
         cluster: clusterlib.ClusterLib,
@@ -1265,6 +1295,7 @@ class TestNegative:
     @common.SKIPIF_BUILD_UNUSABLE
     @hypothesis.given(utxo_hash=st.text(alphabet=ADDR_ALPHABET, min_size=10, max_size=550))
     @common.hypothesis_settings(300)
+    @pytest.mark.testnets
     def test_build_invalid_length_utxo_hash(
         self,
         cluster: clusterlib.ClusterLib,
@@ -1295,6 +1326,7 @@ class TestNegative:
         )
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.testnets
     def test_missing_fee(
         self,
         cluster: clusterlib.ClusterLib,
@@ -1352,6 +1384,7 @@ class TestNegative:
         VERSIONS.transaction_era != VERSIONS.SHELLEY or VERSIONS.node >= version.parse("8.7.0"),
         reason="runs only with Shelley TX on node < 8.7.0",
     )
+    @pytest.mark.testnets
     def test_missing_ttl(
         self,
         cluster: clusterlib.ClusterLib,
@@ -1397,6 +1430,7 @@ class TestNegative:
         ), err_str
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.testnets
     def test_missing_tx_in(
         self,
         cluster: clusterlib.ClusterLib,
@@ -1439,6 +1473,7 @@ class TestNegative:
         VERSIONS.transaction_era != VERSIONS.SHELLEY,
         reason="runs only with Shelley TX",
     )
+    @pytest.mark.testnets
     def test_lower_bound_not_supported(
         self,
         cluster: clusterlib.ClusterLib,
@@ -1475,6 +1510,7 @@ class TestNegative:
 
     @allure.link(helpers.get_vcs_link())
     @common.SKIPIF_BUILD_UNUSABLE
+    @pytest.mark.testnets
     def test_build_missing_tx_in(
         self,
         cluster: clusterlib.ClusterLib,
@@ -1517,6 +1553,7 @@ class TestNegative:
 
     @allure.link(helpers.get_vcs_link())
     @common.SKIPIF_BUILD_UNUSABLE
+    @pytest.mark.testnets
     def test_build_missing_change_address(
         self,
         cluster: clusterlib.ClusterLib,
@@ -1558,6 +1595,7 @@ class TestNegative:
 
     @allure.link(helpers.get_vcs_link())
     @common.SKIPIF_BUILD_UNUSABLE
+    @pytest.mark.testnets
     def test_build_multiple_change_addresses(
         self,
         cluster: clusterlib.ClusterLib,

--- a/cardano_node_tests/tests/test_tx_unbalanced.py
+++ b/cardano_node_tests/tests/test_tx_unbalanced.py
@@ -22,7 +22,6 @@ LOGGER = logging.getLogger(__name__)
 MAX_LOVELACE_AMOUNT = common.MAX_UINT64
 
 
-@pytest.mark.testnets
 @pytest.mark.smoke
 class TestUnbalanced:
     """Tests for unbalanced transactions."""
@@ -106,6 +105,7 @@ class TestUnbalanced:
         return cluster.g_query.get_utxo_with_highest_amount(payment_addrs[0].address)
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.testnets
     def test_negative_change(
         self,
         cluster: clusterlib.ClusterLib,
@@ -168,6 +168,7 @@ class TestUnbalanced:
     @hypothesis.given(transfer_add=st.integers(min_value=1, max_value=MAX_LOVELACE_AMOUNT // 2))
     @hypothesis.example(transfer_add=1)
     @common.hypothesis_settings(100)
+    @pytest.mark.testnets
     def test_build_transfer_unavailable_funds(
         self,
         cluster: clusterlib.ClusterLib,
@@ -211,6 +212,7 @@ class TestUnbalanced:
     @hypothesis.example(change_amount=2_000_000)
     @hypothesis.example(change_amount=MAX_LOVELACE_AMOUNT)
     @common.hypothesis_settings(300)
+    @pytest.mark.testnets
     def test_wrong_balance(
         self,
         cluster: clusterlib.ClusterLib,
@@ -270,6 +272,7 @@ class TestUnbalanced:
     @hypothesis.example(change_amount=2_000_000)
     @hypothesis.example(change_amount=MAX_LOVELACE_AMOUNT + 1)
     @common.hypothesis_settings(300)
+    @pytest.mark.testnets
     def test_out_of_bounds_amount(
         self,
         cluster: clusterlib.ClusterLib,
@@ -313,6 +316,7 @@ class TestUnbalanced:
     @hypothesis.example(amount=0)
     @hypothesis.example(amount=tx_common.MIN_UTXO_VALUE[1] - 1_000)
     @common.hypothesis_settings(max_examples=200)
+    @pytest.mark.testnets
     def test_build_transfer_amount_bellow_minimum(
         self,
         cluster: clusterlib.ClusterLib,
@@ -342,6 +346,7 @@ class TestUnbalanced:
     @hypothesis.example(amount=-MAX_LOVELACE_AMOUNT)
     @hypothesis.example(amount=-1)
     @common.hypothesis_settings(max_examples=300)
+    @pytest.mark.testnets
     def test_build_transfer_negative_amount(
         self,
         cluster: clusterlib.ClusterLib,
@@ -373,6 +378,7 @@ class TestUnbalanced:
     @hypothesis.example(amount=0)
     @hypothesis.example(amount=tx_common.MIN_UTXO_VALUE[1] - 1_000)
     @common.hypothesis_settings(max_examples=400)
+    @pytest.mark.testnets
     def test_transfer_amount_bellow_minimum(
         self,
         cluster: clusterlib.ClusterLib,
@@ -434,6 +440,7 @@ class TestUnbalanced:
     @hypothesis.example(amount=-1)
     @hypothesis.example(amount=-MAX_LOVELACE_AMOUNT)
     @common.hypothesis_settings(max_examples=500)
+    @pytest.mark.testnets
     def test_transfer_negative_amount(
         self,
         cluster: clusterlib.ClusterLib,

--- a/cardano_node_tests/tests/tests_plutus/test_mint_build.py
+++ b/cardano_node_tests/tests/tests_plutus/test_mint_build.py
@@ -100,10 +100,10 @@ class TestBuildMinting:
         return retval
 
     @allure.link(helpers.get_vcs_link())
-    @pytest.mark.dbsync
-    @pytest.mark.testnets
     @submit_utils.PARAM_SUBMIT_METHOD
     @common.PARAM_PLUTUS3_VERSION
+    @pytest.mark.testnets
+    @pytest.mark.dbsync
     def test_minting_one_token(
         self,
         cluster: clusterlib.ClusterLib,
@@ -241,9 +241,9 @@ class TestBuildMinting:
         dbsync_utils.check_tx(cluster_obj=cluster, tx_raw_output=tx_output_step2)
 
     @allure.link(helpers.get_vcs_link())
-    @pytest.mark.testnets
     @submit_utils.PARAM_SUBMIT_METHOD
     @common.PARAM_PLUTUS3_VERSION
+    @pytest.mark.testnets
     def test_minting_missing_txout(
         self,
         cluster: clusterlib.ClusterLib,
@@ -359,8 +359,8 @@ class TestBuildMinting:
         ids=("plutus_v1", "plutus_v3"),
     )
     @submit_utils.PARAM_SUBMIT_METHOD
-    @pytest.mark.dbsync
     @pytest.mark.testnets
+    @pytest.mark.dbsync
     def test_time_range_minting(
         self,
         cluster: clusterlib.ClusterLib,
@@ -510,8 +510,6 @@ class TestBuildMinting:
         dbsync_utils.check_tx(cluster_obj=cluster, tx_raw_output=tx_output_step2)
 
     @allure.link(helpers.get_vcs_link())
-    @pytest.mark.dbsync
-    @pytest.mark.testnets
     @submit_utils.PARAM_SUBMIT_METHOD
     @pytest.mark.parametrize(
         "plutus_version",
@@ -521,6 +519,8 @@ class TestBuildMinting:
             pytest.param("mix_v3_v1", marks=common.SKIPIF_PLUTUSV3_UNUSABLE),
         ),
     )
+    @pytest.mark.testnets
+    @pytest.mark.dbsync
     def test_two_scripts_minting(
         self,
         cluster: clusterlib.ClusterLib,
@@ -783,9 +783,9 @@ class TestBuildMinting:
         reason="cannot find `create-script-context` on the PATH",
     )
     @common.SKIPIF_MISMATCHED_ERAS
-    @pytest.mark.dbsync
-    @pytest.mark.testnets
     @submit_utils.PARAM_SUBMIT_METHOD
+    @pytest.mark.testnets
+    @pytest.mark.dbsync
     def test_minting_context_equivalence(
         self,
         cluster: clusterlib.ClusterLib,
@@ -968,8 +968,6 @@ class TestBuildMinting:
             )
 
     @allure.link(helpers.get_vcs_link())
-    @pytest.mark.dbsync
-    @pytest.mark.testnets
     @submit_utils.PARAM_SUBMIT_METHOD
     @pytest.mark.parametrize(
         "key",
@@ -986,6 +984,8 @@ class TestBuildMinting:
         ),
         ids=("plutus_v1", "plutus_v3"),
     )
+    @pytest.mark.testnets
+    @pytest.mark.dbsync
     def test_witness_redeemer(
         self,
         cluster: clusterlib.ClusterLib,
@@ -1256,13 +1256,13 @@ class TestBuildMinting:
             ), f"TTL too far in the future (offset {ttl_offset} slots) was accepted"
 
 
-@pytest.mark.testnets
 class TestCollateralOutput:
     """Tests for collateral output."""
 
     @allure.link(helpers.get_vcs_link())
     @submit_utils.PARAM_SUBMIT_METHOD
     @common.PARAM_PLUTUS3_VERSION
+    @pytest.mark.testnets
     def test_duplicated_collateral(
         self,
         cluster: clusterlib.ClusterLib,

--- a/cardano_node_tests/tests/tests_plutus/test_mint_raw.py
+++ b/cardano_node_tests/tests/tests_plutus/test_mint_raw.py
@@ -1342,12 +1342,12 @@ class TestMinting:
             ), f"TTL too far in the future (offset {ttl_offset} slots) was accepted"
 
 
-@pytest.mark.testnets
 class TestCollateralOutput:
     """Tests for collateral output."""
 
     @allure.link(helpers.get_vcs_link())
     @common.PARAM_PLUTUS3_VERSION
+    @pytest.mark.testnets
     def test_duplicated_collateral(
         self,
         cluster: clusterlib.ClusterLib,

--- a/cardano_node_tests/tests/tests_plutus/test_spend_build.py
+++ b/cardano_node_tests/tests/tests_plutus/test_spend_build.py
@@ -77,13 +77,13 @@ def pool_users(
     return created_users
 
 
-@pytest.mark.testnets
 class TestBuildLocking:
     """Tests for Tx output locking using Plutus smart contracts and `transaction build`."""
 
     @allure.link(helpers.get_vcs_link())
-    @pytest.mark.dbsync
     @common.PARAM_PLUTUS3_VERSION
+    @pytest.mark.testnets
+    @pytest.mark.dbsync
     def test_txout_locking(
         self,
         cluster: clusterlib.ClusterLib,
@@ -150,6 +150,7 @@ class TestBuildLocking:
         reason="cannot find `create-script-context` on the PATH",
     )
     @common.SKIPIF_MISMATCHED_ERAS
+    @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_context_equivalence(
         self,
@@ -258,13 +259,14 @@ class TestBuildLocking:
             assert helpers.is_in_interval(tx_output.fee, expected_fee, frac=0.15)
 
     @allure.link(helpers.get_vcs_link())
-    @pytest.mark.dbsync
     @pytest.mark.parametrize("embed_datum", (True, False), ids=("embedded_datum", "datum"))
     @pytest.mark.parametrize(
         "variant",
         ("typed_json", "typed_cbor", "untyped_value", "untyped_json", "untyped_cbor"),
     )
     @common.PARAM_PLUTUS_VERSION
+    @pytest.mark.testnets
+    @pytest.mark.dbsync
     def test_guessing_game(
         self,
         cluster: clusterlib.ClusterLib,
@@ -366,7 +368,6 @@ class TestBuildLocking:
         )
 
     @allure.link(helpers.get_vcs_link())
-    @pytest.mark.dbsync
     @pytest.mark.parametrize(
         "plutus_version",
         (
@@ -376,6 +377,8 @@ class TestBuildLocking:
             pytest.param("plutus_v2", marks=common.SKIPIF_PLUTUSV2_UNUSABLE),
         ),
     )
+    @pytest.mark.testnets
+    @pytest.mark.dbsync
     def test_two_scripts_spending(
         self,
         cluster: clusterlib.ClusterLib,
@@ -635,6 +638,7 @@ class TestBuildLocking:
 
     @allure.link(helpers.get_vcs_link())
     @common.PARAM_PLUTUS3_VERSION
+    @pytest.mark.testnets
     def test_always_fails(
         self,
         cluster: clusterlib.ClusterLib,
@@ -691,6 +695,7 @@ class TestBuildLocking:
 
     @allure.link(helpers.get_vcs_link())
     @common.PARAM_PLUTUS3_VERSION
+    @pytest.mark.testnets
     def test_script_invalid(
         self,
         cluster: clusterlib.ClusterLib,
@@ -766,8 +771,9 @@ class TestBuildLocking:
             assert helpers.is_in_interval(tx_output.fee, expected_fee, frac=0.15)
 
     @allure.link(helpers.get_vcs_link())
-    @pytest.mark.dbsync
     @common.PARAM_PLUTUS3_VERSION
+    @pytest.mark.testnets
+    @pytest.mark.dbsync
     def test_txout_token_locking(
         self,
         cluster: clusterlib.ClusterLib,
@@ -843,8 +849,9 @@ class TestBuildLocking:
         )
 
     @allure.link(helpers.get_vcs_link())
-    @pytest.mark.dbsync
     @common.PARAM_PLUTUS3_VERSION
+    @pytest.mark.testnets
+    @pytest.mark.dbsync
     def test_partial_spending(
         self,
         cluster: clusterlib.ClusterLib,
@@ -966,8 +973,9 @@ class TestBuildLocking:
         )
 
     @allure.link(helpers.get_vcs_link())
-    @pytest.mark.dbsync
     @common.PARAM_PLUTUS3_VERSION
+    @pytest.mark.testnets
+    @pytest.mark.dbsync
     def test_collateral_is_txin(
         self,
         cluster: clusterlib.ClusterLib,

--- a/cardano_node_tests/tests/tests_plutus/test_spend_compat_build.py
+++ b/cardano_node_tests/tests/tests_plutus/test_spend_compat_build.py
@@ -47,7 +47,6 @@ def payment_addrs(
     return addrs
 
 
-@pytest.mark.testnets
 class TestCompatibility:
     """Tests for checking compatibility with previous Tx eras."""
 
@@ -56,6 +55,7 @@ class TestCompatibility:
         VERSIONS.transaction_era > VERSIONS.ALONZO,
         reason="doesn't run with Tx era > Alonzo",
     )
+    @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_plutusv2_old_tx_era(
         self,

--- a/cardano_node_tests/tests/tests_plutus/test_spend_compat_raw.py
+++ b/cardano_node_tests/tests/tests_plutus/test_spend_compat_raw.py
@@ -46,7 +46,6 @@ def payment_addrs(
     return addrs
 
 
-@pytest.mark.testnets
 class TestCompatibility:
     """Tests for checking compatibility with previous Tx eras."""
 
@@ -55,6 +54,7 @@ class TestCompatibility:
         VERSIONS.transaction_era > VERSIONS.ALONZO,
         reason="doesn't run with Tx era > Alonzo",
     )
+    @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_plutusv2_old_tx_era(
         self,
@@ -107,6 +107,7 @@ class TestCompatibility:
         VERSIONS.transaction_era >= VERSIONS.ALONZO,
         reason="runs only with Tx era < Alonzo",
     )
+    @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_plutusv1_old_tx_era(
         self,

--- a/cardano_node_tests/tests/tests_plutus/test_spend_datum_build.py
+++ b/cardano_node_tests/tests/tests_plutus/test_spend_datum_build.py
@@ -54,11 +54,11 @@ def payment_addrs(
     return addrs
 
 
-@pytest.mark.testnets
 class TestDatum:
     """Tests for datum."""
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_datum_on_key_credential_address(
         self,
@@ -107,6 +107,7 @@ class TestDatum:
 
     @allure.link(helpers.get_vcs_link())
     @common.PARAM_PLUTUS_VERSION
+    @pytest.mark.testnets
     def test_embed_datum_without_pparams(
         self,
         cluster: clusterlib.ClusterLib,
@@ -165,7 +166,6 @@ class TestDatum:
             issues.node_4058.finish_test()
 
 
-@pytest.mark.testnets
 class TestNegativeDatum:
     """Tests for Tx output locking using Plutus smart contracts with wrong datum."""
 
@@ -193,6 +193,7 @@ class TestNegativeDatum:
     @allure.link(helpers.get_vcs_link())
     @pytest.mark.parametrize("address_type", ("script_address", "key_address"))
     @common.PARAM_PLUTUS_VERSION
+    @pytest.mark.testnets
     def test_no_datum_txout(
         self,
         cluster: clusterlib.ClusterLib,
@@ -292,6 +293,7 @@ class TestNegativeDatum:
     @hypothesis.given(datum_value=st.text())
     @common.hypothesis_settings(max_examples=200)
     @common.PARAM_PLUTUS_VERSION
+    @pytest.mark.testnets
     def test_lock_tx_invalid_datum(
         self,
         cluster: clusterlib.ClusterLib,
@@ -330,6 +332,7 @@ class TestNegativeDatum:
 
     @allure.link(helpers.get_vcs_link())
     @common.PARAM_PLUTUS_VERSION
+    @pytest.mark.testnets
     def test_unlock_tx_wrong_datum(
         self,
         cluster: clusterlib.ClusterLib,
@@ -389,6 +392,7 @@ class TestNegativeDatum:
 
     @allure.link(helpers.get_vcs_link())
     @common.PARAM_PLUTUS_VERSION
+    @pytest.mark.testnets
     def test_unlock_non_script_utxo(
         self,
         cluster: clusterlib.ClusterLib,
@@ -480,6 +484,7 @@ class TestNegativeDatum:
     @hypothesis.given(datum_value=st.binary(min_size=65))
     @common.hypothesis_settings(max_examples=100)
     @common.PARAM_PLUTUS_VERSION
+    @pytest.mark.testnets
     def test_too_big(
         self,
         cluster: clusterlib.ClusterLib,

--- a/cardano_node_tests/tests/tests_plutus/test_spend_datum_raw.py
+++ b/cardano_node_tests/tests/tests_plutus/test_spend_datum_raw.py
@@ -51,11 +51,11 @@ def payment_addrs(
     return addrs
 
 
-@pytest.mark.testnets
 class TestDatum:
     """Tests for datum."""
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_datum_on_key_credential_address(
         self,
@@ -94,7 +94,6 @@ class TestDatum:
         dbsync_utils.check_tx(cluster_obj=cluster, tx_raw_output=tx_raw_output)
 
 
-@pytest.mark.testnets
 class TestNegativeDatum:
     """Tests for Tx output locking using Plutus smart contracts with wrong datum."""
 
@@ -134,6 +133,7 @@ class TestNegativeDatum:
     @allure.link(helpers.get_vcs_link())
     @pytest.mark.parametrize("address_type", ("script_address", "key_address"))
     @common.PARAM_PLUTUS_VERSION
+    @pytest.mark.testnets
     def test_no_datum_txout(
         self,
         cluster: clusterlib.ClusterLib,
@@ -216,6 +216,7 @@ class TestNegativeDatum:
     @hypothesis.given(datum_value=st.text())
     @common.hypothesis_settings(max_examples=200)
     @common.PARAM_PLUTUS_VERSION
+    @pytest.mark.testnets
     def test_lock_tx_invalid_datum(
         self,
         cluster: clusterlib.ClusterLib,

--- a/cardano_node_tests/tests/tests_plutus/test_spend_negative_build.py
+++ b/cardano_node_tests/tests/tests_plutus/test_spend_negative_build.py
@@ -52,13 +52,13 @@ def payment_addrs(
     return addrs
 
 
-@pytest.mark.testnets
 class TestNegative:
     """Tests for Tx output locking using Plutus smart contracts that are expected to fail."""
 
     @allure.link(helpers.get_vcs_link())
-    @pytest.mark.dbsync
     @common.PARAM_PLUTUS_VERSION
+    @pytest.mark.testnets
+    @pytest.mark.dbsync
     def test_wrong_script(
         self,
         cluster: clusterlib.ClusterLib,
@@ -111,8 +111,9 @@ class TestNegative:
         assert "points to a Plutus script that does not exist" in err_str, err_str
 
     @allure.link(helpers.get_vcs_link())
-    @pytest.mark.dbsync
     @common.PARAM_PLUTUS_VERSION
+    @pytest.mark.testnets
+    @pytest.mark.dbsync
     def test_no_script(
         self,
         cluster: clusterlib.ClusterLib,
@@ -163,8 +164,9 @@ class TestNegative:
         assert "(MissingScriptWitnessesUTXOW" in err_str, err_str
 
     @allure.link(helpers.get_vcs_link())
-    @pytest.mark.dbsync
     @common.PARAM_PLUTUS3_VERSION
+    @pytest.mark.testnets
+    @pytest.mark.dbsync
     def test_collateral_w_tokens(
         self,
         cluster: clusterlib.ClusterLib,
@@ -232,8 +234,9 @@ class TestNegative:
         assert helpers.is_in_interval(tx_output_fund.fee, expected_fee_fund, frac=0.15)
 
     @allure.link(helpers.get_vcs_link())
-    @pytest.mark.dbsync
     @common.PARAM_PLUTUS3_VERSION
+    @pytest.mark.testnets
+    @pytest.mark.dbsync
     def test_same_collateral_txin(
         self,
         cluster: clusterlib.ClusterLib,
@@ -296,7 +299,6 @@ class TestNegative:
         assert helpers.is_in_interval(tx_output_fund.fee, expected_fee_fund, frac=0.15)
 
     @allure.link(helpers.get_vcs_link())
-    @pytest.mark.dbsync
     @pytest.mark.parametrize(
         "variant",
         (
@@ -306,6 +308,8 @@ class TestNegative:
         ),
     )
     @common.PARAM_PLUTUS_VERSION
+    @pytest.mark.testnets
+    @pytest.mark.dbsync
     def test_invalid_guessing_game(
         self,
         cluster: clusterlib.ClusterLib,
@@ -374,6 +378,7 @@ class TestNegative:
 
     @allure.link(helpers.get_vcs_link())
     @common.PARAM_PLUTUS3_VERSION
+    @pytest.mark.testnets
     def test_two_scripts_spending_one_fail(
         self,
         cluster: clusterlib.ClusterLib,
@@ -525,7 +530,6 @@ class TestNegative:
         assert "The Plutus script evaluation failed" in err_str, err_str
 
 
-@pytest.mark.testnets
 class TestNegativeRedeemer:
     """Tests for Tx output locking using Plutus smart contracts with wrong redeemer."""
 
@@ -645,6 +649,7 @@ class TestNegativeRedeemer:
     @hypothesis.example(redeemer_value=common.MAX_UINT64)
     @common.hypothesis_settings(max_examples=200)
     @common.PARAM_PLUTUS_VERSION
+    @pytest.mark.testnets
     def test_wrong_value_inside_range(
         self,
         cluster: clusterlib.ClusterLib,
@@ -710,6 +715,7 @@ class TestNegativeRedeemer:
     @hypothesis.example(redeemer_value=common.MAX_UINT64 + 1)
     @common.hypothesis_settings(max_examples=200)
     @common.PARAM_PLUTUS_VERSION
+    @pytest.mark.testnets
     def test_wrong_value_above_range(
         self,
         cluster: clusterlib.ClusterLib,
@@ -750,6 +756,7 @@ class TestNegativeRedeemer:
     @hypothesis.example(redeemer_value=MIN_INT_VAL - 1)
     @common.hypothesis_settings(max_examples=200)
     @common.PARAM_PLUTUS_VERSION
+    @pytest.mark.testnets
     def test_wrong_value_bellow_range(
         self,
         cluster: clusterlib.ClusterLib,
@@ -789,6 +796,7 @@ class TestNegativeRedeemer:
     @hypothesis.given(redeemer_value=st.binary(max_size=64))
     @common.hypothesis_settings(max_examples=200)
     @common.PARAM_PLUTUS_VERSION
+    @pytest.mark.testnets
     def test_wrong_type(
         self,
         cluster: clusterlib.ClusterLib,
@@ -845,6 +853,7 @@ class TestNegativeRedeemer:
     @hypothesis.given(redeemer_value=st.binary(min_size=65))
     @common.hypothesis_settings(max_examples=100)
     @common.PARAM_PLUTUS_VERSION
+    @pytest.mark.testnets
     def test_too_big(
         self,
         cluster: clusterlib.ClusterLib,
@@ -904,6 +913,7 @@ class TestNegativeRedeemer:
     @hypothesis.given(redeemer_value=st.binary(max_size=64))
     @common.hypothesis_settings(max_examples=200)
     @common.PARAM_PLUTUS_VERSION
+    @pytest.mark.testnets
     def test_json_schema_typed_int_bytes_declared(
         self,
         cluster: clusterlib.ClusterLib,
@@ -963,6 +973,7 @@ class TestNegativeRedeemer:
     @hypothesis.given(redeemer_value=st.binary(max_size=64))
     @common.hypothesis_settings(max_examples=200)
     @common.PARAM_PLUTUS_VERSION
+    @pytest.mark.testnets
     def test_json_schema_untyped_int_bytes_declared(
         self,
         cluster: clusterlib.ClusterLib,
@@ -1022,6 +1033,7 @@ class TestNegativeRedeemer:
     @hypothesis.given(redeemer_value=st.integers())
     @common.hypothesis_settings(max_examples=200)
     @common.PARAM_PLUTUS_VERSION
+    @pytest.mark.testnets
     def test_json_schema_typed_bytes_int_declared(
         self,
         cluster: clusterlib.ClusterLib,
@@ -1082,6 +1094,7 @@ class TestNegativeRedeemer:
     @hypothesis.given(redeemer_value=st.integers())
     @common.hypothesis_settings(max_examples=200)
     @common.PARAM_PLUTUS_VERSION
+    @pytest.mark.testnets
     def test_json_schema_untyped_bytes_int_declared(
         self,
         cluster: clusterlib.ClusterLib,
@@ -1142,6 +1155,7 @@ class TestNegativeRedeemer:
     @hypothesis.given(redeemer_value=st.text())
     @common.hypothesis_settings(max_examples=200)
     @common.PARAM_PLUTUS_VERSION
+    @pytest.mark.testnets
     def test_invalid_json(
         self,
         cluster: clusterlib.ClusterLib,
@@ -1198,6 +1212,7 @@ class TestNegativeRedeemer:
     @hypothesis.given(redeemer_type=st.text())
     @common.hypothesis_settings(max_examples=200)
     @common.PARAM_PLUTUS_VERSION
+    @pytest.mark.testnets
     def test_json_schema_typed_invalid_type(
         self,
         cluster: clusterlib.ClusterLib,
@@ -1259,6 +1274,7 @@ class TestNegativeRedeemer:
     @hypothesis.given(redeemer_type=st.text())
     @common.hypothesis_settings(max_examples=200)
     @common.PARAM_PLUTUS_VERSION
+    @pytest.mark.testnets
     def test_json_schema_untyped_invalid_type(
         self,
         cluster: clusterlib.ClusterLib,

--- a/cardano_node_tests/tests/tests_plutus/test_spend_negative_raw.py
+++ b/cardano_node_tests/tests/tests_plutus/test_spend_negative_raw.py
@@ -58,7 +58,6 @@ def payment_addrs(
     return addrs
 
 
-@pytest.mark.testnets
 class TestNegative:
     """Tests for Tx output locking using Plutus smart contracts that are expected to fail."""
 
@@ -107,6 +106,7 @@ class TestNegative:
         ),
     )
     @common.PARAM_PLUTUS_VERSION
+    @pytest.mark.testnets
     def test_invalid_guessing_game(
         self,
         cluster: clusterlib.ClusterLib,
@@ -173,6 +173,7 @@ class TestNegative:
     @allure.link(helpers.get_vcs_link())
     @pytest.mark.dbsync
     @common.PARAM_PLUTUS_VERSION
+    @pytest.mark.testnets
     def test_wrong_script(
         self,
         cluster: clusterlib.ClusterLib,
@@ -229,6 +230,7 @@ class TestNegative:
     @allure.link(helpers.get_vcs_link())
     @pytest.mark.dbsync
     @common.PARAM_PLUTUS_VERSION
+    @pytest.mark.testnets
     def test_no_script(
         self,
         cluster: clusterlib.ClusterLib,
@@ -278,8 +280,9 @@ class TestNegative:
         assert "(MissingScriptWitnessesUTXOW" in err_str, err_str
 
     @allure.link(helpers.get_vcs_link())
-    @pytest.mark.dbsync
     @common.PARAM_PLUTUS3_VERSION
+    @pytest.mark.testnets
+    @pytest.mark.dbsync
     def test_collateral_w_tokens(
         self,
         cluster: clusterlib.ClusterLib,
@@ -343,8 +346,9 @@ class TestNegative:
         assert "CollateralContainsNonADA" in err_str, err_str
 
     @allure.link(helpers.get_vcs_link())
-    @pytest.mark.dbsync
     @common.PARAM_PLUTUS3_VERSION
+    @pytest.mark.testnets
+    @pytest.mark.dbsync
     def test_same_collateral_txin(
         self,
         cluster: clusterlib.ClusterLib,
@@ -395,8 +399,9 @@ class TestNegative:
         assert "ScriptsNotPaidUTxO" in err_str, err_str
 
     @allure.link(helpers.get_vcs_link())
-    @pytest.mark.dbsync
     @common.PARAM_PLUTUS3_VERSION
+    @pytest.mark.testnets
+    @pytest.mark.dbsync
     def test_collateral_percent(
         self,
         cluster: clusterlib.ClusterLib,
@@ -453,6 +458,7 @@ class TestNegative:
 
     @allure.link(helpers.get_vcs_link())
     @common.PARAM_PLUTUS3_VERSION
+    @pytest.mark.testnets
     def test_two_scripts_spending_one_fail(
         self,
         cluster: clusterlib.ClusterLib,
@@ -623,6 +629,7 @@ class TestNegative:
         ids=("plutus_v1", "plutus_v2"),
         indirect=True,
     )
+    @pytest.mark.testnets
     def test_execution_units_above_limit(
         self,
         cluster: clusterlib.ClusterLib,
@@ -683,7 +690,6 @@ class TestNegative:
         assert "ExUnitsTooBigUTxO" in err_str, err_str
 
 
-@pytest.mark.testnets
 class TestNegativeRedeemer:
     """Tests for Tx output locking using Plutus smart contracts with wrong redeemer."""
 
@@ -901,6 +907,7 @@ class TestNegativeRedeemer:
     @hypothesis.example(redeemer_value=common.MAX_UINT64)
     @common.hypothesis_settings(max_examples=200)
     @common.PARAM_PLUTUS_VERSION
+    @pytest.mark.testnets
     def test_wrong_value_inside_range(
         self,
         cluster: clusterlib.ClusterLib,
@@ -986,6 +993,7 @@ class TestNegativeRedeemer:
     @hypothesis.example(redeemer_value=MIN_INT_VAL - 1)
     @common.hypothesis_settings(max_examples=200)
     @common.PARAM_PLUTUS_VERSION
+    @pytest.mark.testnets
     def test_wrong_value_bellow_range(
         self,
         cluster: clusterlib.ClusterLib,
@@ -1029,6 +1037,7 @@ class TestNegativeRedeemer:
     @hypothesis.example(redeemer_value=common.MAX_UINT64 + 1)
     @common.hypothesis_settings(max_examples=200)
     @common.PARAM_PLUTUS_VERSION
+    @pytest.mark.testnets
     def test_wrong_value_above_range(
         self,
         cluster: clusterlib.ClusterLib,
@@ -1071,6 +1080,7 @@ class TestNegativeRedeemer:
     @hypothesis.given(redeemer_value=st.binary(max_size=64))
     @common.hypothesis_settings(max_examples=200)
     @common.PARAM_PLUTUS_VERSION
+    @pytest.mark.testnets
     def test_wrong_type(
         self,
         cluster: clusterlib.ClusterLib,
@@ -1148,6 +1158,7 @@ class TestNegativeRedeemer:
     @hypothesis.given(redeemer_value=st.binary(min_size=65))
     @common.hypothesis_settings(max_examples=200)
     @common.PARAM_PLUTUS_VERSION
+    @pytest.mark.testnets
     def test_too_big(
         self,
         cluster: clusterlib.ClusterLib,
@@ -1224,6 +1235,7 @@ class TestNegativeRedeemer:
     @hypothesis.given(redeemer_value=st.binary(max_size=64))
     @common.hypothesis_settings(max_examples=200)
     @common.PARAM_PLUTUS_VERSION
+    @pytest.mark.testnets
     def test_json_schema_typed_int_bytes_declared(
         self,
         cluster: clusterlib.ClusterLib,
@@ -1264,6 +1276,7 @@ class TestNegativeRedeemer:
     @hypothesis.given(redeemer_value=st.binary(max_size=64))
     @common.hypothesis_settings(max_examples=200)
     @common.PARAM_PLUTUS_VERSION
+    @pytest.mark.testnets
     def test_json_schema_untyped_int_bytes_declared(
         self,
         cluster: clusterlib.ClusterLib,
@@ -1303,6 +1316,7 @@ class TestNegativeRedeemer:
     @hypothesis.given(redeemer_value=st.integers())
     @common.hypothesis_settings(max_examples=200)
     @common.PARAM_PLUTUS_VERSION
+    @pytest.mark.testnets
     def test_json_schema_typed_bytes_int_declared(
         self,
         cluster: clusterlib.ClusterLib,
@@ -1342,6 +1356,7 @@ class TestNegativeRedeemer:
     @hypothesis.given(redeemer_value=st.integers())
     @common.hypothesis_settings(max_examples=200)
     @common.PARAM_PLUTUS_VERSION
+    @pytest.mark.testnets
     def test_json_schema_untyped_bytes_int_declared(
         self,
         cluster: clusterlib.ClusterLib,
@@ -1381,6 +1396,7 @@ class TestNegativeRedeemer:
     @hypothesis.given(redeemer_value=st.text())
     @common.hypothesis_settings(max_examples=200)
     @common.PARAM_PLUTUS_VERSION
+    @pytest.mark.testnets
     def test_invalid_json(
         self,
         cluster: clusterlib.ClusterLib,
@@ -1420,6 +1436,7 @@ class TestNegativeRedeemer:
     @hypothesis.given(redeemer_type=st.text())
     @common.hypothesis_settings(max_examples=200)
     @common.PARAM_PLUTUS_VERSION
+    @pytest.mark.testnets
     def test_json_schema_typed_invalid_type(
         self,
         cluster: clusterlib.ClusterLib,
@@ -1465,6 +1482,7 @@ class TestNegativeRedeemer:
     @hypothesis.given(redeemer_type=st.text())
     @common.hypothesis_settings(max_examples=200)
     @common.PARAM_PLUTUS_VERSION
+    @pytest.mark.testnets
     def test_json_schema_untyped_invalid_type(
         self,
         cluster: clusterlib.ClusterLib,

--- a/cardano_node_tests/tests/tests_plutus/test_spend_raw.py
+++ b/cardano_node_tests/tests/tests_plutus/test_spend_raw.py
@@ -129,13 +129,13 @@ def _check_pretty_utxo(
     return err
 
 
-@pytest.mark.testnets
 class TestLocking:
     """Tests for Tx output locking using Plutus smart contracts."""
 
     @allure.link(helpers.get_vcs_link())
-    @pytest.mark.dbsync
     @common.PARAM_PLUTUS3_VERSION
+    @pytest.mark.testnets
+    @pytest.mark.dbsync
     def test_txout_locking(
         self,
         cluster: clusterlib.ClusterLib,
@@ -192,6 +192,7 @@ class TestLocking:
         reason="cannot find `create-script-context` on the PATH",
     )
     @common.SKIPIF_MISMATCHED_ERAS
+    @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_context_equivalence(
         self,
@@ -291,7 +292,6 @@ class TestLocking:
         )
 
     @allure.link(helpers.get_vcs_link())
-    @pytest.mark.dbsync
     @pytest.mark.parametrize("embed_datum", (True, False), ids=("embedded_datum", "datum"))
     @pytest.mark.parametrize(
         "variant",
@@ -304,6 +304,8 @@ class TestLocking:
         ),
     )
     @common.PARAM_PLUTUS_VERSION
+    @pytest.mark.testnets
+    @pytest.mark.dbsync
     def test_guessing_game(
         self,
         cluster: clusterlib.ClusterLib,
@@ -393,7 +395,6 @@ class TestLocking:
         )
 
     @allure.link(helpers.get_vcs_link())
-    @pytest.mark.dbsync
     @pytest.mark.parametrize(
         "plutus_version",
         (
@@ -403,6 +404,8 @@ class TestLocking:
             pytest.param("plutus_v2", marks=common.SKIPIF_PLUTUSV2_UNUSABLE),
         ),
     )
+    @pytest.mark.testnets
+    @pytest.mark.dbsync
     def test_two_scripts_spending(
         self,
         cluster: clusterlib.ClusterLib,
@@ -630,6 +633,7 @@ class TestLocking:
 
     @allure.link(helpers.get_vcs_link())
     @common.PARAM_PLUTUS3_VERSION
+    @pytest.mark.testnets
     def test_always_fails(
         self,
         cluster: clusterlib.ClusterLib,
@@ -688,6 +692,7 @@ class TestLocking:
 
     @allure.link(helpers.get_vcs_link())
     @common.PARAM_PLUTUS3_VERSION
+    @pytest.mark.testnets
     def test_script_invalid(
         self,
         cluster: clusterlib.ClusterLib,
@@ -751,8 +756,9 @@ class TestLocking:
             issues.consensus_947.finish_test()
 
     @allure.link(helpers.get_vcs_link())
-    @pytest.mark.dbsync
     @common.PARAM_PLUTUS3_VERSION
+    @pytest.mark.testnets
+    @pytest.mark.dbsync
     def test_txout_token_locking(
         self,
         cluster: clusterlib.ClusterLib,
@@ -812,8 +818,9 @@ class TestLocking:
         )
 
     @allure.link(helpers.get_vcs_link())
-    @pytest.mark.dbsync
     @common.PARAM_PLUTUS3_VERSION
+    @pytest.mark.testnets
+    @pytest.mark.dbsync
     def test_partial_spending(
         self,
         cluster: clusterlib.ClusterLib,
@@ -901,9 +908,10 @@ class TestLocking:
             assert u.datum_hash == script_utxos[0].datum_hash
 
     @allure.link(helpers.get_vcs_link())
-    @pytest.mark.dbsync
     @pytest.mark.parametrize("scenario", ("max", "max+1", "none"))
     @common.PARAM_PLUTUS3_VERSION
+    @pytest.mark.testnets
+    @pytest.mark.dbsync
     def test_collaterals(
         self,
         cluster: clusterlib.ClusterLib,

--- a/cardano_node_tests/tests/tests_plutus_v2/test_mint_build.py
+++ b/cardano_node_tests/tests/tests_plutus_v2/test_mint_build.py
@@ -100,12 +100,12 @@ def _build_reference_txin(
     return reference_txin
 
 
-@pytest.mark.testnets
 class TestBuildMinting:
     """Tests for minting using Plutus smart contracts and `transaction build`."""
 
     @allure.link(helpers.get_vcs_link())
     @common.PARAM_PLUTUS2ONWARDS_VERSION
+    @pytest.mark.testnets
     def test_minting_ref_one_token(
         self,
         cluster: clusterlib.ClusterLib,
@@ -249,6 +249,7 @@ class TestBuildMinting:
 
     @allure.link(helpers.get_vcs_link())
     @common.PARAM_PLUTUS2ONWARDS_VERSION
+    @pytest.mark.testnets
     def test_minting_ref_missing_txout(
         self,
         cluster: clusterlib.ClusterLib,
@@ -359,6 +360,7 @@ class TestBuildMinting:
     @pytest.mark.parametrize(
         "valid_redeemer", (True, False), ids=("right_redeemer", "wrong_redeemer")
     )
+    @pytest.mark.testnets
     def test_reference_inputs_visibility(
         self,
         cluster: clusterlib.ClusterLib,
@@ -504,6 +506,7 @@ class TestBuildMinting:
     @pytest.mark.parametrize(
         "valid_redeemer", (True, False), ids=("right_redeemer", "wrong_redeemer")
     )
+    @pytest.mark.testnets
     def test_reference_scripts_visibility(
         self,
         cluster: clusterlib.ClusterLib,
@@ -633,6 +636,7 @@ class TestBuildMinting:
         "scenario",
         ("reference_script", "readonly_reference_input", "different_datum"),
     )
+    @pytest.mark.testnets
     def test_inline_datum_visibility(
         self,
         cluster: clusterlib.ClusterLib,

--- a/cardano_node_tests/tests/tests_plutus_v2/test_mint_negative_build.py
+++ b/cardano_node_tests/tests/tests_plutus_v2/test_mint_negative_build.py
@@ -47,7 +47,6 @@ def payment_addrs(
     return addrs
 
 
-@pytest.mark.testnets
 class TestNegativeCollateralOutput:
     """Tests for collateral output that are expected to fail."""
 
@@ -58,6 +57,7 @@ class TestNegativeCollateralOutput:
         ids=("with_return_collateral", "without_return_collateral"),
     )
     @common.PARAM_PLUTUS2ONWARDS_VERSION
+    @pytest.mark.testnets
     def test_minting_with_unbalanced_total_collateral(
         self,
         cluster: clusterlib.ClusterLib,

--- a/cardano_node_tests/tests/tests_plutus_v2/test_mint_negative_raw.py
+++ b/cardano_node_tests/tests/tests_plutus_v2/test_mint_negative_raw.py
@@ -46,12 +46,12 @@ def payment_addrs(
     return addrs
 
 
-@pytest.mark.testnets
 class TestNegativeCollateralOutput:
     """Tests for collateral output that are expected to fail."""
 
     @allure.link(helpers.get_vcs_link())
     @common.PARAM_PLUTUS2ONWARDS_VERSION
+    @pytest.mark.testnets
     def test_minting_with_limited_collateral(
         self,
         cluster: clusterlib.ClusterLib,
@@ -168,6 +168,7 @@ class TestNegativeCollateralOutput:
         ids=("with_return_collateral", "without_return_collateral"),
     )
     @common.PARAM_PLUTUS2ONWARDS_VERSION
+    @pytest.mark.testnets
     def test_minting_with_unbalanced_total_collateral(
         self,
         cluster: clusterlib.ClusterLib,

--- a/cardano_node_tests/tests/tests_plutus_v2/test_mint_raw.py
+++ b/cardano_node_tests/tests/tests_plutus_v2/test_mint_raw.py
@@ -90,7 +90,6 @@ def _build_reference_txin(
     return reference_txin
 
 
-@pytest.mark.testnets
 class TestMinting:
     """Tests for minting using Plutus smart contracts."""
 
@@ -99,6 +98,7 @@ class TestMinting:
         "use_reference_script", (True, False), ids=("reference_script", "script_file")
     )
     @common.PARAM_PLUTUS2ONWARDS_VERSION
+    @pytest.mark.testnets
     def test_minting_two_tokens(
         self,
         cluster: clusterlib.ClusterLib,
@@ -234,6 +234,7 @@ class TestMinting:
     @pytest.mark.parametrize(
         "scenario", ("reference_script", "readonly_reference_input", "different_datum")
     )
+    @pytest.mark.testnets
     def test_datum_hash_visibility(
         self,
         cluster: clusterlib.ClusterLib,

--- a/cardano_node_tests/tests/tests_plutus_v2/test_mint_secp256k1_build.py
+++ b/cardano_node_tests/tests/tests_plutus_v2/test_mint_secp256k1_build.py
@@ -48,7 +48,6 @@ def payment_addrs(
     return addrs
 
 
-@pytest.mark.testnets
 class TestSECP256k1:
     def _fund_issuer_mint_token(
         self,
@@ -136,6 +135,7 @@ class TestSECP256k1:
     @allure.link(helpers.get_vcs_link())
     @common.PARAM_PLUTUS2ONWARDS_VERSION
     @pytest.mark.parametrize("algorithm", ("ecdsa", "schnorr"))
+    @pytest.mark.testnets
     def test_use_secp_builtin_functions(
         self,
         cluster: clusterlib.ClusterLib,
@@ -211,6 +211,7 @@ class TestSECP256k1:
         ("invalid_sig", "invalid_pubkey", "no_msg", "no_pubkey", "no_sig"),
     )
     @pytest.mark.parametrize("algorithm", ("ecdsa", "schnorr"))
+    @pytest.mark.testnets
     def test_negative_secp_builtin_functions(
         self,
         cluster: clusterlib.ClusterLib,

--- a/cardano_node_tests/tests/tests_plutus_v2/test_mint_secp256k1_raw.py
+++ b/cardano_node_tests/tests/tests_plutus_v2/test_mint_secp256k1_raw.py
@@ -48,7 +48,6 @@ def payment_addrs(
     return addrs
 
 
-@pytest.mark.testnets
 class TestSECP256k1:
     def _fund_issuer_mint_token(
         self,
@@ -139,6 +138,7 @@ class TestSECP256k1:
     @allure.link(helpers.get_vcs_link())
     @common.PARAM_PLUTUS2ONWARDS_VERSION
     @pytest.mark.parametrize("algorithm", ("ecdsa", "schnorr"))
+    @pytest.mark.testnets
     def test_use_secp_builtin_functions(
         self,
         cluster: clusterlib.ClusterLib,
@@ -189,6 +189,7 @@ class TestSECP256k1:
         ("invalid_sig", "invalid_pubkey", "no_msg", "no_pubkey", "no_sig"),
     )
     @pytest.mark.parametrize("algorithm", ("ecdsa", "schnorr"))
+    @pytest.mark.testnets
     def test_negative_secp_builtin_functions(
         self,
         cluster: clusterlib.ClusterLib,

--- a/cardano_node_tests/tests/tests_plutus_v2/test_spend_build.py
+++ b/cardano_node_tests/tests/tests_plutus_v2/test_spend_build.py
@@ -50,7 +50,6 @@ def payment_addrs(
     return addrs
 
 
-@pytest.mark.testnets
 class TestBuildLocking:
     """Tests for Tx output locking using Plutus V2 functionalities and `transaction build`."""
 
@@ -59,6 +58,7 @@ class TestBuildLocking:
     @pytest.mark.parametrize(
         "use_reference_script", (True, False), ids=("reference_script", "script_file")
     )
+    @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_txout_locking(
         self,
@@ -213,6 +213,7 @@ class TestBuildLocking:
         (True, False),
         ids=("with_reference_script", "without_reference_script"),
     )
+    @pytest.mark.testnets
     def test_min_required_utxo(
         self,
         cluster: clusterlib.ClusterLib,

--- a/cardano_node_tests/tests/tests_plutus_v2/test_spend_collateral_build.py
+++ b/cardano_node_tests/tests/tests_plutus_v2/test_spend_collateral_build.py
@@ -50,7 +50,6 @@ def payment_addrs(
     return addrs
 
 
-@pytest.mark.testnets
 class TestCollateralOutput:
     """Tests for Tx output locking using Plutus with collateral output."""
 
@@ -131,6 +130,7 @@ class TestCollateralOutput:
         (True, False),
         ids=("using_total_collateral", "without_total_collateral"),
     )
+    @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_with_total_return_collateral(
         self,
@@ -232,6 +232,7 @@ class TestCollateralOutput:
         tx_view.check_tx_view(cluster_obj=cluster, tx_raw_output=tx_output_redeem)
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_collateral_with_tokens(
         self, cluster: clusterlib.ClusterLib, payment_addrs: tp.List[clusterlib.AddressRecord]

--- a/cardano_node_tests/tests/tests_plutus_v2/test_spend_collateral_raw.py
+++ b/cardano_node_tests/tests/tests_plutus_v2/test_spend_collateral_raw.py
@@ -49,7 +49,6 @@ def payment_addrs(
     return addrs
 
 
-@pytest.mark.testnets
 class TestCollateralOutput:
     """Tests for Tx output locking using Plutus with collateral output."""
 
@@ -64,6 +63,7 @@ class TestCollateralOutput:
         (True, False),
         ids=("using_total_collateral", "without_total_collateral"),
     )
+    @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_with_total_return_collateral(
         self,
@@ -208,6 +208,7 @@ class TestCollateralOutput:
         tx_view.check_tx_view(cluster_obj=cluster, tx_raw_output=tx_output_redeem)
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_collateral_with_tokens(
         self,

--- a/cardano_node_tests/tests/tests_plutus_v2/test_spend_compat_build.py
+++ b/cardano_node_tests/tests/tests_plutus_v2/test_spend_compat_build.py
@@ -48,7 +48,6 @@ def payment_addrs(
     return addrs
 
 
-@pytest.mark.testnets
 class TestCompatibility:
     """Tests for checking compatibility with previous Tx eras."""
 
@@ -57,6 +56,7 @@ class TestCompatibility:
         VERSIONS.transaction_era >= VERSIONS.BABBAGE,
         reason="runs only with Tx era < Babbage",
     )
+    @pytest.mark.testnets
     def test_inline_datum_old_tx_era(
         self,
         cluster: clusterlib.ClusterLib,
@@ -101,6 +101,7 @@ class TestCompatibility:
         VERSIONS.transaction_era >= VERSIONS.BABBAGE,
         reason="runs only with Tx era < Babbage",
     )
+    @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_reference_script_old_tx_era(
         self,
@@ -148,6 +149,7 @@ class TestCompatibility:
         VERSIONS.transaction_era >= VERSIONS.BABBAGE,
         reason="runs only with Tx era < Babbage",
     )
+    @pytest.mark.testnets
     def test_ro_reference_old_tx_era(
         self,
         cluster: clusterlib.ClusterLib,

--- a/cardano_node_tests/tests/tests_plutus_v2/test_spend_compat_raw.py
+++ b/cardano_node_tests/tests/tests_plutus_v2/test_spend_compat_raw.py
@@ -47,7 +47,6 @@ def payment_addrs(
     return addrs
 
 
-@pytest.mark.testnets
 class TestCompatibility:
     """Tests for checking compatibility with previous Tx eras."""
 
@@ -56,6 +55,7 @@ class TestCompatibility:
         VERSIONS.transaction_era >= VERSIONS.BABBAGE,
         reason="runs only with Tx era < Babbage",
     )
+    @pytest.mark.testnets
     def test_inline_datum_old_tx_era(
         self,
         cluster: clusterlib.ClusterLib,
@@ -112,6 +112,7 @@ class TestCompatibility:
         VERSIONS.transaction_era >= VERSIONS.BABBAGE,
         reason="runs only with Tx era < Babbage",
     )
+    @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_reference_script_old_tx_era(
         self,
@@ -169,6 +170,7 @@ class TestCompatibility:
         VERSIONS.transaction_era >= VERSIONS.BABBAGE,
         reason="runs only with Tx era < Babbage",
     )
+    @pytest.mark.testnets
     def test_ro_reference_old_tx_era(
         self,
         cluster: clusterlib.ClusterLib,

--- a/cardano_node_tests/tests/tests_plutus_v2/test_spend_datum_build.py
+++ b/cardano_node_tests/tests/tests_plutus_v2/test_spend_datum_build.py
@@ -52,11 +52,11 @@ def payment_addrs(
     return addrs
 
 
-@pytest.mark.testnets
 class TestInlineDatum:
     """Tests for Tx output with inline datum."""
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.testnets
     def test_check_inline_datum_cost(self, cluster: clusterlib.ClusterLib):
         """Check that the min UTxO value with an inline datum depends on the size of the datum.
 
@@ -162,7 +162,6 @@ class TestInlineDatum:
         ), "The min UTxO value doesn't correspond to the inline datum size"
 
 
-@pytest.mark.testnets
 class TestNegativeInlineDatum:
     """Tests for Tx output with inline datum that are expected to fail."""
 
@@ -186,6 +185,7 @@ class TestNegativeInlineDatum:
     @allure.link(helpers.get_vcs_link())
     @hypothesis.given(datum_value=st.text())
     @common.hypothesis_settings()
+    @pytest.mark.testnets
     def test_lock_tx_invalid_datum(
         self,
         cluster: clusterlib.ClusterLib,
@@ -223,6 +223,7 @@ class TestNegativeInlineDatum:
         assert "JSON object expected. Unexpected value" in err_str, err_str
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_lock_tx_v1_script(
         self,
@@ -293,6 +294,7 @@ class TestNegativeInlineDatum:
     @allure.link(helpers.get_vcs_link())
     @hypothesis.given(datum_content=st.text(alphabet=string.ascii_letters, min_size=65))
     @common.hypothesis_settings(max_examples=100)
+    @pytest.mark.testnets
     def test_lock_tx_big_datum(
         self,
         cluster: clusterlib.ClusterLib,
@@ -344,6 +346,7 @@ class TestNegativeInlineDatum:
         ), err_str
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_lock_tx_datum_as_witness(
         self, cluster: clusterlib.ClusterLib, payment_addrs: tp.List[clusterlib.AddressRecord]

--- a/cardano_node_tests/tests/tests_plutus_v2/test_spend_datum_raw.py
+++ b/cardano_node_tests/tests/tests_plutus_v2/test_spend_datum_raw.py
@@ -51,7 +51,6 @@ def payment_addrs(
     return addrs
 
 
-@pytest.mark.testnets
 class TestNegativeInlineDatum:
     """Tests for Tx output with inline datum that are expected to fail."""
 
@@ -87,6 +86,7 @@ class TestNegativeInlineDatum:
     @allure.link(helpers.get_vcs_link())
     @hypothesis.given(datum_value=st.text())
     @common.hypothesis_settings()
+    @pytest.mark.testnets
     def test_lock_tx_invalid_datum(
         self,
         cluster: clusterlib.ClusterLib,
@@ -136,6 +136,7 @@ class TestNegativeInlineDatum:
         assert "JSON object expected. Unexpected value" in err_str, err_str
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_lock_tx_v1_script(
         self,
@@ -224,6 +225,7 @@ class TestNegativeInlineDatum:
     @allure.link(helpers.get_vcs_link())
     @hypothesis.given(datum_content=st.text(alphabet=string.ascii_letters, min_size=65))
     @common.hypothesis_settings(max_examples=200)
+    @pytest.mark.testnets
     def test_lock_tx_big_datum(
         self,
         cluster: clusterlib.ClusterLib,
@@ -278,6 +280,7 @@ class TestNegativeInlineDatum:
         ), err_str
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_lock_tx_datum_as_witness(
         self, cluster: clusterlib.ClusterLib, payment_addrs: tp.List[clusterlib.AddressRecord]

--- a/cardano_node_tests/tests/tests_plutus_v2/test_spend_raw.py
+++ b/cardano_node_tests/tests/tests_plutus_v2/test_spend_raw.py
@@ -49,7 +49,6 @@ def payment_addrs(
     return addrs
 
 
-@pytest.mark.testnets
 class TestLockingV2:
     """Tests for Tx output locking using Plutus V2 smart contracts."""
 
@@ -58,6 +57,7 @@ class TestLockingV2:
     @pytest.mark.parametrize(
         "use_reference_script", (True, False), ids=("reference_script", "script_file")
     )
+    @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_txout_locking(
         self,
@@ -181,6 +181,7 @@ class TestLockingV2:
         assert helpers.is_in_interval(fee, expected_fee_redeem, frac=0.15)
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.testnets
     @pytest.mark.needs_dbsync
     def test_datum_bytes_in_dbsync(
         self,

--- a/cardano_node_tests/tests/tests_plutus_v2/test_spend_ref_inputs_build.py
+++ b/cardano_node_tests/tests/tests_plutus_v2/test_spend_ref_inputs_build.py
@@ -51,13 +51,12 @@ def payment_addrs(
     return addrs
 
 
-@pytest.mark.testnets
 class TestReadonlyReferenceInputs:
     """Tests for Tx with readonly reference inputs."""
 
     @allure.link(helpers.get_vcs_link())
-    @pytest.mark.dbsync
     @pytest.mark.parametrize("reference_input_scenario", ("single", "duplicated"))
+    @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_use_reference_input(
         self,
@@ -164,6 +163,7 @@ class TestReadonlyReferenceInputs:
         dbsync_utils.check_tx(cluster_obj=cluster, tx_raw_output=tx_output_redeem)
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_same_input_as_reference_input(
         self,
@@ -267,6 +267,7 @@ class TestReadonlyReferenceInputs:
         tx_view.check_tx_view(cluster_obj=cluster, tx_raw_output=tx_output_redeem)
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.testnets
     def test_use_same_reference_input_multiple_times(
         self,
         cluster: clusterlib.ClusterLib,
@@ -342,6 +343,7 @@ class TestReadonlyReferenceInputs:
         ), f"The reference input was spent `{reference_input[0]}`"
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_reference_input_non_plutus(
         self,
@@ -407,11 +409,11 @@ class TestReadonlyReferenceInputs:
         dbsync_utils.check_tx(cluster_obj=cluster, tx_raw_output=tx_output)
 
 
-@pytest.mark.testnets
 class TestNegativeReadonlyReferenceInputs:
     """Tests for Tx with readonly reference inputs that are expected to fail."""
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_reference_spent_output(
         self,
@@ -522,6 +524,7 @@ class TestNegativeReadonlyReferenceInputs:
         ), err_str
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_v1_script_with_reference_input(
         self,
@@ -606,6 +609,7 @@ class TestNegativeReadonlyReferenceInputs:
                 raise
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.testnets
     def test_reference_input_without_spend_anything(
         self,
         cluster: clusterlib.ClusterLib,

--- a/cardano_node_tests/tests/tests_plutus_v2/test_spend_ref_inputs_raw.py
+++ b/cardano_node_tests/tests/tests_plutus_v2/test_spend_ref_inputs_raw.py
@@ -50,12 +50,12 @@ def payment_addrs(
     return addrs
 
 
-@pytest.mark.testnets
 class TestReadonlyReferenceInputs:
     """Tests for Tx with readonly reference inputs."""
 
     @allure.link(helpers.get_vcs_link())
     @pytest.mark.parametrize("reference_input_scenario", ("single", "duplicated"))
+    @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_use_reference_input(
         self,
@@ -153,6 +153,7 @@ class TestReadonlyReferenceInputs:
         tx_view.check_tx_view(cluster_obj=cluster, tx_raw_output=tx_raw_output)
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_same_input_as_reference_input(
         self,
@@ -254,6 +255,7 @@ class TestReadonlyReferenceInputs:
         tx_view.check_tx_view(cluster_obj=cluster, tx_raw_output=tx_output_redeem)
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_reference_input_non_plutus(
         self,
@@ -313,11 +315,11 @@ class TestReadonlyReferenceInputs:
         dbsync_utils.check_tx(cluster_obj=cluster, tx_raw_output=tx_raw_output)
 
 
-@pytest.mark.testnets
 class TestNegativeReadonlyReferenceInputs:
     """Tests for Tx with readonly reference inputs that are expected to fail."""
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_reference_spent_output(
         self,
@@ -423,6 +425,7 @@ class TestNegativeReadonlyReferenceInputs:
         ), err_str
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_v1_script_with_reference_input(
         self, cluster: clusterlib.ClusterLib, payment_addrs: tp.List[clusterlib.AddressRecord]
@@ -514,6 +517,7 @@ class TestNegativeReadonlyReferenceInputs:
                 raise
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.testnets
     def test_reference_input_without_spend_anything(
         self,
         cluster: clusterlib.ClusterLib,

--- a/cardano_node_tests/tests/tests_plutus_v2/test_spend_ref_scripts_build.py
+++ b/cardano_node_tests/tests/tests_plutus_v2/test_spend_ref_scripts_build.py
@@ -48,7 +48,6 @@ def payment_addrs(
     return addrs
 
 
-@pytest.mark.testnets
 class TestReferenceScripts:
     """Tests for Tx output locking using Plutus smart contracts with reference scripts."""
 
@@ -56,6 +55,7 @@ class TestReferenceScripts:
     @pytest.mark.parametrize(
         "use_same_script", (True, False), ids=("same_script", "multiple_script")
     )
+    @pytest.mark.testnets
     def test_reference_multiple_script(
         self,
         cluster: clusterlib.ClusterLib,
@@ -231,6 +231,7 @@ class TestReferenceScripts:
         assert helpers.is_in_interval(min_required_utxo, expected_min_required_utxo, frac=0.15)
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.testnets
     def test_reference_same_script(
         self,
         cluster: clusterlib.ClusterLib,
@@ -376,6 +377,7 @@ class TestReferenceScripts:
         ), f"Script address UTxOs were NOT spent - `{script_utxos1}` and `{script_utxos2}`"
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.testnets
     def test_mix_reference_attached_script(
         self,
         cluster: clusterlib.ClusterLib,
@@ -542,6 +544,7 @@ class TestReferenceScripts:
     @allure.link(helpers.get_vcs_link())
     @pytest.mark.parametrize("plutus_version", ("v1", "v2"), ids=("plutus_v1", "plutus_v2"))
     @pytest.mark.parametrize("address_type", ("shelley", "byron"))
+    @pytest.mark.testnets
     def test_spend_reference_script(
         self,
         cluster: clusterlib.ClusterLib,
@@ -609,6 +612,7 @@ class TestReferenceScripts:
 
     @allure.link(helpers.get_vcs_link())
     @pytest.mark.parametrize("plutus_version", ("v1", "v2"), ids=("plutus_v1", "plutus_v2"))
+    @pytest.mark.testnets
     def test_spend_regular_utxo_and_reference_script(
         self,
         cluster: clusterlib.ClusterLib,
@@ -699,11 +703,11 @@ class TestReferenceScripts:
         assert utxo_balance == amount, f"Incorrect balance for destination UTxO `{new_utxo}`"
 
 
-@pytest.mark.testnets
 class TestNegativeReferenceScripts:
     """Tests for Tx output with reference scripts that are expected to fail."""
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.testnets
     def test_not_a_script(
         self,
         cluster: clusterlib.ClusterLib,
@@ -737,6 +741,7 @@ class TestNegativeReferenceScripts:
         assert "Syntax error in script" in err_str, err_str
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.testnets
     def test_two_scripts_one_fail(
         self,
         cluster: clusterlib.ClusterLib,
@@ -883,6 +888,7 @@ class TestNegativeReferenceScripts:
         assert "The Plutus script evaluation failed" in err_str, err_str
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_lock_tx_v1_reference_script(
         self,
@@ -958,6 +964,7 @@ class TestNegativeReferenceScripts:
         ), err_str
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.testnets
     def test_v1_attached_v2_reference(
         self,
         cluster: clusterlib.ClusterLib,
@@ -1103,6 +1110,7 @@ class TestNegativeReferenceScripts:
         ), err_str
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_lock_byron_reference_script(
         self,

--- a/cardano_node_tests/tests/tests_plutus_v2/test_spend_ref_scripts_raw.py
+++ b/cardano_node_tests/tests/tests_plutus_v2/test_spend_ref_scripts_raw.py
@@ -48,7 +48,6 @@ def payment_addrs(
     return addrs
 
 
-@pytest.mark.testnets
 class TestReferenceScripts:
     """Tests for Tx output locking using Plutus smart contracts with reference scripts."""
 
@@ -56,6 +55,7 @@ class TestReferenceScripts:
     @pytest.mark.parametrize(
         "use_same_script", (True, False), ids=("same_script", "multiple_script")
     )
+    @pytest.mark.testnets
     def test_reference_multiple_script(
         self,
         cluster: clusterlib.ClusterLib,
@@ -215,6 +215,7 @@ class TestReferenceScripts:
         ), f"Script address UTxOs were NOT spent - `{script_utxos1}` and `{script_utxos2}`"
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.testnets
     def test_reference_same_script(
         self,
         cluster: clusterlib.ClusterLib,
@@ -356,6 +357,7 @@ class TestReferenceScripts:
         ), f"Script address UTxOs were NOT spent - `{script_utxos1}` and `{script_utxos2}`"
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.testnets
     def test_mix_reference_attached_script(
         self,
         cluster: clusterlib.ClusterLib,
@@ -504,6 +506,7 @@ class TestReferenceScripts:
     @allure.link(helpers.get_vcs_link())
     @pytest.mark.parametrize("plutus_version", ("v1", "v2"), ids=("plutus_v1", "plutus_v2"))
     @pytest.mark.parametrize("address_type", ("shelley", "byron"))
+    @pytest.mark.testnets
     def test_spend_reference_script(
         self,
         cluster: clusterlib.ClusterLib,
@@ -562,6 +565,7 @@ class TestReferenceScripts:
 
     @allure.link(helpers.get_vcs_link())
     @pytest.mark.parametrize("plutus_version", ("v1", "v2"), ids=("plutus_v1", "plutus_v2"))
+    @pytest.mark.testnets
     def test_spend_regular_utxo_and_reference_script(
         self,
         cluster: clusterlib.ClusterLib,
@@ -636,6 +640,7 @@ class TestReferenceScripts:
         assert utxo_balance == amount, f"Incorrect balance for destination UTxO `{new_utxo}`"
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.testnets
     def test_reference_script_byron_address(
         self,
         cluster: clusterlib.ClusterLib,
@@ -668,11 +673,11 @@ class TestReferenceScripts:
         assert reference_utxo.reference_script, "Reference script is missing"
 
 
-@pytest.mark.testnets
 class TestNegativeReferenceScripts:
     """Tests for Tx output with reference scripts that are expected to fail."""
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.testnets
     def test_not_a_script(
         self,
         cluster: clusterlib.ClusterLib,
@@ -715,6 +720,7 @@ class TestNegativeReferenceScripts:
         assert "Syntax error in script" in err_str, err_str
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.testnets
     def test_two_scripts_one_fail(
         self,
         cluster: clusterlib.ClusterLib,
@@ -871,6 +877,7 @@ class TestNegativeReferenceScripts:
             issues.ledger_3731.finish_test()
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_lock_tx_v1_reference_script(
         self,
@@ -964,6 +971,7 @@ class TestNegativeReferenceScripts:
         ), err_str
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.testnets
     def test_v1_attached_v2_reference(
         self,
         cluster: clusterlib.ClusterLib,
@@ -1113,6 +1121,7 @@ class TestNegativeReferenceScripts:
         ), err_str
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_lock_byron_reference_script(
         self,

--- a/cardano_node_tests/tests/tests_plutus_v2/test_spend_secp256k1_build.py
+++ b/cardano_node_tests/tests/tests_plutus_v2/test_spend_secp256k1_build.py
@@ -51,7 +51,6 @@ def payment_addrs(
     return addrs
 
 
-@pytest.mark.testnets
 class TestSECP256k1:
     @pytest.fixture
     def build_fund_script_secp(
@@ -135,6 +134,7 @@ class TestSECP256k1:
 
     @allure.link(helpers.get_vcs_link())
     @pytest.mark.parametrize("build_fund_script_secp", ("ecdsa", "schnorr"), indirect=True)
+    @pytest.mark.testnets
     def test_use_secp_builtin_functions(
         self,
         cluster: clusterlib.ClusterLib,
@@ -231,6 +231,7 @@ class TestSECP256k1:
         number_of_iterations=st.integers(min_value=1000300, max_value=common.MAX_UINT64)
     )
     @common.hypothesis_settings(max_examples=200)
+    @pytest.mark.testnets
     def test_overspending_execution_budget(
         self,
         cluster: clusterlib.ClusterLib,

--- a/cardano_node_tests/tests/tests_plutus_v2/test_spend_secp256k1_raw.py
+++ b/cardano_node_tests/tests/tests_plutus_v2/test_spend_secp256k1_raw.py
@@ -47,7 +47,6 @@ def payment_addrs(
     return addrs
 
 
-@pytest.mark.testnets
 class TestSECP256k1:
     @pytest.fixture
     def fund_script_secp(
@@ -119,6 +118,7 @@ class TestSECP256k1:
 
     @allure.link(helpers.get_vcs_link())
     @pytest.mark.parametrize("fund_script_secp", ("ecdsa", "schnorr"), indirect=True)
+    @pytest.mark.testnets
     def test_use_secp_builtin_functions(
         self,
         cluster: clusterlib.ClusterLib,


### PR DESCRIPTION
Make sure that the "testnet" marker is used only on individual tests, not on class or module level.