### PR TITLE
refactor: review "smoke" marker

### DIFF
--- a/cardano_node_tests/tests/test_addr_registration.py
+++ b/cardano_node_tests/tests/test_addr_registration.py
@@ -61,12 +61,12 @@ def pool_users_disposable(
     return pool_users
 
 
-@pytest.mark.smoke
 class TestRegisterAddr:
     """Tests for stake address registration and deregistration."""
 
     @allure.link(helpers.get_vcs_link())
     @common.PARAM_USE_BUILD_CMD
+    @pytest.mark.smoke
     @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_deregister_registered(
@@ -194,6 +194,7 @@ class TestRegisterAddr:
 
     @allure.link(helpers.get_vcs_link())
     @common.PARAM_USE_BUILD_CMD
+    @pytest.mark.smoke
     @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_addr_registration_deregistration(
@@ -287,6 +288,7 @@ class TestRegisterAddr:
     @allure.link(helpers.get_vcs_link())
     @submit_utils.PARAM_SUBMIT_METHOD
     @common.PARAM_USE_BUILD_CMD
+    @pytest.mark.smoke
     @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_addr_registration_certificate_order(
@@ -378,11 +380,11 @@ class TestRegisterAddr:
             assert user_registered.stake.address in tx_db_record.stake_deregistration
 
 
-@pytest.mark.smoke
 class TestNegative:
     """Tests that are expected to fail."""
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_registration_cert_with_wrong_key(
         self,
@@ -406,6 +408,7 @@ class TestNegative:
         assert "Expected: StakeVerificationKeyShelley" in err_msg, err_msg
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_register_addr_with_wrong_key(
         self,
@@ -444,6 +447,7 @@ class TestNegative:
 
     @allure.link(helpers.get_vcs_link())
     @common.PARAM_USE_BUILD_CMD
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_deregister_not_registered_addr(
         self,

--- a/cardano_node_tests/tests/test_cli.py
+++ b/cardano_node_tests/tests/test_cli.py
@@ -36,7 +36,6 @@ ADDR_ALPHABET = list(f"{string.ascii_lowercase}{string.digits}")
 pytestmark = common.SKIPIF_WRONG_ERA
 
 
-@pytest.mark.smoke
 class TestCLI:
     """Tests for cardano-cli."""
 
@@ -46,6 +45,7 @@ class TestCLI:
     TX_OUT_JSON = DATA_DIR / "test_tx_metadata_both_tx_json.out"
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_protocol_mode(self, cluster: clusterlib.ClusterLib):
         """Check the default protocol mode - command works even without specifying protocol mode."""
@@ -62,6 +62,7 @@ class TestCLI:
         )
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_calculate_min_fee(self, cluster: clusterlib.ClusterLib):
         """Check the `calculate-min-fee` command."""
@@ -101,6 +102,7 @@ class TestCLI:
         assert coin == "Lovelace", f"Unexpected coin: {coin} != Lovelace"
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.smoke
     def test_txid_with_process_substitution(self, cluster: clusterlib.ClusterLib):
         """Check that it is possible to pass Tx file using process substitution."""
         common.get_test_id(cluster)
@@ -120,6 +122,7 @@ class TestCLI:
             raise
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.smoke
     def test_sign_tx_with_process_substitution(self, cluster: clusterlib.ClusterLib):
         """Check that it is possible to pass skey file using process substitution."""
         temp_template = common.get_test_id(cluster)
@@ -134,6 +137,7 @@ class TestCLI:
         helpers.run_in_bash(command=cmd)
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.smoke
     def test_tx_view(self, cluster: clusterlib.ClusterLib):
         """Check that the output of `transaction view` is as expected."""
         common.get_test_id(cluster)
@@ -157,6 +161,7 @@ class TestCLI:
         assert tx == tx_golden.strip()
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_query_tip(self, cluster: clusterlib.ClusterLib):
         """Test `query tip`."""
@@ -218,12 +223,12 @@ class TestCLI:
             raise AssertionError(errors_str)
 
 
-@pytest.mark.smoke
 class TestAddressInfo:
     """Tests for cardano-cli address info."""
 
     @allure.link(helpers.get_vcs_link())
     @pytest.mark.parametrize("addr_gen", ("static", "dynamic"))
+    @pytest.mark.smoke
     def test_address_info_payment(self, cluster: clusterlib.ClusterLib, addr_gen: str):
         """Check payment address info."""
         temp_template = common.get_test_id(cluster)
@@ -247,6 +252,7 @@ class TestAddressInfo:
 
     @allure.link(helpers.get_vcs_link())
     @pytest.mark.parametrize("addr_gen", ("static", "dynamic"))
+    @pytest.mark.smoke
     def test_address_info_stake(self, cluster: clusterlib.ClusterLib, addr_gen: str):
         """Check stake address info."""
         temp_template = common.get_test_id(cluster)
@@ -269,6 +275,7 @@ class TestAddressInfo:
             assert addr_info.base16 == "e0a9b82c30b12e1c33ae5667f4d8e9ed2d18d3016bfe916b176d30a307"
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.smoke
     def test_address_info_script(self, cluster: clusterlib.ClusterLib):
         """Check script address info."""
         temp_template = common.get_test_id(cluster)
@@ -300,6 +307,7 @@ class TestAddressInfo:
         assert addr_info.type == "payment"
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.smoke
     def test_address_info_payment_with_outfile(self, cluster: clusterlib.ClusterLib):
         """Compare payment address info with and without outfile provided."""
         common.get_test_id(cluster)
@@ -326,6 +334,7 @@ class TestAddressInfo:
     @allure.link(helpers.get_vcs_link())
     @hypothesis.given(address=st.text(alphabet=ADDR_ALPHABET, min_size=1))
     @common.hypothesis_settings(max_examples=300)
+    @pytest.mark.smoke
     def test_address_info_with_invalid_address(self, cluster: clusterlib.ClusterLib, address: str):
         """Try to use 'address info' with invalid address (property-based test).
 
@@ -341,7 +350,6 @@ class TestAddressInfo:
         assert "Invalid address" in err_str, err_str
 
 
-@pytest.mark.smoke
 class TestAddressBuild:
     """Tests for cardano-cli address build."""
 
@@ -357,6 +365,7 @@ class TestAddressBuild:
             "address",
         ),
     )
+    @pytest.mark.smoke
     def test_address_build(
         self,
         cluster: clusterlib.ClusterLib,
@@ -421,6 +430,7 @@ class TestAddressBuild:
     @pytest.mark.parametrize("option", ("vkey", "vkey_file", "script_file"))
     @hypothesis.given(key=st.text(alphabet=ADDR_ALPHABET, min_size=1))
     @common.hypothesis_settings(max_examples=300)
+    @pytest.mark.smoke
     def test_invalid_payment_info(
         self,
         cluster: clusterlib.ClusterLib,
@@ -478,6 +488,7 @@ class TestAddressBuild:
     )
     @hypothesis.given(key=st.text(alphabet=ADDR_ALPHABET, min_size=1))
     @common.hypothesis_settings(max_examples=300)
+    @pytest.mark.smoke
     def test_invalid_stake_info(
         self,
         cluster: clusterlib.ClusterLib,
@@ -530,12 +541,12 @@ class TestAddressBuild:
         ), err_str
 
 
-@pytest.mark.smoke
 class TestAddressKeyHash:
     """Tests for cardano-cli address key-hash."""
 
     @allure.link(helpers.get_vcs_link())
     @pytest.mark.parametrize("option", ("vkey", "vkey_file"))
+    @pytest.mark.smoke
     def test_valid_verification_key(self, cluster: clusterlib.ClusterLib, option: str):
         """Check `address key-hash` with valid verification key."""
         common.get_test_id(cluster)
@@ -562,6 +573,7 @@ class TestAddressKeyHash:
     @pytest.mark.parametrize("option", ("vkey", "vkey_file"))
     @hypothesis.given(vkey=st.text(alphabet=ADDR_ALPHABET, min_size=1))
     @common.hypothesis_settings(max_examples=300)
+    @pytest.mark.smoke
     def test_invalid_verification_key(self, cluster: clusterlib.ClusterLib, option: str, vkey: str):
         """Try to use `address key-hash` with invalid verification key (property-based test).
 
@@ -591,11 +603,11 @@ class TestAddressKeyHash:
         assert "Invalid key" in err_str, err_str
 
 
-@pytest.mark.smoke
 class TestKey:
     """Tests for cardano-cli key."""
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.smoke
     def test_non_extended_key_valid(self, cluster: clusterlib.ClusterLib):
         """Check that the non-extended verification key is according the verification key."""
         temp_template = common.get_test_id(cluster)
@@ -621,6 +633,7 @@ class TestKey:
         assert extended_vkey.startswith(non_extended_vkey)
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.smoke
     def test_stake_non_extended_key(self, cluster: clusterlib.ClusterLib):
         """Get a stake non-extended-key from a stake extended key."""
         temp_template = common.get_test_id(cluster)
@@ -638,6 +651,7 @@ class TestKey:
             raise
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.smoke
     def test_non_extended_key_error(self, cluster: clusterlib.ClusterLib):
         """Try to get a non-extended verification key with a signing key file.
 
@@ -663,11 +677,11 @@ class TestKey:
         ), err_str
 
 
-@pytest.mark.smoke
 class TestQueryUTxO:
     """Tests for cardano-cli query utxo."""
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.smoke
     def test_whole_utxo(self, cluster: clusterlib.ClusterLib):
         """Check that it is possible to return the whole UTxO on local cluster."""
         common.get_test_id(cluster)
@@ -682,11 +696,12 @@ class TestQueryUTxO:
         )
 
     @allure.link(helpers.get_vcs_link())
-    @pytest.mark.testnets
     @pytest.mark.skipif(
         VERSIONS.transaction_era != VERSIONS.DEFAULT_CLUSTER_ERA,
         reason="works only with the latest TX era",
     )
+    @pytest.mark.smoke
+    @pytest.mark.testnets
     def test_pretty_utxo(
         self, cluster_manager: cluster_management.ClusterManager, cluster: clusterlib.ClusterLib
     ):
@@ -767,6 +782,7 @@ class TestQueryUTxO:
     @pytest.mark.parametrize("invalid_param", ("tx_hash", "tx_ix"))
     @hypothesis.given(filter_str=st.text(alphabet=string.ascii_letters, min_size=1))
     @common.hypothesis_settings(max_examples=300)
+    @pytest.mark.smoke
     def test_tx_in_invalid_data(
         self, cluster: clusterlib.ClusterLib, filter_str: str, invalid_param: str
     ):
@@ -802,6 +818,7 @@ class TestQueryUTxO:
     @allure.link(helpers.get_vcs_link())
     @hypothesis.given(filter_str=st.text(alphabet=ADDR_ALPHABET, min_size=1))
     @common.hypothesis_settings(max_examples=300)
+    @pytest.mark.smoke
     def test_address_invalid_data(self, cluster: clusterlib.ClusterLib, filter_str: str):
         """Try to use 'query utxo' with invalid 'address' (property-based test).
 
@@ -824,12 +841,12 @@ class TestQueryUTxO:
         assert "invalid address" in err_str, err_str
 
 
-@pytest.mark.smoke
 class TestStakeAddressKeyHash:
     """Tests for cardano-cli stake-address key-hash."""
 
     @allure.link(helpers.get_vcs_link())
     @pytest.mark.parametrize("option", ("vkey", "vkey_file"))
+    @pytest.mark.smoke
     def test_valid_verification_key(self, cluster: clusterlib.ClusterLib, option: str):
         """Check `stake-address key-hash` with valid verification key."""
         common.get_test_id(cluster)
@@ -856,6 +873,7 @@ class TestStakeAddressKeyHash:
     @pytest.mark.parametrize("option", ("vkey", "vkey_file"))
     @hypothesis.given(vkey=st.text(alphabet=ADDR_ALPHABET, min_size=1))
     @common.hypothesis_settings(max_examples=300)
+    @pytest.mark.smoke
     def test_invalid_verification_key(self, cluster: clusterlib.ClusterLib, option: str, vkey: str):
         """Try to use `stake-address key-hash` with invalid verification key (property-based test).
 
@@ -1111,9 +1129,9 @@ class TestAdvancedQueries:
             ),
         ),
     )
-    @pytest.mark.dbsync
-    @pytest.mark.testnets
     @pytest.mark.smoke
+    @pytest.mark.testnets
+    @pytest.mark.dbsync
     def test_stake_snapshot(
         self,
         cluster_manager: cluster_management.ClusterManager,
@@ -1133,8 +1151,8 @@ class TestAdvancedQueries:
         )
 
     @allure.link(helpers.get_vcs_link())
-    @pytest.mark.testnets
     @pytest.mark.smoke
+    @pytest.mark.testnets
     def test_pool_params(self, cluster: clusterlib.ClusterLib, pool_ids: tp.List[str]):
         """Test `query pool-params`."""
         common.get_test_id(cluster)
@@ -1147,13 +1165,13 @@ class TestAdvancedQueries:
         assert hasattr(pool_params, "retiring")
 
     @allure.link(helpers.get_vcs_link())
-    @pytest.mark.testnets
-    @pytest.mark.smoke
     @pytest.mark.parametrize(
         "with_out_file",
         (True, False),
         ids=("with_out_file", "without_out_file"),
     )
+    @pytest.mark.smoke
+    @pytest.mark.testnets
     def test_tx_mempool_info(
         self,
         cluster: clusterlib.ClusterLib,
@@ -1187,6 +1205,7 @@ class TestAdvancedQueries:
         assert {"capacityInBytes", "numberOfTxs", "sizeInBytes", "slot"}.issubset(tx_mempool)
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_pool_state(self, cluster: clusterlib.ClusterLib, pool_ids: tp.List[str]):
         """Test `query pool-state`."""
@@ -1197,11 +1216,11 @@ class TestAdvancedQueries:
         assert hasattr(pool_params, "retiring")
 
 
-@pytest.mark.smoke
 class TestPing:
     """Tests for `cardano-cli ping`."""
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_ping_localhost(
         self,
@@ -1246,6 +1265,7 @@ class TestPing:
         assert last_pong["cookie"] == count - 1, f"Expected cookie {count - 1}, got {last_pong}"
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_ping_unix_socket(
         self,
@@ -1307,11 +1327,11 @@ class TestPing:
         assert last_pong["cookie"] == count - 1, f"Expected cookie {count - 1}, got {last_pong}"
 
 
-@pytest.mark.smoke
 class TestQuerySlotNumber:
     """Tests for `cardano-cli query slot-number`."""
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.smoke
     def test_slot_number(
         self,
         cluster: clusterlib.ClusterLib,
@@ -1332,6 +1352,7 @@ class TestQuerySlotNumber:
         assert slot_number <= (tip_out["epoch"] + 1) * cluster.epoch_length - cluster.slots_offset
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.smoke
     def test_slot_number_invalid_format(
         self,
         cluster: clusterlib.ClusterLib,
@@ -1353,6 +1374,7 @@ class TestQuerySlotNumber:
 
     @allure.link(helpers.get_vcs_link())
     @pytest.mark.parametrize("time_val", ("above", "bellow"))
+    @pytest.mark.smoke
     def test_slot_number_out_of_range(
         self,
         cluster: clusterlib.ClusterLib,

--- a/cardano_node_tests/tests/test_delegation.py
+++ b/cardano_node_tests/tests/test_delegation.py
@@ -848,11 +848,11 @@ class TestDelegateAddr:
             assert pool_id == tx_db_deleg.stake_delegation[0].pool_id
 
 
-@pytest.mark.smoke
 class TestNegative:
     """Tests that are expected to fail."""
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_delegation_cert_with_wrong_key(
         self,
@@ -880,6 +880,7 @@ class TestNegative:
         ), err_msg
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_delegate_addr_with_wrong_key(
         self,
@@ -942,6 +943,7 @@ class TestNegative:
 
     @allure.link(helpers.get_vcs_link())
     @common.PARAM_USE_BUILD_CMD
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_delegate_unknown_addr(
         self,
@@ -1001,6 +1003,7 @@ class TestNegative:
 
     @allure.link(helpers.get_vcs_link())
     @common.PARAM_USE_BUILD_CMD
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_delegate_deregistered_addr(
         self,
@@ -1105,6 +1108,7 @@ class TestNegative:
         ), err_msg
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_delegatee_not_registered(
         self,

--- a/cardano_node_tests/tests/test_env_network_id.py
+++ b/cardano_node_tests/tests/test_env_network_id.py
@@ -123,11 +123,11 @@ def payment_addrs(
     return addrs
 
 
-@pytest.mark.smoke
 class TestNetworkIdEnv:
     """Tests for `CARDANO_NODE_NETWORK_ID`."""
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_query_protocol_state(
         self,
@@ -142,6 +142,7 @@ class TestNetworkIdEnv:
         assert "lastSlot" in state
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_query_stake_distribution(
         self,
@@ -156,6 +157,7 @@ class TestNetworkIdEnv:
         assert next(iter(distrib)).startswith("pool")
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_query_protocol_params(
         self,
@@ -170,6 +172,7 @@ class TestNetworkIdEnv:
         assert "protocolVersion" in protocol_params
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_query_pool_state(
         self,
@@ -183,6 +186,7 @@ class TestNetworkIdEnv:
         cluster.g_query.get_pool_state(stake_pool_id=POOL_ID)
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_query_stake_addr_info(
         self,
@@ -197,6 +201,7 @@ class TestNetworkIdEnv:
 
     @allure.link(helpers.get_vcs_link())
     @common.SKIPIF_BUILD_UNUSABLE
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_build_transfer_funds(
         self,
@@ -247,7 +252,6 @@ class TestNetworkIdEnv:
         ), f"Incorrect balance for destination address `{dst_addr.address}`"
 
 
-@pytest.mark.smoke
 class TestNegativeNetworkIdEnv:
     """Negative tests for `CARDANO_NODE_NETWORK_ID`."""
 
@@ -264,6 +268,7 @@ class TestNegativeNetworkIdEnv:
     @allure.link(helpers.get_vcs_link())
     @PARAM_ENV_SCENARIO
     @PARAM_ARG_SCENARIO
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_neg_query_protocol_state(
         self,
@@ -294,6 +299,7 @@ class TestNegativeNetworkIdEnv:
     @allure.link(helpers.get_vcs_link())
     @PARAM_ENV_SCENARIO
     @PARAM_ARG_SCENARIO
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_neg_query_stake_distribution(
         self,
@@ -323,6 +329,7 @@ class TestNegativeNetworkIdEnv:
     @allure.link(helpers.get_vcs_link())
     @PARAM_ENV_SCENARIO
     @PARAM_ARG_SCENARIO
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_neg_query_protocol_params(
         self,
@@ -352,6 +359,7 @@ class TestNegativeNetworkIdEnv:
     @allure.link(helpers.get_vcs_link())
     @PARAM_ENV_SCENARIO
     @PARAM_ARG_SCENARIO
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_neg_query_pool_state(
         self,
@@ -381,6 +389,7 @@ class TestNegativeNetworkIdEnv:
     @allure.link(helpers.get_vcs_link())
     @PARAM_ENV_SCENARIO
     @PARAM_ARG_SCENARIO
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_neg_query_stake_addr_info(
         self,
@@ -411,6 +420,7 @@ class TestNegativeNetworkIdEnv:
     @common.SKIPIF_BUILD_UNUSABLE
     @PARAM_ENV_SCENARIO
     @PARAM_ARG_SCENARIO
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_neg_build_transfer_funds(
         self,

--- a/cardano_node_tests/tests/test_governance.py
+++ b/cardano_node_tests/tests/test_governance.py
@@ -36,7 +36,6 @@ pytestmark = pytest.mark.skipif(
 )
 
 
-@pytest.mark.smoke
 class TestPoll:
     """Tests for SPO poll."""
 
@@ -72,6 +71,7 @@ class TestPoll:
     @allure.link(helpers.get_vcs_link())
     @common.PARAM_USE_BUILD_CMD
     @pytest.mark.parametrize("required_signer_option", ("skey", "vkey_hash"))
+    @pytest.mark.smoke
     @pytest.mark.dbsync
     def test_create_and_answer_poll(
         self,
@@ -229,6 +229,7 @@ class TestPoll:
     @allure.link(helpers.get_vcs_link())
     @common.PARAM_USE_BUILD_CMD
     @pytest.mark.parametrize("tx_file_type", ("body", "signed"))
+    @pytest.mark.smoke
     def test_answer_golden_poll(
         self,
         cluster: clusterlib.ClusterLib,
@@ -300,6 +301,7 @@ class TestPoll:
     @hypothesis.example(answer_index=-common.MAX_INT64)
     @hypothesis.example(answer_index=common.MAX_INT64)
     @common.hypothesis_settings(max_examples=1000)
+    @pytest.mark.smoke
     def test_create_invalid_answer(
         self,
         cluster: clusterlib.ClusterLib,
@@ -328,6 +330,7 @@ class TestPoll:
         assert "Poll answer out of bounds" in err_str or "negative index" in err_str, err_str
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.smoke
     def test_create_answer_negative_index(
         self,
         cluster: clusterlib.ClusterLib,
@@ -358,6 +361,7 @@ class TestPoll:
     @allure.link(helpers.get_vcs_link())
     @common.PARAM_USE_BUILD_CMD
     @pytest.mark.parametrize("tx_file_type", ("body", "signed"))
+    @pytest.mark.smoke
     def test_verify_answer_without_required_signer(
         self,
         cluster: clusterlib.ClusterLib,

--- a/cardano_node_tests/tests/test_native_tokens.py
+++ b/cardano_node_tests/tests/test_native_tokens.py
@@ -1171,12 +1171,12 @@ class TestMinting:
 
 
 @common.SKIPIF_TOKENS_UNUSABLE
-@pytest.mark.smoke
 class TestPolicies:
     """Tests for minting and burning tokens using minting policies."""
 
     @allure.link(helpers.get_vcs_link())
     @common.PARAM_USE_BUILD_CMD
+    @pytest.mark.smoke
     @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_valid_policy_after(
@@ -1268,6 +1268,7 @@ class TestPolicies:
 
     @allure.link(helpers.get_vcs_link())
     @common.PARAM_USE_BUILD_CMD
+    @pytest.mark.smoke
     @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_valid_policy_before(
@@ -1360,6 +1361,7 @@ class TestPolicies:
         dbsync_utils.check_tx(cluster_obj=cluster, tx_raw_output=tx_out_burn)
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_policy_before_past(
         self, cluster: clusterlib.ClusterLib, issuers_addrs: tp.List[clusterlib.AddressRecord]
@@ -1430,6 +1432,7 @@ class TestPolicies:
             assert not token_utxo, "The token was minted unexpectedly"
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_policy_before_future(
         self, cluster: clusterlib.ClusterLib, issuers_addrs: tp.List[clusterlib.AddressRecord]
@@ -1492,6 +1495,7 @@ class TestPolicies:
             assert not token_utxo, "The token was minted unexpectedly"
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_policy_after_future(
         self, cluster: clusterlib.ClusterLib, issuers_addrs: tp.List[clusterlib.AddressRecord]
@@ -1565,6 +1569,7 @@ class TestPolicies:
             assert not token_utxo, "The token was minted unexpectedly"
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_policy_after_past(
         self, cluster: clusterlib.ClusterLib, issuers_addrs: tp.List[clusterlib.AddressRecord]
@@ -1628,7 +1633,6 @@ class TestPolicies:
 
 
 @common.SKIPIF_TOKENS_UNUSABLE
-@pytest.mark.smoke
 class TestTransfer:
     """Tests for transferring tokens."""
 
@@ -1695,6 +1699,7 @@ class TestTransfer:
     @allure.link(helpers.get_vcs_link())
     @common.PARAM_USE_BUILD_CMD
     @pytest.mark.parametrize("amount", (1, 10, 200, 2_000, 100_000))
+    @pytest.mark.smoke
     @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_transfer_tokens(
@@ -1827,6 +1832,7 @@ class TestTransfer:
 
     @allure.link(helpers.get_vcs_link())
     @common.PARAM_USE_BUILD_CMD
+    @pytest.mark.smoke
     @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_transfer_multiple_tokens(
@@ -2010,6 +2016,7 @@ class TestTransfer:
         cluster_nodes.get_cluster_type().type != cluster_nodes.ClusterType.LOCAL,
         reason="runs only on local cluster",
     )
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_transfer_no_ada(
         self,
@@ -2064,6 +2071,7 @@ class TestTransfer:
     @hypothesis.example(token_amount=MAX_TOKEN_AMOUNT)
     @common.hypothesis_settings(max_examples=200)
     @common.PARAM_USE_BUILD_CMD
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_transfer_invalid_token_amount(
         self,
@@ -2136,7 +2144,6 @@ class TestTransfer:
 
 
 @common.SKIPIF_TOKENS_UNUSABLE
-@pytest.mark.smoke
 class TestNegative:
     """Negative tests for minting tokens."""
 
@@ -2202,6 +2209,7 @@ class TestNegative:
         )
     )
     @common.hypothesis_settings(max_examples=300)
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_long_name(
         self,
@@ -2248,6 +2256,7 @@ class TestNegative:
     @hypothesis.given(token_amount=st.integers(min_value=MAX_TOKEN_AMOUNT + 1))
     @hypothesis.example(token_amount=MAX_TOKEN_AMOUNT + 1)
     @common.hypothesis_settings(max_examples=300)
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_minting_amount_above_the_allowed(
         self,
@@ -2287,11 +2296,11 @@ class TestNegative:
 
 
 @common.SKIPIF_WRONG_ERA
-@pytest.mark.smoke
 class TestCLITxOutSyntax:
     """Tests of syntax for specifying muti-asset values and txouts."""
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.smoke
     @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_multiasset_txouts_syntax(
@@ -2430,7 +2439,6 @@ class TestCLITxOutSyntax:
         dbsync_utils.check_tx(cluster_obj=cluster, tx_raw_output=tx_raw_output)
 
 
-@pytest.mark.smoke
 @pytest.mark.skipif(
     VERSIONS.transaction_era < VERSIONS.BABBAGE,
     reason="runs only with Babbage+ TX",
@@ -2441,6 +2449,7 @@ class TestReferenceUTxO:
     @allure.link(helpers.get_vcs_link())
     @common.PARAM_USE_BUILD_CMD
     @pytest.mark.parametrize("script_version", ("simple_v1", "simple_v2"))
+    @pytest.mark.smoke
     @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_script_reference_utxo(

--- a/cardano_node_tests/tests/test_pools.py
+++ b/cardano_node_tests/tests/test_pools.py
@@ -1915,7 +1915,6 @@ class TestPoolCost:
                 _subtest(pc)
 
 
-@pytest.mark.smoke
 class TestNegative:
     """Stake pool tests that are expected to fail."""
 
@@ -1984,6 +1983,7 @@ class TestNegative:
         return pool_name, pool_metadata_hash, node_vrf, node_cold
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_pool_registration_cert_wrong_vrf(
         self,
@@ -2010,6 +2010,7 @@ class TestNegative:
         assert "Expected: VrfVerificationKey_PraosVRF" in str(excinfo.value)
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_pool_registration_cert_wrong_cold(
         self,
@@ -2036,6 +2037,7 @@ class TestNegative:
         assert "Expected: StakePoolVerificationKey" in str(excinfo.value)
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_pool_registration_cert_wrong_stake(
         self,
@@ -2062,6 +2064,7 @@ class TestNegative:
         assert "Expected: StakeVerificationKeyShelley" in str(excinfo.value)
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_pool_registration_missing_cold_skey(
         self,
@@ -2102,6 +2105,7 @@ class TestNegative:
         assert "MissingVKeyWitnessesUTXOW" in str(excinfo.value)
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_pool_registration_missing_payment_skey(
         self,
@@ -2141,6 +2145,7 @@ class TestNegative:
 
     @allure.link(helpers.get_vcs_link())
     @common.PARAM_USE_BUILD_CMD
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_pool_deregistration_not_registered(
         self,
@@ -2191,6 +2196,7 @@ class TestNegative:
         assert "StakePoolNotRegisteredOnKeyPOOL" in str(excinfo.value)
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_stake_pool_metadata_no_name(
         self,
@@ -2216,6 +2222,7 @@ class TestNegative:
         assert 'key "name" not found' in str(excinfo.value)
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_stake_pool_metadata_no_description(
         self,
@@ -2241,6 +2248,7 @@ class TestNegative:
         assert 'key "description" not found' in str(excinfo.value)
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_stake_pool_metadata_no_ticker(
         self,
@@ -2266,6 +2274,7 @@ class TestNegative:
         assert 'key "ticker" not found' in str(excinfo.value)
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_stake_pool_metadata_no_homepage(
         self,
@@ -2293,6 +2302,7 @@ class TestNegative:
     @allure.link(helpers.get_vcs_link())
     @hypothesis.given(pool_name=st.text(min_size=51))
     @common.hypothesis_settings()
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_stake_pool_metadata_long_name(
         self,
@@ -2326,6 +2336,7 @@ class TestNegative:
     @allure.link(helpers.get_vcs_link())
     @hypothesis.given(pool_description=st.text(min_size=256, max_size=1000))
     @common.hypothesis_settings()
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_stake_pool_metadata_long_description(
         self,
@@ -2359,6 +2370,7 @@ class TestNegative:
     @allure.link(helpers.get_vcs_link())
     @hypothesis.given(pool_ticker=st.text())
     @common.hypothesis_settings()
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_stake_pool_metadata_long_ticker(
         self,
@@ -2394,6 +2406,7 @@ class TestNegative:
     @allure.link(helpers.get_vcs_link())
     @hypothesis.given(pool_homepage=st.text(min_size=425, max_size=1000))
     @common.hypothesis_settings()
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_stake_pool_metadata_long_homepage(
         self,
@@ -2425,6 +2438,7 @@ class TestNegative:
         metadata_url=st.text(alphabet=st.characters(blacklist_categories=["C"]), min_size=25)
     )
     @common.hypothesis_settings()
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_stake_pool_long_metadata_url(
         self,

--- a/cardano_node_tests/tests/test_protocol.py
+++ b/cardano_node_tests/tests/test_protocol.py
@@ -82,11 +82,11 @@ PROTOCOL_PARAM_KEYS_MISSING_8_12_0 = frozenset(
 
 
 @common.SKIPIF_WRONG_ERA
-@pytest.mark.smoke
 class TestProtocol:
     """Basic tests for protocol."""
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_protocol_state_keys(self, cluster: clusterlib.ClusterLib):
         """Check output of `query protocol-state`."""
@@ -107,6 +107,7 @@ class TestProtocol:
         assert set(protocol_state) == PROTOCOL_STATE_KEYS
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_protocol_state_outfile(self, cluster: clusterlib.ClusterLib):
         """Check output file produced by `query protocol-state`."""
@@ -122,6 +123,7 @@ class TestProtocol:
         assert set(protocol_state) == PROTOCOL_STATE_KEYS
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_protocol_params(self, cluster: clusterlib.ClusterLib):
         """Check output of `query protocol-parameters`."""

--- a/cardano_node_tests/tests/test_scripts.py
+++ b/cardano_node_tests/tests/test_scripts.py
@@ -135,7 +135,6 @@ def multisig_tx(
     return tx_raw_output
 
 
-@pytest.mark.smoke
 class TestBasic:
     """Basic tests for multisig transactions."""
 
@@ -167,6 +166,7 @@ class TestBasic:
         return addrs
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_script_addr_length(
         self, cluster: clusterlib.ClusterLib, payment_addrs: tp.List[clusterlib.AddressRecord]
@@ -197,6 +197,7 @@ class TestBasic:
     @allure.link(helpers.get_vcs_link())
     @submit_utils.PARAM_SUBMIT_METHOD
     @common.PARAM_USE_BUILD_CMD
+    @pytest.mark.smoke
     @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_multisig_all(
@@ -255,6 +256,7 @@ class TestBasic:
     @allure.link(helpers.get_vcs_link())
     @submit_utils.PARAM_SUBMIT_METHOD
     @common.PARAM_USE_BUILD_CMD
+    @pytest.mark.smoke
     @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_multisig_any(
@@ -350,6 +352,7 @@ class TestBasic:
     @allure.link(helpers.get_vcs_link())
     @submit_utils.PARAM_SUBMIT_METHOD
     @common.PARAM_USE_BUILD_CMD
+    @pytest.mark.smoke
     @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_multisig_atleast(
@@ -420,6 +423,7 @@ class TestBasic:
     @allure.link(helpers.get_vcs_link())
     @submit_utils.PARAM_SUBMIT_METHOD
     @common.PARAM_USE_BUILD_CMD
+    @pytest.mark.smoke
     @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_normal_tx_to_script_addr(
@@ -479,6 +483,7 @@ class TestBasic:
     @allure.link(helpers.get_vcs_link())
     @submit_utils.PARAM_SUBMIT_METHOD
     @common.PARAM_USE_BUILD_CMD
+    @pytest.mark.smoke
     @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_normal_tx_from_script_addr(
@@ -557,6 +562,7 @@ class TestBasic:
         dbsync_utils.check_tx(cluster_obj=cluster, tx_raw_output=tx_out_from)
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.smoke
     @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_multisig_empty_all(
@@ -610,6 +616,7 @@ class TestBasic:
         dbsync_utils.check_tx(cluster_obj=cluster, tx_raw_output=tx_out_from)
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.smoke
     @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_multisig_no_required_atleast(
@@ -671,7 +678,6 @@ class TestBasic:
         dbsync_utils.check_tx(cluster_obj=cluster, tx_raw_output=tx_out_from)
 
 
-@pytest.mark.smoke
 class TestNegative:
     """Transaction tests that are expected to fail."""
 
@@ -705,6 +711,7 @@ class TestNegative:
         return addrs
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.smoke
     @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_multisig_all_missing_skey(
@@ -758,6 +765,7 @@ class TestNegative:
         dbsync_utils.check_tx(cluster_obj=cluster, tx_raw_output=tx_raw_output)
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.smoke
     @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_multisig_any_unlisted_skey(
@@ -811,6 +819,7 @@ class TestNegative:
         dbsync_utils.check_tx(cluster_obj=cluster, tx_raw_output=tx_raw_output)
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.smoke
     @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_multisig_atleast_low_num_of_skeys(
@@ -869,7 +878,6 @@ class TestNegative:
         dbsync_utils.check_tx(cluster_obj=cluster, tx_raw_output=tx_raw_output)
 
 
-@pytest.mark.smoke
 @pytest.mark.skipif(
     VERSIONS.transaction_era < VERSIONS.ALLEGRA,
     reason="runs only with Allegra+ TX",
@@ -1051,6 +1059,7 @@ class TestTimeLocking:
     @pytest.mark.parametrize(
         "use_tx_validity", (True, False), ids=("tx_validity", "no_tx_validity")
     )
+    @pytest.mark.smoke
     @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_script_after(
@@ -1123,6 +1132,7 @@ class TestTimeLocking:
     @pytest.mark.parametrize(
         "use_tx_validity", (True, False), ids=("tx_validity", "no_tx_validity")
     )
+    @pytest.mark.smoke
     @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_script_before(
@@ -1191,6 +1201,7 @@ class TestTimeLocking:
     @allure.link(helpers.get_vcs_link())
     @common.PARAM_USE_BUILD_CMD
     @pytest.mark.parametrize("slot_type", ("before", "after"))
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_tx_missing_validity(
         self,
@@ -1259,6 +1270,7 @@ class TestTimeLocking:
 
     @allure.link(helpers.get_vcs_link())
     @common.PARAM_USE_BUILD_CMD
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_tx_negative_validity(
         self,
@@ -1339,6 +1351,7 @@ class TestTimeLocking:
     )
     @hypothesis.given(data=st.data())
     @common.hypothesis_settings(max_examples=50)
+    @pytest.mark.smoke
     @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_before_past(
@@ -1407,6 +1420,7 @@ class TestTimeLocking:
     )
     @hypothesis.given(slot_no=st.integers(min_value=1, max_value=10_000))
     @common.hypothesis_settings(max_examples=50)
+    @pytest.mark.smoke
     @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_before_future(
@@ -1456,6 +1470,7 @@ class TestTimeLocking:
     )
     @hypothesis.given(data=st.data())
     @common.hypothesis_settings(max_examples=50)
+    @pytest.mark.smoke
     @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_after_future(
@@ -1524,6 +1539,7 @@ class TestTimeLocking:
     )
     @hypothesis.given(data=st.data())
     @common.hypothesis_settings(max_examples=50)
+    @pytest.mark.smoke
     @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_after_past(
@@ -1568,7 +1584,6 @@ class TestTimeLocking:
         dbsync_utils.check_tx(cluster_obj=cluster, tx_raw_output=tx_output)
 
 
-@pytest.mark.smoke
 @pytest.mark.skipif(
     VERSIONS.transaction_era < VERSIONS.ALLEGRA,
     reason="runs only with Allegra+ TX",
@@ -1608,6 +1623,7 @@ class TestAuxiliaryScripts:
     @allure.link(helpers.get_vcs_link())
     @submit_utils.PARAM_SUBMIT_METHOD
     @common.PARAM_USE_BUILD_CMD
+    @pytest.mark.smoke
     @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_tx_script_metadata_json(
@@ -1664,6 +1680,7 @@ class TestAuxiliaryScripts:
     @allure.link(helpers.get_vcs_link())
     @submit_utils.PARAM_SUBMIT_METHOD
     @common.PARAM_USE_BUILD_CMD
+    @pytest.mark.smoke
     @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_tx_script_metadata_cbor(
@@ -1721,6 +1738,7 @@ class TestAuxiliaryScripts:
     @allure.link(helpers.get_vcs_link())
     @submit_utils.PARAM_SUBMIT_METHOD
     @common.PARAM_USE_BUILD_CMD
+    @pytest.mark.smoke
     @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_tx_script_no_metadata(
@@ -1768,6 +1786,7 @@ class TestAuxiliaryScripts:
 
     @allure.link(helpers.get_vcs_link())
     @common.PARAM_USE_BUILD_CMD
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_tx_script_invalid(
         self,
@@ -1803,7 +1822,6 @@ class TestAuxiliaryScripts:
         assert 'Error in $: key "type" not found' in err_str, err_str
 
 
-@pytest.mark.smoke
 class TestIncrementalSigning:
     """Tests for incremental signing."""
 
@@ -1844,6 +1862,7 @@ class TestIncrementalSigning:
     @submit_utils.PARAM_SUBMIT_METHOD
     @common.PARAM_USE_BUILD_CMD
     @pytest.mark.parametrize("tx_is", ("witnessed", "signed"))
+    @pytest.mark.smoke
     @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_incremental_signing(
@@ -1999,7 +2018,6 @@ class TestIncrementalSigning:
         dbsync_utils.check_tx(cluster_obj=cluster, tx_raw_output=tx_out_from)
 
 
-@pytest.mark.smoke
 @pytest.mark.skipif(
     VERSIONS.transaction_era < VERSIONS.ALONZO,
     reason="runs only with Alonzo+ TX",
@@ -2040,6 +2058,7 @@ class TestDatum:
     @submit_utils.PARAM_SUBMIT_METHOD
     @common.PARAM_USE_BUILD_CMD
     @pytest.mark.parametrize("script_version", ("simple_v1", "simple_v2"))
+    @pytest.mark.smoke
     @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_script_utxo_datum(
@@ -2111,7 +2130,6 @@ class TestDatum:
         dbsync_utils.check_tx(cluster_obj=cluster, tx_raw_output=tx_output)
 
 
-@pytest.mark.smoke
 @pytest.mark.skipif(
     VERSIONS.transaction_era < VERSIONS.BABBAGE,
     reason="runs only with Babbage+ TX",
@@ -2150,6 +2168,7 @@ class TestReferenceUTxO:
     @submit_utils.PARAM_SUBMIT_METHOD
     @common.PARAM_USE_BUILD_CMD
     @pytest.mark.parametrize("script_version", ("simple_v1", "simple_v2"))
+    @pytest.mark.smoke
     @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_script_reference_utxo(
@@ -2293,6 +2312,7 @@ class TestReferenceUTxO:
     @common.PARAM_USE_BUILD_CMD
     @pytest.mark.parametrize("script_version", ("simple_v1", "simple_v2"))
     @pytest.mark.parametrize("address_type", ("shelley", "byron"))
+    @pytest.mark.smoke
     @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_spend_reference_script(
@@ -2381,7 +2401,6 @@ class TestReferenceUTxO:
         # TODO: check reference script in db-sync (the `tx_out_spend`)
 
 
-@pytest.mark.smoke
 @pytest.mark.skipif(
     VERSIONS.transaction_era < VERSIONS.ALLEGRA,
     reason="runs only with Allegra+ TX",
@@ -2423,6 +2442,7 @@ class TestNested:
     @common.PARAM_USE_BUILD_CMD
     @pytest.mark.parametrize("type_top", ("all", "any"))
     @pytest.mark.parametrize("type_nested", ("all", "any"))
+    @pytest.mark.smoke
     @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_nested_script(
@@ -2526,6 +2546,7 @@ class TestNested:
     @allure.link(helpers.get_vcs_link())
     @submit_utils.PARAM_SUBMIT_METHOD
     @common.PARAM_USE_BUILD_CMD
+    @pytest.mark.smoke
     @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_nested_optional_all(
@@ -2610,6 +2631,7 @@ class TestNested:
     @pytest.mark.parametrize(
         "scenario", ("all1", "all2", "all3", "all4", "all5", "all6", "any1", "any2", "any3", "any4")
     )
+    @pytest.mark.smoke
     @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_invalid(  # noqa: C901
@@ -2813,7 +2835,6 @@ class TestNested:
         dbsync_utils.check_tx(cluster_obj=cluster, tx_raw_output=tx_raw_output)
 
 
-@pytest.mark.smoke
 class TestCompatibility:
     """Tests for checking compatibility with previous Tx eras."""
 
@@ -2849,6 +2870,7 @@ class TestCompatibility:
         reason="runs only with Shelley TX",
     )
     @submit_utils.PARAM_SUBMIT_METHOD
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_script_v2(
         self,
@@ -2913,6 +2935,7 @@ class TestCompatibility:
         reason="runs only with Shelley TX",
     )
     @submit_utils.PARAM_SUBMIT_METHOD
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_auxiliary_scripts(
         self,

--- a/cardano_node_tests/tests/test_socket_path.py
+++ b/cardano_node_tests/tests/test_socket_path.py
@@ -115,12 +115,12 @@ def payment_addrs(
     return addrs
 
 
-@pytest.mark.smoke
 class TestSocketPath:
     """Tests for `cardano-cli ... --socket-path`."""
 
     @allure.link(helpers.get_vcs_link())
     @PARAM_ENV_SCENARIO
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_query_protocol_state(
         self,
@@ -139,6 +139,7 @@ class TestSocketPath:
 
     @allure.link(helpers.get_vcs_link())
     @PARAM_ENV_SCENARIO
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_query_stake_distribution(
         self,
@@ -157,6 +158,7 @@ class TestSocketPath:
 
     @allure.link(helpers.get_vcs_link())
     @PARAM_ENV_SCENARIO
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_query_protocol_params(
         self,
@@ -175,6 +177,7 @@ class TestSocketPath:
 
     @allure.link(helpers.get_vcs_link())
     @PARAM_ENV_SCENARIO
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_query_pool_state(
         self,
@@ -192,6 +195,7 @@ class TestSocketPath:
 
     @allure.link(helpers.get_vcs_link())
     @PARAM_ENV_SCENARIO
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_query_stake_addr_info(
         self,
@@ -210,6 +214,7 @@ class TestSocketPath:
     @allure.link(helpers.get_vcs_link())
     @common.SKIPIF_BUILD_UNUSABLE
     @PARAM_ENV_SCENARIO
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_build_transfer_funds(
         self,

--- a/cardano_node_tests/tests/test_tx_basic.py
+++ b/cardano_node_tests/tests/test_tx_basic.py
@@ -28,7 +28,6 @@ from cardano_node_tests.utils.versions import VERSIONS
 LOGGER = logging.getLogger(__name__)
 
 
-@pytest.mark.smoke
 class TestBasicTransactions:
     """Test basic transactions - transferring funds, transaction IDs."""
 
@@ -161,6 +160,7 @@ class TestBasicTransactions:
     @pytest.mark.parametrize(
         "src_addr_type", ("shelley", "byron"), ids=("src_shelley", "src_byron")
     )
+    @pytest.mark.smoke
     @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_transfer_funds(
@@ -222,6 +222,7 @@ class TestBasicTransactions:
     @allure.link(helpers.get_vcs_link())
     @common.SKIPIF_BUILD_UNUSABLE
     @submit_utils.PARAM_SUBMIT_METHOD
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_byron_fee_too_small(
         self,
@@ -271,6 +272,7 @@ class TestBasicTransactions:
     @allure.link(helpers.get_vcs_link())
     @common.SKIPIF_BUILD_UNUSABLE
     @submit_utils.PARAM_SUBMIT_METHOD
+    @pytest.mark.smoke
     @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_build_no_change(
@@ -356,6 +358,7 @@ class TestBasicTransactions:
 
     @allure.link(helpers.get_vcs_link())
     @submit_utils.PARAM_SUBMIT_METHOD
+    @pytest.mark.smoke
     @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_transfer_all_funds(
@@ -426,6 +429,7 @@ class TestBasicTransactions:
     @allure.link(helpers.get_vcs_link())
     @submit_utils.PARAM_SUBMIT_METHOD
     @common.PARAM_USE_BUILD_CMD
+    @pytest.mark.smoke
     @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_funds_to_valid_address(
@@ -486,6 +490,7 @@ class TestBasicTransactions:
     @allure.link(helpers.get_vcs_link())
     @submit_utils.PARAM_SUBMIT_METHOD
     @common.PARAM_USE_BUILD_CMD
+    @pytest.mark.smoke
     @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_get_txid(
@@ -541,6 +546,7 @@ class TestBasicTransactions:
 
     @allure.link(helpers.get_vcs_link())
     @submit_utils.PARAM_SUBMIT_METHOD
+    @pytest.mark.smoke
     @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_extra_signing_keys(
@@ -605,6 +611,7 @@ class TestBasicTransactions:
 
     @allure.link(helpers.get_vcs_link())
     @submit_utils.PARAM_SUBMIT_METHOD
+    @pytest.mark.smoke
     @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_duplicate_signing_keys(
@@ -669,6 +676,7 @@ class TestBasicTransactions:
     @allure.link(helpers.get_vcs_link())
     @submit_utils.PARAM_SUBMIT_METHOD
     @pytest.mark.parametrize("file_type", ("tx_body", "tx"))
+    @pytest.mark.smoke
     @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_sign_wrong_file(
@@ -738,6 +746,7 @@ class TestBasicTransactions:
 
     @allure.link(helpers.get_vcs_link())
     @submit_utils.PARAM_SUBMIT_METHOD
+    @pytest.mark.smoke
     @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_no_txout(
@@ -788,6 +797,7 @@ class TestBasicTransactions:
         dbsync_utils.check_tx(cluster_obj=cluster, tx_raw_output=tx_raw_output)
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_missing_tx_out(
         self,
@@ -827,6 +837,7 @@ class TestBasicTransactions:
         reason="doesn't run with Shelley TX on node < 8.7.0",
     )
     @submit_utils.PARAM_SUBMIT_METHOD
+    @pytest.mark.smoke
     @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_missing_ttl(
@@ -888,6 +899,7 @@ class TestBasicTransactions:
 
     @allure.link(helpers.get_vcs_link())
     @submit_utils.PARAM_SUBMIT_METHOD
+    @pytest.mark.smoke
     @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_multiple_same_txins(
@@ -952,6 +964,7 @@ class TestBasicTransactions:
 
     @allure.link(helpers.get_vcs_link())
     @common.SKIPIF_BUILD_UNUSABLE
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_build_multiple_same_txins(
         self,
@@ -999,8 +1012,9 @@ class TestBasicTransactions:
         reason="doesn't run with TX era < Alonzo",
     )
     @submit_utils.PARAM_SUBMIT_METHOD
-    @pytest.mark.dbsync
+    @pytest.mark.smoke
     @pytest.mark.testnets
+    @pytest.mark.dbsync
     def test_utxo_with_datum_hash(
         self,
         cluster: clusterlib.ClusterLib,
@@ -1066,8 +1080,9 @@ class TestBasicTransactions:
 
     @allure.link(helpers.get_vcs_link())
     @submit_utils.PARAM_SUBMIT_METHOD
-    @pytest.mark.dbsync
+    @pytest.mark.smoke
     @pytest.mark.testnets
+    @pytest.mark.dbsync
     def test_far_future_ttl(
         self,
         cluster: clusterlib.ClusterLib,
@@ -1126,6 +1141,7 @@ class TestBasicTransactions:
         ids=("explicit_tx_era", "implicit_tx_era"),
         indirect=True,
     )
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_default_tx_era(
         self,
@@ -1164,7 +1180,6 @@ class TestBasicTransactions:
         tx_view.check_tx_view(cluster_obj=cluster, tx_raw_output=tx_output)
 
 
-@pytest.mark.smoke
 class TestMultiInOut:
     """Test transactions with multiple txins and/or txouts."""
 
@@ -1285,6 +1300,7 @@ class TestMultiInOut:
 
     @allure.link(helpers.get_vcs_link())
     @submit_utils.PARAM_SUBMIT_METHOD
+    @pytest.mark.smoke
     @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_10_transactions(
@@ -1340,6 +1356,7 @@ class TestMultiInOut:
     @common.PARAM_USE_BUILD_CMD
     @submit_utils.PARAM_SUBMIT_METHOD
     @pytest.mark.parametrize("amount", (1_500_000, 2_000_000, 10_000_000))
+    @pytest.mark.smoke
     @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_transaction_to_10_addrs_from_1_addr(
@@ -1371,6 +1388,7 @@ class TestMultiInOut:
     @common.PARAM_USE_BUILD_CMD
     @submit_utils.PARAM_SUBMIT_METHOD
     @pytest.mark.parametrize("amount", (1_500_000, 2_000_000, 10_000_000))
+    @pytest.mark.smoke
     @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_transaction_to_1_addr_from_10_addrs(
@@ -1402,6 +1420,7 @@ class TestMultiInOut:
     @common.PARAM_USE_BUILD_CMD
     @submit_utils.PARAM_SUBMIT_METHOD
     @pytest.mark.parametrize("amount", (1_500_000, 2_000_000, 10_000_000))
+    @pytest.mark.smoke
     @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_transaction_to_10_addrs_from_10_addrs(
@@ -1433,6 +1452,7 @@ class TestMultiInOut:
     @common.PARAM_USE_BUILD_CMD
     @submit_utils.PARAM_SUBMIT_METHOD
     @pytest.mark.parametrize("amount", (1_500_000, 2_000_000, 5_000_000))
+    @pytest.mark.smoke
     @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_transaction_to_100_addrs_from_50_addrs(
@@ -1461,7 +1481,6 @@ class TestMultiInOut:
         )
 
 
-@pytest.mark.smoke
 class TestIncrementalSigning:
     """Test incremental signing of transactions."""
 
@@ -1498,6 +1517,7 @@ class TestIncrementalSigning:
     @common.PARAM_USE_BUILD_CMD
     @submit_utils.PARAM_SUBMIT_METHOD
     @pytest.mark.parametrize("tx_is", ("witnessed", "signed"))
+    @pytest.mark.smoke
     @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_incremental_signing(

--- a/cardano_node_tests/tests/test_tx_fees.py
+++ b/cardano_node_tests/tests/test_tx_fees.py
@@ -38,7 +38,6 @@ else:
     TO_10_FROM_10_PARAMS = [(1, 309_557), (100, 309_997), (11_000, 310_437), (100_000, 311_317)]
 
 
-@pytest.mark.smoke
 class TestFee:
     """General fees tests."""
 
@@ -72,6 +71,7 @@ class TestFee:
     @allure.link(helpers.get_vcs_link())
     @hypothesis.given(fee=st.integers(max_value=-1))
     @common.hypothesis_settings()
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_negative_fee(
         self,
@@ -103,6 +103,7 @@ class TestFee:
 
     @allure.link(helpers.get_vcs_link())
     @pytest.mark.parametrize("fee_change", (0, 1.1, 1.5, 2))
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_smaller_fee(
         self,
@@ -146,6 +147,7 @@ class TestFee:
 
     @allure.link(helpers.get_vcs_link())
     @pytest.mark.parametrize("fee_add", (0, 1_000, 100_000, 1_000_000))
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_expected_or_higher_fee(
         self,
@@ -192,7 +194,6 @@ class TestFee:
         ), f"Incorrect balance for destination address `{dst_address}`"
 
 
-@pytest.mark.smoke
 class TestExpectedFees:
     """Test expected fees."""
 
@@ -319,6 +320,7 @@ class TestExpectedFees:
 
     @allure.link(helpers.get_vcs_link())
     @pytest.mark.parametrize("addr_fee", [(1, 197_753), (3, 234_009), (5, 270_265), (10, 340_000)])
+    @pytest.mark.smoke
     def test_pool_registration_fees(
         self,
         cluster: clusterlib.ClusterLib,
@@ -371,6 +373,7 @@ class TestExpectedFees:
 
     @allure.link(helpers.get_vcs_link())
     @pytest.mark.parametrize("addr_fee", POOL_DEREG_PARAMS)
+    @pytest.mark.smoke
     def test_pool_deregistration_fees(
         self,
         cluster: clusterlib.ClusterLib,
@@ -435,6 +438,7 @@ class TestExpectedFees:
 
     @allure.link(helpers.get_vcs_link())
     @pytest.mark.parametrize("addr_fee", [(1, 178_965), (3, 206_949), (5, 234_933), (10, 290_000)])
+    @pytest.mark.smoke
     def test_addr_registration_fees(
         self,
         cluster: clusterlib.ClusterLib,
@@ -475,6 +479,7 @@ class TestExpectedFees:
 
     @allure.link(helpers.get_vcs_link())
     @pytest.mark.parametrize("addr_fee", [(1, 178_965), (3, 206_949), (5, 234_933), (10, 290_000)])
+    @pytest.mark.smoke
     def test_addr_deregistration_fees(
         self,
         cluster: clusterlib.ClusterLib,
@@ -517,6 +522,7 @@ class TestExpectedFees:
     @pytest.mark.parametrize(
         "amount_expected", [(1, 176_677), (100, 176_721), (11_000, 176_765), (100_000, 176_853)]
     )
+    @pytest.mark.smoke
     def test_transaction_to_1_addr_from_1_addr_fees(
         self,
         cluster: clusterlib.ClusterLib,
@@ -537,6 +543,7 @@ class TestExpectedFees:
 
     @allure.link(helpers.get_vcs_link())
     @pytest.mark.parametrize("amount_expected", TO_10_FROM_1_PARAMS)
+    @pytest.mark.smoke
     def test_transaction_to_10_addrs_from_1_addr_fees(
         self,
         cluster: clusterlib.ClusterLib,
@@ -557,6 +564,7 @@ class TestExpectedFees:
 
     @allure.link(helpers.get_vcs_link())
     @pytest.mark.parametrize("amount_expected", TO_1_FROM_10_PARAMS)
+    @pytest.mark.smoke
     def test_transaction_to_1_addr_from_10_addrs_fees(
         self,
         cluster: clusterlib.ClusterLib,
@@ -577,6 +585,7 @@ class TestExpectedFees:
 
     @allure.link(helpers.get_vcs_link())
     @pytest.mark.parametrize("amount_expected", TO_10_FROM_10_PARAMS)
+    @pytest.mark.smoke
     def test_transaction_to_10_addrs_from_10_addrs_fees(
         self,
         cluster: clusterlib.ClusterLib,
@@ -600,6 +609,7 @@ class TestExpectedFees:
         VERSIONS.node < version.parse("8.7.0"), reason="Doesn't run on node < 8.7.0"
     )
     @pytest.mark.parametrize("amount_expected", TO_FROM_100_PARAMS)
+    @pytest.mark.smoke
     def test_transaction_to_100_addrs_from_100_addrs_fees(
         self,
         cluster: clusterlib.ClusterLib,

--- a/cardano_node_tests/tests/test_tx_metadata.py
+++ b/cardano_node_tests/tests/test_tx_metadata.py
@@ -20,7 +20,6 @@ LOGGER = logging.getLogger(__name__)
 DATA_DIR = pl.Path(__file__).parent / "data"
 
 
-@pytest.mark.smoke
 class TestMetadata:
     """Tests for transactions with metadata."""
 
@@ -58,6 +57,7 @@ class TestMetadata:
         return addr
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_tx_wrong_json_metadata_format(
         self, cluster: clusterlib.ClusterLib, payment_addr: clusterlib.AddressRecord
@@ -85,6 +85,7 @@ class TestMetadata:
 
     @allure.link(helpers.get_vcs_link())
     @common.SKIPIF_BUILD_UNUSABLE
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_build_tx_wrong_json_metadata_format(
         self, cluster: clusterlib.ClusterLib, payment_addr: clusterlib.AddressRecord
@@ -113,6 +114,7 @@ class TestMetadata:
         assert "The JSON metadata top level must be a map" in str_err, str_err
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_tx_invalid_json_metadata(
         self, cluster: clusterlib.ClusterLib, payment_addr: clusterlib.AddressRecord
@@ -143,6 +145,7 @@ class TestMetadata:
 
     @allure.link(helpers.get_vcs_link())
     @common.SKIPIF_BUILD_UNUSABLE
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_build_tx_invalid_json_metadata(
         self, cluster: clusterlib.ClusterLib, payment_addr: clusterlib.AddressRecord
@@ -175,6 +178,7 @@ class TestMetadata:
         ), str_err
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_tx_too_long_metadata_json(
         self, cluster: clusterlib.ClusterLib, payment_addr: clusterlib.AddressRecord
@@ -201,6 +205,7 @@ class TestMetadata:
 
     @allure.link(helpers.get_vcs_link())
     @common.SKIPIF_BUILD_UNUSABLE
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_build_tx_too_long_metadata_json(
         self, cluster: clusterlib.ClusterLib, payment_addr: clusterlib.AddressRecord
@@ -230,6 +235,7 @@ class TestMetadata:
         ), str_err
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.smoke
     @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_tx_metadata_json(
@@ -272,6 +278,7 @@ class TestMetadata:
 
     @allure.link(helpers.get_vcs_link())
     @common.SKIPIF_BUILD_UNUSABLE
+    @pytest.mark.smoke
     @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_build_tx_metadata_json(
@@ -323,6 +330,7 @@ class TestMetadata:
             ), "Metadata in db-sync doesn't match the original metadata"
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.smoke
     @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_tx_metadata_cbor(
@@ -362,6 +370,7 @@ class TestMetadata:
 
     @allure.link(helpers.get_vcs_link())
     @common.SKIPIF_BUILD_UNUSABLE
+    @pytest.mark.smoke
     @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_build_tx_metadata_cbor(
@@ -412,6 +421,7 @@ class TestMetadata:
             ), "Metadata in db-sync doesn't match the original metadata"
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.smoke
     @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_tx_metadata_both(
@@ -463,6 +473,7 @@ class TestMetadata:
 
     @allure.link(helpers.get_vcs_link())
     @common.SKIPIF_BUILD_UNUSABLE
+    @pytest.mark.smoke
     @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_build_tx_metadata_both(
@@ -524,6 +535,7 @@ class TestMetadata:
             ), "Metadata in db-sync doesn't match the original metadata"
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_tx_duplicate_metadata_keys(
         self, cluster: clusterlib.ClusterLib, payment_addr: clusterlib.AddressRecord
@@ -572,6 +584,7 @@ class TestMetadata:
             ), "Metadata in db-sync doesn't match the original metadata"
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.smoke
     @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_tx_metadata_no_txout(

--- a/cardano_node_tests/tests/test_tx_negative.py
+++ b/cardano_node_tests/tests/test_tx_negative.py
@@ -34,7 +34,6 @@ LOGGER = logging.getLogger(__name__)
 ADDR_ALPHABET = list(f"{string.ascii_lowercase}{string.digits}")
 
 
-@pytest.mark.smoke
 class TestNegative:
     """Transaction tests that are expected to fail."""
 
@@ -304,6 +303,7 @@ class TestNegative:
 
     @allure.link(helpers.get_vcs_link())
     @common.PARAM_USE_BUILD_CMD
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_past_ttl(
         self,
@@ -330,6 +330,7 @@ class TestNegative:
         reason="runs only with Allegra+ TX",
     )
     @common.PARAM_USE_BUILD_CMD
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_before_negative_overflow(
         self,
@@ -381,6 +382,7 @@ class TestNegative:
         reason="runs only with Allegra+ TX",
     )
     @common.PARAM_USE_BUILD_CMD
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_before_positive_overflow(
         self,
@@ -433,6 +435,7 @@ class TestNegative:
         reason="runs only with Allegra+ TX",
     )
     @common.PARAM_USE_BUILD_CMD
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_before_too_high(
         self,
@@ -470,6 +473,7 @@ class TestNegative:
     @hypothesis.example(before_value=common.MAX_INT64)
     @common.hypothesis_settings(max_examples=200)
     @common.PARAM_USE_BUILD_CMD
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_pbt_before_negative_overflow(
         self,
@@ -516,6 +520,7 @@ class TestNegative:
     @hypothesis.example(before_value=common.MAX_UINT64)
     @common.hypothesis_settings(max_examples=200)
     @common.PARAM_USE_BUILD_CMD
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_pbt_before_positive_overflow(
         self,
@@ -563,6 +568,7 @@ class TestNegative:
     @hypothesis.example(before_value=common.MAX_UINT64)
     @common.hypothesis_settings(max_examples=200)
     @common.PARAM_USE_BUILD_CMD
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_pbt_before_too_high(
         self,
@@ -589,6 +595,7 @@ class TestNegative:
         assert slot_no == before_value, f"SlotNo: {slot_no}, `before_value`: {before_value}"
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_duplicated_tx(
         self,
@@ -646,6 +653,7 @@ class TestNegative:
         assert "ValueNotConservedUTxO" in str(excinfo.value)
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_wrong_network_magic(
         self,
@@ -715,6 +723,7 @@ class TestNegative:
         assert "HandshakeError" in str(excinfo.value)
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_wrong_signing_key(
         self,
@@ -742,6 +751,7 @@ class TestNegative:
         assert "MissingVKeyWitnessesUTXOW" in str(excinfo.value)
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_wrong_tx_era(
         self,
@@ -774,6 +784,7 @@ class TestNegative:
 
     @allure.link(helpers.get_vcs_link())
     @common.PARAM_USE_BUILD_CMD
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_send_funds_to_reward_address(
         self,
@@ -798,6 +809,7 @@ class TestNegative:
 
     @allure.link(helpers.get_vcs_link())
     @common.PARAM_USE_BUILD_CMD
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_send_funds_to_utxo_address(
         self,
@@ -824,6 +836,7 @@ class TestNegative:
     @allure.link(helpers.get_vcs_link())
     @hypothesis.given(addr=st.text(alphabet=ADDR_ALPHABET, min_size=98, max_size=98))
     @common.hypothesis_settings(300)
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_send_funds_to_invalid_address(
         self,
@@ -846,6 +859,7 @@ class TestNegative:
     @common.SKIPIF_BUILD_UNUSABLE
     @hypothesis.given(addr=st.text(alphabet=ADDR_ALPHABET, min_size=98, max_size=98))
     @common.hypothesis_settings(300)
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_build_send_funds_to_invalid_address(
         self,
@@ -873,6 +887,7 @@ class TestNegative:
     @allure.link(helpers.get_vcs_link())
     @hypothesis.given(addr=st.text(alphabet=ADDR_ALPHABET, min_size=50, max_size=250))
     @common.hypothesis_settings(300)
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_send_funds_to_invalid_length_address(
         self,
@@ -895,6 +910,7 @@ class TestNegative:
     @common.SKIPIF_BUILD_UNUSABLE
     @hypothesis.given(addr=st.text(alphabet=ADDR_ALPHABET, min_size=50, max_size=250))
     @common.hypothesis_settings(300)
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_build_send_funds_to_invalid_length_address(
         self,
@@ -924,6 +940,7 @@ class TestNegative:
         addr=st.text(alphabet=st.characters(blacklist_categories=["C"]), min_size=98, max_size=98)
     )
     @common.hypothesis_settings(300)
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_send_funds_to_invalid_chars_address(
         self,
@@ -948,6 +965,7 @@ class TestNegative:
         addr=st.text(alphabet=st.characters(blacklist_categories=["C"]), min_size=98, max_size=98)
     )
     @common.hypothesis_settings(300)
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_build_send_funds_to_invalid_chars_address(
         self,
@@ -975,6 +993,7 @@ class TestNegative:
     @allure.link(helpers.get_vcs_link())
     @hypothesis.given(addr=st.text(alphabet=ADDR_ALPHABET, min_size=98, max_size=98))
     @common.hypothesis_settings(300)
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_send_funds_from_invalid_address(
         self,
@@ -997,6 +1016,7 @@ class TestNegative:
     @common.SKIPIF_BUILD_UNUSABLE
     @hypothesis.given(addr=st.text(alphabet=ADDR_ALPHABET, min_size=98, max_size=98))
     @common.hypothesis_settings(300)
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_build_send_funds_from_invalid_address(
         self,
@@ -1024,6 +1044,7 @@ class TestNegative:
     @allure.link(helpers.get_vcs_link())
     @hypothesis.given(addr=st.text(alphabet=ADDR_ALPHABET, min_size=50, max_size=250))
     @common.hypothesis_settings(300)
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_send_funds_from_invalid_length_address(
         self,
@@ -1046,6 +1067,7 @@ class TestNegative:
     @common.SKIPIF_BUILD_UNUSABLE
     @hypothesis.given(addr=st.text(alphabet=ADDR_ALPHABET, min_size=50, max_size=250))
     @common.hypothesis_settings(300)
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_build_send_funds_from_invalid_length_address(
         self,
@@ -1075,6 +1097,7 @@ class TestNegative:
         addr=st.text(alphabet=st.characters(blacklist_categories=["C"]), min_size=98, max_size=98)
     )
     @common.hypothesis_settings(300)
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_send_funds_from_invalid_chars_address(
         self,
@@ -1099,6 +1122,7 @@ class TestNegative:
         addr=st.text(alphabet=st.characters(blacklist_categories=["C"]), min_size=98, max_size=98)
     )
     @common.hypothesis_settings(300)
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_build_send_funds_from_invalid_chars_address(
         self,
@@ -1127,6 +1151,7 @@ class TestNegative:
     @common.SKIPIF_BUILD_UNUSABLE
     @hypothesis.given(addr=st.text(alphabet=ADDR_ALPHABET, min_size=98, max_size=98))
     @common.hypothesis_settings(300)
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_build_send_funds_invalid_change_address(
         self,
@@ -1153,6 +1178,7 @@ class TestNegative:
         addr=st.text(alphabet=st.characters(blacklist_categories=["C"]), min_size=98, max_size=98)
     )
     @common.hypothesis_settings(300)
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_build_send_funds_invalid_chars_change_address(
         self,
@@ -1177,6 +1203,7 @@ class TestNegative:
     @common.SKIPIF_BUILD_UNUSABLE
     @hypothesis.given(addr=st.text(alphabet=ADDR_ALPHABET, min_size=50, max_size=250))
     @common.hypothesis_settings(300)
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_build_send_funds_invalid_length_change_address(
         self,
@@ -1199,6 +1226,7 @@ class TestNegative:
 
     @allure.link(helpers.get_vcs_link())
     @common.PARAM_USE_BUILD_CMD
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_nonexistent_utxo_ix(
         self,
@@ -1232,6 +1260,7 @@ class TestNegative:
 
     @allure.link(helpers.get_vcs_link())
     @common.PARAM_USE_BUILD_CMD
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_nonexistent_utxo_hash(
         self,
@@ -1267,6 +1296,7 @@ class TestNegative:
     @allure.link(helpers.get_vcs_link())
     @hypothesis.given(utxo_hash=st.text(alphabet=ADDR_ALPHABET, min_size=10, max_size=550))
     @common.hypothesis_settings(300)
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_invalid_length_utxo_hash(
         self,
@@ -1295,6 +1325,7 @@ class TestNegative:
     @common.SKIPIF_BUILD_UNUSABLE
     @hypothesis.given(utxo_hash=st.text(alphabet=ADDR_ALPHABET, min_size=10, max_size=550))
     @common.hypothesis_settings(300)
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_build_invalid_length_utxo_hash(
         self,
@@ -1326,6 +1357,7 @@ class TestNegative:
         )
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_missing_fee(
         self,
@@ -1384,6 +1416,7 @@ class TestNegative:
         VERSIONS.transaction_era != VERSIONS.SHELLEY or VERSIONS.node >= version.parse("8.7.0"),
         reason="runs only with Shelley TX on node < 8.7.0",
     )
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_missing_ttl(
         self,
@@ -1430,6 +1463,7 @@ class TestNegative:
         ), err_str
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_missing_tx_in(
         self,
@@ -1473,6 +1507,7 @@ class TestNegative:
         VERSIONS.transaction_era != VERSIONS.SHELLEY,
         reason="runs only with Shelley TX",
     )
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_lower_bound_not_supported(
         self,
@@ -1510,6 +1545,7 @@ class TestNegative:
 
     @allure.link(helpers.get_vcs_link())
     @common.SKIPIF_BUILD_UNUSABLE
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_build_missing_tx_in(
         self,
@@ -1553,6 +1589,7 @@ class TestNegative:
 
     @allure.link(helpers.get_vcs_link())
     @common.SKIPIF_BUILD_UNUSABLE
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_build_missing_change_address(
         self,
@@ -1595,6 +1632,7 @@ class TestNegative:
 
     @allure.link(helpers.get_vcs_link())
     @common.SKIPIF_BUILD_UNUSABLE
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_build_multiple_change_addresses(
         self,

--- a/cardano_node_tests/tests/test_tx_unbalanced.py
+++ b/cardano_node_tests/tests/test_tx_unbalanced.py
@@ -22,7 +22,6 @@ LOGGER = logging.getLogger(__name__)
 MAX_LOVELACE_AMOUNT = common.MAX_UINT64
 
 
-@pytest.mark.smoke
 class TestUnbalanced:
     """Tests for unbalanced transactions."""
 
@@ -105,6 +104,7 @@ class TestUnbalanced:
         return cluster.g_query.get_utxo_with_highest_amount(payment_addrs[0].address)
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_negative_change(
         self,
@@ -168,6 +168,7 @@ class TestUnbalanced:
     @hypothesis.given(transfer_add=st.integers(min_value=1, max_value=MAX_LOVELACE_AMOUNT // 2))
     @hypothesis.example(transfer_add=1)
     @common.hypothesis_settings(100)
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_build_transfer_unavailable_funds(
         self,
@@ -212,6 +213,7 @@ class TestUnbalanced:
     @hypothesis.example(change_amount=2_000_000)
     @hypothesis.example(change_amount=MAX_LOVELACE_AMOUNT)
     @common.hypothesis_settings(300)
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_wrong_balance(
         self,
@@ -272,6 +274,7 @@ class TestUnbalanced:
     @hypothesis.example(change_amount=2_000_000)
     @hypothesis.example(change_amount=MAX_LOVELACE_AMOUNT + 1)
     @common.hypothesis_settings(300)
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_out_of_bounds_amount(
         self,
@@ -316,6 +319,7 @@ class TestUnbalanced:
     @hypothesis.example(amount=0)
     @hypothesis.example(amount=tx_common.MIN_UTXO_VALUE[1] - 1_000)
     @common.hypothesis_settings(max_examples=200)
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_build_transfer_amount_bellow_minimum(
         self,
@@ -346,6 +350,7 @@ class TestUnbalanced:
     @hypothesis.example(amount=-MAX_LOVELACE_AMOUNT)
     @hypothesis.example(amount=-1)
     @common.hypothesis_settings(max_examples=300)
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_build_transfer_negative_amount(
         self,
@@ -378,6 +383,7 @@ class TestUnbalanced:
     @hypothesis.example(amount=0)
     @hypothesis.example(amount=tx_common.MIN_UTXO_VALUE[1] - 1_000)
     @common.hypothesis_settings(max_examples=400)
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_transfer_amount_bellow_minimum(
         self,
@@ -440,6 +446,7 @@ class TestUnbalanced:
     @hypothesis.example(amount=-1)
     @hypothesis.example(amount=-MAX_LOVELACE_AMOUNT)
     @common.hypothesis_settings(max_examples=500)
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_transfer_negative_amount(
         self,

--- a/cardano_node_tests/tests/tests_conway/test_conway.py
+++ b/cardano_node_tests/tests/tests_conway/test_conway.py
@@ -19,11 +19,11 @@ pytestmark = pytest.mark.skipif(
 )
 
 
-@pytest.mark.smoke
 class TestConway:
     """General tests for Conway era."""
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_protocol_mode(self, cluster: clusterlib.ClusterLib):
         """Check that the `create-genesis-key-delegation-certificate` command is not available."""

--- a/cardano_node_tests/tests/tests_plutus/test_mint_build.py
+++ b/cardano_node_tests/tests/tests_plutus/test_mint_build.py
@@ -30,7 +30,6 @@ LOGGER = logging.getLogger(__name__)
 pytestmark = [
     common.SKIPIF_BUILD_UNUSABLE,
     common.SKIPIF_PLUTUS_UNUSABLE,
-    pytest.mark.smoke,
     pytest.mark.plutus,
 ]
 
@@ -102,6 +101,7 @@ class TestBuildMinting:
     @allure.link(helpers.get_vcs_link())
     @submit_utils.PARAM_SUBMIT_METHOD
     @common.PARAM_PLUTUS3_VERSION
+    @pytest.mark.smoke
     @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_minting_one_token(
@@ -243,6 +243,7 @@ class TestBuildMinting:
     @allure.link(helpers.get_vcs_link())
     @submit_utils.PARAM_SUBMIT_METHOD
     @common.PARAM_PLUTUS3_VERSION
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_minting_missing_txout(
         self,
@@ -359,6 +360,7 @@ class TestBuildMinting:
         ids=("plutus_v1", "plutus_v3"),
     )
     @submit_utils.PARAM_SUBMIT_METHOD
+    @pytest.mark.smoke
     @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_time_range_minting(
@@ -519,6 +521,7 @@ class TestBuildMinting:
             pytest.param("mix_v3_v1", marks=common.SKIPIF_PLUTUSV3_UNUSABLE),
         ),
     )
+    @pytest.mark.smoke
     @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_two_scripts_minting(
@@ -784,6 +787,7 @@ class TestBuildMinting:
     )
     @common.SKIPIF_MISMATCHED_ERAS
     @submit_utils.PARAM_SUBMIT_METHOD
+    @pytest.mark.smoke
     @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_minting_context_equivalence(
@@ -984,6 +988,7 @@ class TestBuildMinting:
         ),
         ids=("plutus_v1", "plutus_v3"),
     )
+    @pytest.mark.smoke
     @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_witness_redeemer(
@@ -1144,6 +1149,7 @@ class TestBuildMinting:
         (100, 1_000, 3_000, 10_000, 100_000, 1000_000, -1, -2),
     )
     @common.PARAM_PLUTUS3_VERSION
+    @pytest.mark.smoke
     def test_ttl_horizon(
         self,
         cluster: clusterlib.ClusterLib,
@@ -1262,6 +1268,7 @@ class TestCollateralOutput:
     @allure.link(helpers.get_vcs_link())
     @submit_utils.PARAM_SUBMIT_METHOD
     @common.PARAM_PLUTUS3_VERSION
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_duplicated_collateral(
         self,

--- a/cardano_node_tests/tests/tests_plutus/test_mint_negative_build.py
+++ b/cardano_node_tests/tests/tests_plutus/test_mint_negative_build.py
@@ -27,7 +27,6 @@ LOGGER = logging.getLogger(__name__)
 pytestmark = [
     common.SKIPIF_PLUTUS_UNUSABLE,
     common.SKIPIF_BUILD_UNUSABLE,
-    pytest.mark.smoke,
     pytest.mark.plutus,
 ]
 
@@ -88,7 +87,6 @@ class TestBuildMintingNegative:
         return mint_utxos, collateral_utxos, payment_addrs
 
     @allure.link(helpers.get_vcs_link())
-    @pytest.mark.testnets
     @pytest.mark.parametrize(
         "plutus_version",
         (
@@ -98,6 +96,8 @@ class TestBuildMintingNegative:
         ids=("plutus_v1", "plutus_v3"),
     )
     @submit_utils.PARAM_SUBMIT_METHOD
+    @pytest.mark.smoke
+    @pytest.mark.testnets
     def test_witness_redeemer_missing_signer(
         self,
         cluster: clusterlib.ClusterLib,
@@ -195,6 +195,7 @@ class TestBuildMintingNegative:
         ), str_err
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_redeemer_with_simple_minting_script(
         self,
@@ -294,6 +295,7 @@ class TestBuildMintingNegative:
         )
     )
     @common.hypothesis_settings(max_examples=300)
+    @pytest.mark.smoke
     def test_asset_name_too_long(
         self,
         cluster: clusterlib.ClusterLib,
@@ -373,6 +375,7 @@ class TestBuildMintingNegative:
         ),
         ids=("plutus_v1", "plutus_v3"),
     )
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_time_range_missing_tx_validity(
         self,

--- a/cardano_node_tests/tests/tests_plutus/test_mint_negative_raw.py
+++ b/cardano_node_tests/tests/tests_plutus/test_mint_negative_raw.py
@@ -23,7 +23,6 @@ LOGGER = logging.getLogger(__name__)
 
 pytestmark = [
     common.SKIPIF_PLUTUS_UNUSABLE,
-    pytest.mark.smoke,
     pytest.mark.plutus,
 ]
 
@@ -105,6 +104,7 @@ class TestMintingNegative:
         ),
         ids=("plutus_v1", "plutus_v3"),
     )
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_witness_redeemer_missing_signer(
         self,
@@ -200,8 +200,9 @@ class TestMintingNegative:
         ), str_err
 
     @allure.link(helpers.get_vcs_link())
-    @pytest.mark.testnets
     @common.PARAM_PLUTUS3_VERSION
+    @pytest.mark.smoke
+    @pytest.mark.testnets
     def test_low_budget(
         self,
         cluster: clusterlib.ClusterLib,
@@ -297,8 +298,9 @@ class TestMintingNegative:
         ), err_str
 
     @allure.link(helpers.get_vcs_link())
-    @pytest.mark.testnets
     @common.PARAM_PLUTUS3_VERSION
+    @pytest.mark.smoke
+    @pytest.mark.testnets
     def test_low_fee(
         self,
         cluster: clusterlib.ClusterLib,
@@ -391,7 +393,6 @@ class TestMintingNegative:
         assert "FeeTooSmallUTxO" in str(excinfo.value)
 
     @allure.link(helpers.get_vcs_link())
-    @pytest.mark.testnets
     @hypothesis.given(data=st.data())
     @common.hypothesis_settings(100)
     @pytest.mark.parametrize(
@@ -400,6 +401,8 @@ class TestMintingNegative:
         ids=("plutus_v1", "plutus_v2"),
         indirect=True,
     )
+    @pytest.mark.smoke
+    @pytest.mark.testnets
     def test_execution_units_above_limit(
         self,
         cluster: clusterlib.ClusterLib,
@@ -516,6 +519,7 @@ class TestMintingNegative:
         ),
         ids=("plutus_v1", "plutus_v3"),
     )
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_time_range_missing_tx_validity(
         self,
@@ -620,8 +624,9 @@ class TestNegativeCollateral:
     """Tests for collaterals that are expected to fail."""
 
     @allure.link(helpers.get_vcs_link())
-    @pytest.mark.testnets
     @common.PARAM_PLUTUS3_VERSION
+    @pytest.mark.smoke
+    @pytest.mark.testnets
     def test_minting_with_invalid_collaterals(
         self,
         cluster: clusterlib.ClusterLib,
@@ -720,8 +725,9 @@ class TestNegativeCollateral:
         assert "NoCollateralInputs" in str(excinfo.value)
 
     @allure.link(helpers.get_vcs_link())
-    @pytest.mark.testnets
     @common.PARAM_PLUTUS3_VERSION
+    @pytest.mark.smoke
+    @pytest.mark.testnets
     def test_minting_with_insufficient_collateral(
         self,
         cluster: clusterlib.ClusterLib,

--- a/cardano_node_tests/tests/tests_plutus/test_mint_raw.py
+++ b/cardano_node_tests/tests/tests_plutus/test_mint_raw.py
@@ -26,7 +26,6 @@ LOGGER = logging.getLogger(__name__)
 
 pytestmark = [
     common.SKIPIF_PLUTUS_UNUSABLE,
-    pytest.mark.smoke,
     pytest.mark.plutus,
 ]
 
@@ -104,9 +103,10 @@ class TestMinting:
     """Tests for minting using Plutus smart contracts."""
 
     @allure.link(helpers.get_vcs_link())
-    @pytest.mark.dbsync
-    @pytest.mark.testnets
     @common.PARAM_PLUTUS3_VERSION
+    @pytest.mark.smoke
+    @pytest.mark.testnets
+    @pytest.mark.dbsync
     def test_minting_two_tokens(
         self,
         cluster: clusterlib.ClusterLib,
@@ -236,8 +236,6 @@ class TestMinting:
             pytest.fail(utxo_err)
 
     @allure.link(helpers.get_vcs_link())
-    @pytest.mark.dbsync
-    @pytest.mark.testnets
     @pytest.mark.parametrize(
         "key",
         (
@@ -253,6 +251,9 @@ class TestMinting:
         ),
         ids=("plutus_v1", "plutus_v3"),
     )
+    @pytest.mark.smoke
+    @pytest.mark.testnets
+    @pytest.mark.dbsync
     def test_witness_redeemer(
         self,
         cluster: clusterlib.ClusterLib,
@@ -383,8 +384,9 @@ class TestMinting:
         ),
         ids=("plutus_v1", "plutus_v3"),
     )
-    @pytest.mark.dbsync
+    @pytest.mark.smoke
     @pytest.mark.testnets
+    @pytest.mark.dbsync
     def test_time_range_minting(
         self,
         cluster: clusterlib.ClusterLib,
@@ -502,8 +504,6 @@ class TestMinting:
         dbsync_utils.check_tx(cluster_obj=cluster, tx_raw_output=tx_raw_output_step2)
 
     @allure.link(helpers.get_vcs_link())
-    @pytest.mark.dbsync
-    @pytest.mark.testnets
     @pytest.mark.parametrize(
         "plutus_version",
         (
@@ -512,6 +512,9 @@ class TestMinting:
             pytest.param("mix_v3_v1", marks=common.SKIPIF_PLUTUSV3_UNUSABLE),
         ),
     )
+    @pytest.mark.smoke
+    @pytest.mark.testnets
+    @pytest.mark.dbsync
     def test_two_scripts_minting(
         self,
         cluster: clusterlib.ClusterLib,
@@ -732,8 +735,9 @@ class TestMinting:
         dbsync_utils.check_tx(cluster_obj=cluster, tx_raw_output=tx_raw_output_step2)
 
     @allure.link(helpers.get_vcs_link())
-    @pytest.mark.dbsync
+    @pytest.mark.smoke
     @pytest.mark.testnets
+    @pytest.mark.dbsync
     def test_minting_policy_executed_once1(
         self,
         cluster: clusterlib.ClusterLib,
@@ -889,8 +893,9 @@ class TestMinting:
         dbsync_utils.check_tx(cluster_obj=cluster, tx_raw_output=tx_raw_output_step2)
 
     @allure.link(helpers.get_vcs_link())
-    @pytest.mark.dbsync
+    @pytest.mark.smoke
     @pytest.mark.testnets
+    @pytest.mark.dbsync
     def test_minting_policy_executed_once2(
         self,
         cluster: clusterlib.ClusterLib,
@@ -1049,8 +1054,9 @@ class TestMinting:
         reason="cannot find `create-script-context` on the PATH",
     )
     @common.SKIPIF_MISMATCHED_ERAS
-    @pytest.mark.dbsync
+    @pytest.mark.smoke
     @pytest.mark.testnets
+    @pytest.mark.dbsync
     def test_minting_context_equivalence(
         self, cluster: clusterlib.ClusterLib, payment_addrs: tp.List[clusterlib.AddressRecord]
     ):
@@ -1204,6 +1210,7 @@ class TestMinting:
         (100, 1_000, 3_000, 10_000, 100_000, 1000_000, -1, -2),
     )
     @common.PARAM_PLUTUS3_VERSION
+    @pytest.mark.smoke
     def test_ttl_horizon(
         self,
         cluster: clusterlib.ClusterLib,
@@ -1347,6 +1354,7 @@ class TestCollateralOutput:
 
     @allure.link(helpers.get_vcs_link())
     @common.PARAM_PLUTUS3_VERSION
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_duplicated_collateral(
         self,

--- a/cardano_node_tests/tests/tests_plutus/test_spend_build.py
+++ b/cardano_node_tests/tests/tests_plutus/test_spend_build.py
@@ -25,7 +25,6 @@ LOGGER = logging.getLogger(__name__)
 pytestmark = [
     common.SKIPIF_BUILD_UNUSABLE,
     common.SKIPIF_PLUTUS_UNUSABLE,
-    pytest.mark.smoke,
     pytest.mark.plutus,
 ]
 
@@ -82,6 +81,7 @@ class TestBuildLocking:
 
     @allure.link(helpers.get_vcs_link())
     @common.PARAM_PLUTUS3_VERSION
+    @pytest.mark.smoke
     @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_txout_locking(
@@ -150,6 +150,7 @@ class TestBuildLocking:
         reason="cannot find `create-script-context` on the PATH",
     )
     @common.SKIPIF_MISMATCHED_ERAS
+    @pytest.mark.smoke
     @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_context_equivalence(
@@ -265,6 +266,7 @@ class TestBuildLocking:
         ("typed_json", "typed_cbor", "untyped_value", "untyped_json", "untyped_cbor"),
     )
     @common.PARAM_PLUTUS_VERSION
+    @pytest.mark.smoke
     @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_guessing_game(
@@ -377,6 +379,7 @@ class TestBuildLocking:
             pytest.param("plutus_v2", marks=common.SKIPIF_PLUTUSV2_UNUSABLE),
         ),
     )
+    @pytest.mark.smoke
     @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_two_scripts_spending(
@@ -638,6 +641,7 @@ class TestBuildLocking:
 
     @allure.link(helpers.get_vcs_link())
     @common.PARAM_PLUTUS3_VERSION
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_always_fails(
         self,
@@ -695,6 +699,7 @@ class TestBuildLocking:
 
     @allure.link(helpers.get_vcs_link())
     @common.PARAM_PLUTUS3_VERSION
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_script_invalid(
         self,
@@ -772,6 +777,7 @@ class TestBuildLocking:
 
     @allure.link(helpers.get_vcs_link())
     @common.PARAM_PLUTUS3_VERSION
+    @pytest.mark.smoke
     @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_txout_token_locking(
@@ -850,6 +856,7 @@ class TestBuildLocking:
 
     @allure.link(helpers.get_vcs_link())
     @common.PARAM_PLUTUS3_VERSION
+    @pytest.mark.smoke
     @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_partial_spending(
@@ -974,6 +981,7 @@ class TestBuildLocking:
 
     @allure.link(helpers.get_vcs_link())
     @common.PARAM_PLUTUS3_VERSION
+    @pytest.mark.smoke
     @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_collateral_is_txin(

--- a/cardano_node_tests/tests/tests_plutus/test_spend_compat_build.py
+++ b/cardano_node_tests/tests/tests_plutus/test_spend_compat_build.py
@@ -19,7 +19,6 @@ LOGGER = logging.getLogger(__name__)
 
 pytestmark = [
     common.SKIPIF_BUILD_UNUSABLE,
-    pytest.mark.smoke,
     pytest.mark.plutus,
 ]
 
@@ -55,6 +54,7 @@ class TestCompatibility:
         VERSIONS.transaction_era > VERSIONS.ALONZO,
         reason="doesn't run with Tx era > Alonzo",
     )
+    @pytest.mark.smoke
     @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_plutusv2_old_tx_era(

--- a/cardano_node_tests/tests/tests_plutus/test_spend_compat_raw.py
+++ b/cardano_node_tests/tests/tests_plutus/test_spend_compat_raw.py
@@ -18,7 +18,6 @@ from cardano_node_tests.utils.versions import VERSIONS
 LOGGER = logging.getLogger(__name__)
 
 pytestmark = [
-    pytest.mark.smoke,
     pytest.mark.plutus,
 ]
 
@@ -54,6 +53,7 @@ class TestCompatibility:
         VERSIONS.transaction_era > VERSIONS.ALONZO,
         reason="doesn't run with Tx era > Alonzo",
     )
+    @pytest.mark.smoke
     @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_plutusv2_old_tx_era(
@@ -107,6 +107,7 @@ class TestCompatibility:
         VERSIONS.transaction_era >= VERSIONS.ALONZO,
         reason="runs only with Tx era < Alonzo",
     )
+    @pytest.mark.smoke
     @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_plutusv1_old_tx_era(

--- a/cardano_node_tests/tests/tests_plutus/test_spend_datum_build.py
+++ b/cardano_node_tests/tests/tests_plutus/test_spend_datum_build.py
@@ -26,7 +26,6 @@ LOGGER = logging.getLogger(__name__)
 pytestmark = [
     common.SKIPIF_BUILD_UNUSABLE,
     common.SKIPIF_PLUTUS_UNUSABLE,
-    pytest.mark.smoke,
     pytest.mark.plutus,
 ]
 
@@ -58,6 +57,7 @@ class TestDatum:
     """Tests for datum."""
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.smoke
     @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_datum_on_key_credential_address(
@@ -107,6 +107,7 @@ class TestDatum:
 
     @allure.link(helpers.get_vcs_link())
     @common.PARAM_PLUTUS_VERSION
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_embed_datum_without_pparams(
         self,
@@ -193,6 +194,7 @@ class TestNegativeDatum:
     @allure.link(helpers.get_vcs_link())
     @pytest.mark.parametrize("address_type", ("script_address", "key_address"))
     @common.PARAM_PLUTUS_VERSION
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_no_datum_txout(
         self,
@@ -293,6 +295,7 @@ class TestNegativeDatum:
     @hypothesis.given(datum_value=st.text())
     @common.hypothesis_settings(max_examples=200)
     @common.PARAM_PLUTUS_VERSION
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_lock_tx_invalid_datum(
         self,
@@ -332,6 +335,7 @@ class TestNegativeDatum:
 
     @allure.link(helpers.get_vcs_link())
     @common.PARAM_PLUTUS_VERSION
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_unlock_tx_wrong_datum(
         self,
@@ -392,6 +396,7 @@ class TestNegativeDatum:
 
     @allure.link(helpers.get_vcs_link())
     @common.PARAM_PLUTUS_VERSION
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_unlock_non_script_utxo(
         self,
@@ -484,6 +489,7 @@ class TestNegativeDatum:
     @hypothesis.given(datum_value=st.binary(min_size=65))
     @common.hypothesis_settings(max_examples=100)
     @common.PARAM_PLUTUS_VERSION
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_too_big(
         self,

--- a/cardano_node_tests/tests/tests_plutus/test_spend_datum_raw.py
+++ b/cardano_node_tests/tests/tests_plutus/test_spend_datum_raw.py
@@ -23,7 +23,6 @@ LOGGER = logging.getLogger(__name__)
 
 pytestmark = [
     common.SKIPIF_PLUTUS_UNUSABLE,
-    pytest.mark.smoke,
     pytest.mark.plutus,
 ]
 
@@ -55,6 +54,7 @@ class TestDatum:
     """Tests for datum."""
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.smoke
     @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_datum_on_key_credential_address(
@@ -133,6 +133,7 @@ class TestNegativeDatum:
     @allure.link(helpers.get_vcs_link())
     @pytest.mark.parametrize("address_type", ("script_address", "key_address"))
     @common.PARAM_PLUTUS_VERSION
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_no_datum_txout(
         self,
@@ -216,6 +217,7 @@ class TestNegativeDatum:
     @hypothesis.given(datum_value=st.text())
     @common.hypothesis_settings(max_examples=200)
     @common.PARAM_PLUTUS_VERSION
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_lock_tx_invalid_datum(
         self,
@@ -260,6 +262,7 @@ class TestNegativeDatum:
 
     @allure.link(helpers.get_vcs_link())
     @common.PARAM_PLUTUS_VERSION
+    @pytest.mark.smoke
     def test_unlock_tx_wrong_datum(
         self,
         cluster: clusterlib.ClusterLib,
@@ -320,6 +323,7 @@ class TestNegativeDatum:
 
     @allure.link(helpers.get_vcs_link())
     @common.PARAM_PLUTUS_VERSION
+    @pytest.mark.smoke
     def test_unlock_non_script_utxo(
         self,
         cluster: clusterlib.ClusterLib,
@@ -411,6 +415,7 @@ class TestNegativeDatum:
     @hypothesis.given(datum_value=st.binary(min_size=65))
     @common.hypothesis_settings(max_examples=200)
     @common.PARAM_PLUTUS_VERSION
+    @pytest.mark.smoke
     def test_too_big(
         self,
         cluster: clusterlib.ClusterLib,

--- a/cardano_node_tests/tests/tests_plutus/test_spend_negative_build.py
+++ b/cardano_node_tests/tests/tests_plutus/test_spend_negative_build.py
@@ -24,7 +24,6 @@ LOGGER = logging.getLogger(__name__)
 pytestmark = [
     common.SKIPIF_BUILD_UNUSABLE,
     common.SKIPIF_PLUTUS_UNUSABLE,
-    pytest.mark.smoke,
     pytest.mark.plutus,
 ]
 
@@ -57,6 +56,7 @@ class TestNegative:
 
     @allure.link(helpers.get_vcs_link())
     @common.PARAM_PLUTUS_VERSION
+    @pytest.mark.smoke
     @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_wrong_script(
@@ -112,6 +112,7 @@ class TestNegative:
 
     @allure.link(helpers.get_vcs_link())
     @common.PARAM_PLUTUS_VERSION
+    @pytest.mark.smoke
     @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_no_script(
@@ -165,6 +166,7 @@ class TestNegative:
 
     @allure.link(helpers.get_vcs_link())
     @common.PARAM_PLUTUS3_VERSION
+    @pytest.mark.smoke
     @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_collateral_w_tokens(
@@ -235,6 +237,7 @@ class TestNegative:
 
     @allure.link(helpers.get_vcs_link())
     @common.PARAM_PLUTUS3_VERSION
+    @pytest.mark.smoke
     @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_same_collateral_txin(
@@ -308,6 +311,7 @@ class TestNegative:
         ),
     )
     @common.PARAM_PLUTUS_VERSION
+    @pytest.mark.smoke
     @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_invalid_guessing_game(
@@ -378,6 +382,7 @@ class TestNegative:
 
     @allure.link(helpers.get_vcs_link())
     @common.PARAM_PLUTUS3_VERSION
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_two_scripts_spending_one_fail(
         self,
@@ -649,6 +654,7 @@ class TestNegativeRedeemer:
     @hypothesis.example(redeemer_value=common.MAX_UINT64)
     @common.hypothesis_settings(max_examples=200)
     @common.PARAM_PLUTUS_VERSION
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_wrong_value_inside_range(
         self,
@@ -715,6 +721,7 @@ class TestNegativeRedeemer:
     @hypothesis.example(redeemer_value=common.MAX_UINT64 + 1)
     @common.hypothesis_settings(max_examples=200)
     @common.PARAM_PLUTUS_VERSION
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_wrong_value_above_range(
         self,
@@ -756,6 +763,7 @@ class TestNegativeRedeemer:
     @hypothesis.example(redeemer_value=MIN_INT_VAL - 1)
     @common.hypothesis_settings(max_examples=200)
     @common.PARAM_PLUTUS_VERSION
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_wrong_value_bellow_range(
         self,
@@ -796,6 +804,7 @@ class TestNegativeRedeemer:
     @hypothesis.given(redeemer_value=st.binary(max_size=64))
     @common.hypothesis_settings(max_examples=200)
     @common.PARAM_PLUTUS_VERSION
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_wrong_type(
         self,
@@ -853,6 +862,7 @@ class TestNegativeRedeemer:
     @hypothesis.given(redeemer_value=st.binary(min_size=65))
     @common.hypothesis_settings(max_examples=100)
     @common.PARAM_PLUTUS_VERSION
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_too_big(
         self,
@@ -913,6 +923,7 @@ class TestNegativeRedeemer:
     @hypothesis.given(redeemer_value=st.binary(max_size=64))
     @common.hypothesis_settings(max_examples=200)
     @common.PARAM_PLUTUS_VERSION
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_json_schema_typed_int_bytes_declared(
         self,
@@ -973,6 +984,7 @@ class TestNegativeRedeemer:
     @hypothesis.given(redeemer_value=st.binary(max_size=64))
     @common.hypothesis_settings(max_examples=200)
     @common.PARAM_PLUTUS_VERSION
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_json_schema_untyped_int_bytes_declared(
         self,
@@ -1033,6 +1045,7 @@ class TestNegativeRedeemer:
     @hypothesis.given(redeemer_value=st.integers())
     @common.hypothesis_settings(max_examples=200)
     @common.PARAM_PLUTUS_VERSION
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_json_schema_typed_bytes_int_declared(
         self,
@@ -1094,6 +1107,7 @@ class TestNegativeRedeemer:
     @hypothesis.given(redeemer_value=st.integers())
     @common.hypothesis_settings(max_examples=200)
     @common.PARAM_PLUTUS_VERSION
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_json_schema_untyped_bytes_int_declared(
         self,
@@ -1155,6 +1169,7 @@ class TestNegativeRedeemer:
     @hypothesis.given(redeemer_value=st.text())
     @common.hypothesis_settings(max_examples=200)
     @common.PARAM_PLUTUS_VERSION
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_invalid_json(
         self,
@@ -1212,6 +1227,7 @@ class TestNegativeRedeemer:
     @hypothesis.given(redeemer_type=st.text())
     @common.hypothesis_settings(max_examples=200)
     @common.PARAM_PLUTUS_VERSION
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_json_schema_typed_invalid_type(
         self,
@@ -1274,6 +1290,7 @@ class TestNegativeRedeemer:
     @hypothesis.given(redeemer_type=st.text())
     @common.hypothesis_settings(max_examples=200)
     @common.PARAM_PLUTUS_VERSION
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_json_schema_untyped_invalid_type(
         self,

--- a/cardano_node_tests/tests/tests_plutus/test_spend_negative_raw.py
+++ b/cardano_node_tests/tests/tests_plutus/test_spend_negative_raw.py
@@ -25,7 +25,6 @@ LOGGER = logging.getLogger(__name__)
 
 pytestmark = [
     common.SKIPIF_PLUTUS_UNUSABLE,
-    pytest.mark.smoke,
     pytest.mark.plutus,
 ]
 
@@ -106,6 +105,7 @@ class TestNegative:
         ),
     )
     @common.PARAM_PLUTUS_VERSION
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_invalid_guessing_game(
         self,
@@ -171,9 +171,10 @@ class TestNegative:
         assert "ValidationTagMismatch (IsValid True)" in err, err
 
     @allure.link(helpers.get_vcs_link())
-    @pytest.mark.dbsync
     @common.PARAM_PLUTUS_VERSION
+    @pytest.mark.smoke
     @pytest.mark.testnets
+    @pytest.mark.dbsync
     def test_wrong_script(
         self,
         cluster: clusterlib.ClusterLib,
@@ -228,9 +229,10 @@ class TestNegative:
         ), err_str
 
     @allure.link(helpers.get_vcs_link())
-    @pytest.mark.dbsync
     @common.PARAM_PLUTUS_VERSION
+    @pytest.mark.smoke
     @pytest.mark.testnets
+    @pytest.mark.dbsync
     def test_no_script(
         self,
         cluster: clusterlib.ClusterLib,
@@ -281,6 +283,7 @@ class TestNegative:
 
     @allure.link(helpers.get_vcs_link())
     @common.PARAM_PLUTUS3_VERSION
+    @pytest.mark.smoke
     @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_collateral_w_tokens(
@@ -347,6 +350,7 @@ class TestNegative:
 
     @allure.link(helpers.get_vcs_link())
     @common.PARAM_PLUTUS3_VERSION
+    @pytest.mark.smoke
     @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_same_collateral_txin(
@@ -400,6 +404,7 @@ class TestNegative:
 
     @allure.link(helpers.get_vcs_link())
     @common.PARAM_PLUTUS3_VERSION
+    @pytest.mark.smoke
     @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_collateral_percent(
@@ -458,6 +463,7 @@ class TestNegative:
 
     @allure.link(helpers.get_vcs_link())
     @common.PARAM_PLUTUS3_VERSION
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_two_scripts_spending_one_fail(
         self,
@@ -629,6 +635,7 @@ class TestNegative:
         ids=("plutus_v1", "plutus_v2"),
         indirect=True,
     )
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_execution_units_above_limit(
         self,
@@ -907,6 +914,7 @@ class TestNegativeRedeemer:
     @hypothesis.example(redeemer_value=common.MAX_UINT64)
     @common.hypothesis_settings(max_examples=200)
     @common.PARAM_PLUTUS_VERSION
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_wrong_value_inside_range(
         self,
@@ -993,6 +1001,7 @@ class TestNegativeRedeemer:
     @hypothesis.example(redeemer_value=MIN_INT_VAL - 1)
     @common.hypothesis_settings(max_examples=200)
     @common.PARAM_PLUTUS_VERSION
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_wrong_value_bellow_range(
         self,
@@ -1037,6 +1046,7 @@ class TestNegativeRedeemer:
     @hypothesis.example(redeemer_value=common.MAX_UINT64 + 1)
     @common.hypothesis_settings(max_examples=200)
     @common.PARAM_PLUTUS_VERSION
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_wrong_value_above_range(
         self,
@@ -1080,6 +1090,7 @@ class TestNegativeRedeemer:
     @hypothesis.given(redeemer_value=st.binary(max_size=64))
     @common.hypothesis_settings(max_examples=200)
     @common.PARAM_PLUTUS_VERSION
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_wrong_type(
         self,
@@ -1158,6 +1169,7 @@ class TestNegativeRedeemer:
     @hypothesis.given(redeemer_value=st.binary(min_size=65))
     @common.hypothesis_settings(max_examples=200)
     @common.PARAM_PLUTUS_VERSION
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_too_big(
         self,
@@ -1235,6 +1247,7 @@ class TestNegativeRedeemer:
     @hypothesis.given(redeemer_value=st.binary(max_size=64))
     @common.hypothesis_settings(max_examples=200)
     @common.PARAM_PLUTUS_VERSION
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_json_schema_typed_int_bytes_declared(
         self,
@@ -1276,6 +1289,7 @@ class TestNegativeRedeemer:
     @hypothesis.given(redeemer_value=st.binary(max_size=64))
     @common.hypothesis_settings(max_examples=200)
     @common.PARAM_PLUTUS_VERSION
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_json_schema_untyped_int_bytes_declared(
         self,
@@ -1316,6 +1330,7 @@ class TestNegativeRedeemer:
     @hypothesis.given(redeemer_value=st.integers())
     @common.hypothesis_settings(max_examples=200)
     @common.PARAM_PLUTUS_VERSION
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_json_schema_typed_bytes_int_declared(
         self,
@@ -1356,6 +1371,7 @@ class TestNegativeRedeemer:
     @hypothesis.given(redeemer_value=st.integers())
     @common.hypothesis_settings(max_examples=200)
     @common.PARAM_PLUTUS_VERSION
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_json_schema_untyped_bytes_int_declared(
         self,
@@ -1396,6 +1412,7 @@ class TestNegativeRedeemer:
     @hypothesis.given(redeemer_value=st.text())
     @common.hypothesis_settings(max_examples=200)
     @common.PARAM_PLUTUS_VERSION
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_invalid_json(
         self,
@@ -1436,6 +1453,7 @@ class TestNegativeRedeemer:
     @hypothesis.given(redeemer_type=st.text())
     @common.hypothesis_settings(max_examples=200)
     @common.PARAM_PLUTUS_VERSION
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_json_schema_typed_invalid_type(
         self,
@@ -1482,6 +1500,7 @@ class TestNegativeRedeemer:
     @hypothesis.given(redeemer_type=st.text())
     @common.hypothesis_settings(max_examples=200)
     @common.PARAM_PLUTUS_VERSION
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_json_schema_untyped_invalid_type(
         self,

--- a/cardano_node_tests/tests/tests_plutus/test_spend_raw.py
+++ b/cardano_node_tests/tests/tests_plutus/test_spend_raw.py
@@ -29,7 +29,6 @@ LOGGER = logging.getLogger(__name__)
 
 pytestmark = [
     common.SKIPIF_PLUTUS_UNUSABLE,
-    pytest.mark.smoke,
     pytest.mark.plutus,
 ]
 
@@ -134,6 +133,7 @@ class TestLocking:
 
     @allure.link(helpers.get_vcs_link())
     @common.PARAM_PLUTUS3_VERSION
+    @pytest.mark.smoke
     @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_txout_locking(
@@ -192,6 +192,7 @@ class TestLocking:
         reason="cannot find `create-script-context` on the PATH",
     )
     @common.SKIPIF_MISMATCHED_ERAS
+    @pytest.mark.smoke
     @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_context_equivalence(
@@ -304,6 +305,7 @@ class TestLocking:
         ),
     )
     @common.PARAM_PLUTUS_VERSION
+    @pytest.mark.smoke
     @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_guessing_game(
@@ -404,6 +406,7 @@ class TestLocking:
             pytest.param("plutus_v2", marks=common.SKIPIF_PLUTUSV2_UNUSABLE),
         ),
     )
+    @pytest.mark.smoke
     @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_two_scripts_spending(
@@ -633,6 +636,7 @@ class TestLocking:
 
     @allure.link(helpers.get_vcs_link())
     @common.PARAM_PLUTUS3_VERSION
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_always_fails(
         self,
@@ -692,6 +696,7 @@ class TestLocking:
 
     @allure.link(helpers.get_vcs_link())
     @common.PARAM_PLUTUS3_VERSION
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_script_invalid(
         self,
@@ -757,6 +762,7 @@ class TestLocking:
 
     @allure.link(helpers.get_vcs_link())
     @common.PARAM_PLUTUS3_VERSION
+    @pytest.mark.smoke
     @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_txout_token_locking(
@@ -819,6 +825,7 @@ class TestLocking:
 
     @allure.link(helpers.get_vcs_link())
     @common.PARAM_PLUTUS3_VERSION
+    @pytest.mark.smoke
     @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_partial_spending(
@@ -910,6 +917,7 @@ class TestLocking:
     @allure.link(helpers.get_vcs_link())
     @pytest.mark.parametrize("scenario", ("max", "max+1", "none"))
     @common.PARAM_PLUTUS3_VERSION
+    @pytest.mark.smoke
     @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_collaterals(

--- a/cardano_node_tests/tests/tests_plutus_v2/test_mint_build.py
+++ b/cardano_node_tests/tests/tests_plutus_v2/test_mint_build.py
@@ -22,7 +22,6 @@ LOGGER = logging.getLogger(__name__)
 pytestmark = [
     common.SKIPIF_BUILD_UNUSABLE,
     common.SKIPIF_PLUTUSV2_UNUSABLE,
-    pytest.mark.smoke,
     pytest.mark.plutus,
 ]
 
@@ -105,6 +104,7 @@ class TestBuildMinting:
 
     @allure.link(helpers.get_vcs_link())
     @common.PARAM_PLUTUS2ONWARDS_VERSION
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_minting_ref_one_token(
         self,
@@ -249,6 +249,7 @@ class TestBuildMinting:
 
     @allure.link(helpers.get_vcs_link())
     @common.PARAM_PLUTUS2ONWARDS_VERSION
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_minting_ref_missing_txout(
         self,
@@ -360,6 +361,7 @@ class TestBuildMinting:
     @pytest.mark.parametrize(
         "valid_redeemer", (True, False), ids=("right_redeemer", "wrong_redeemer")
     )
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_reference_inputs_visibility(
         self,
@@ -506,6 +508,7 @@ class TestBuildMinting:
     @pytest.mark.parametrize(
         "valid_redeemer", (True, False), ids=("right_redeemer", "wrong_redeemer")
     )
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_reference_scripts_visibility(
         self,
@@ -636,6 +639,7 @@ class TestBuildMinting:
         "scenario",
         ("reference_script", "readonly_reference_input", "different_datum"),
     )
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_inline_datum_visibility(
         self,

--- a/cardano_node_tests/tests/tests_plutus_v2/test_mint_negative_build.py
+++ b/cardano_node_tests/tests/tests_plutus_v2/test_mint_negative_build.py
@@ -19,7 +19,6 @@ LOGGER = logging.getLogger(__name__)
 pytestmark = [
     common.SKIPIF_BUILD_UNUSABLE,
     common.SKIPIF_PLUTUSV2_UNUSABLE,
-    pytest.mark.smoke,
     pytest.mark.plutus,
 ]
 
@@ -57,6 +56,7 @@ class TestNegativeCollateralOutput:
         ids=("with_return_collateral", "without_return_collateral"),
     )
     @common.PARAM_PLUTUS2ONWARDS_VERSION
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_minting_with_unbalanced_total_collateral(
         self,

--- a/cardano_node_tests/tests/tests_plutus_v2/test_mint_negative_raw.py
+++ b/cardano_node_tests/tests/tests_plutus_v2/test_mint_negative_raw.py
@@ -18,7 +18,6 @@ LOGGER = logging.getLogger(__name__)
 
 pytestmark = [
     common.SKIPIF_PLUTUSV2_UNUSABLE,
-    pytest.mark.smoke,
     pytest.mark.plutus,
 ]
 
@@ -51,6 +50,7 @@ class TestNegativeCollateralOutput:
 
     @allure.link(helpers.get_vcs_link())
     @common.PARAM_PLUTUS2ONWARDS_VERSION
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_minting_with_limited_collateral(
         self,
@@ -168,6 +168,7 @@ class TestNegativeCollateralOutput:
         ids=("with_return_collateral", "without_return_collateral"),
     )
     @common.PARAM_PLUTUS2ONWARDS_VERSION
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_minting_with_unbalanced_total_collateral(
         self,

--- a/cardano_node_tests/tests/tests_plutus_v2/test_mint_raw.py
+++ b/cardano_node_tests/tests/tests_plutus_v2/test_mint_raw.py
@@ -22,7 +22,6 @@ LOGGER = logging.getLogger(__name__)
 
 pytestmark = [
     common.SKIPIF_PLUTUSV2_UNUSABLE,
-    pytest.mark.smoke,
     pytest.mark.plutus,
 ]
 
@@ -98,6 +97,7 @@ class TestMinting:
         "use_reference_script", (True, False), ids=("reference_script", "script_file")
     )
     @common.PARAM_PLUTUS2ONWARDS_VERSION
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_minting_two_tokens(
         self,
@@ -234,6 +234,7 @@ class TestMinting:
     @pytest.mark.parametrize(
         "scenario", ("reference_script", "readonly_reference_input", "different_datum")
     )
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_datum_hash_visibility(
         self,
@@ -387,6 +388,7 @@ class TestMinting:
         ), "Reference UTxO was spent"
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.smoke
     def test_missing_builtin(
         self,
         cluster: clusterlib.ClusterLib,

--- a/cardano_node_tests/tests/tests_plutus_v2/test_mint_secp256k1_build.py
+++ b/cardano_node_tests/tests/tests_plutus_v2/test_mint_secp256k1_build.py
@@ -20,7 +20,6 @@ LOGGER = logging.getLogger(__name__)
 pytestmark = [
     common.SKIPIF_BUILD_UNUSABLE,
     common.SKIPIF_PLUTUSV2_UNUSABLE,
-    pytest.mark.smoke,
     pytest.mark.plutus,
 ]
 
@@ -135,6 +134,7 @@ class TestSECP256k1:
     @allure.link(helpers.get_vcs_link())
     @common.PARAM_PLUTUS2ONWARDS_VERSION
     @pytest.mark.parametrize("algorithm", ("ecdsa", "schnorr"))
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_use_secp_builtin_functions(
         self,
@@ -211,6 +211,7 @@ class TestSECP256k1:
         ("invalid_sig", "invalid_pubkey", "no_msg", "no_pubkey", "no_sig"),
     )
     @pytest.mark.parametrize("algorithm", ("ecdsa", "schnorr"))
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_negative_secp_builtin_functions(
         self,

--- a/cardano_node_tests/tests/tests_plutus_v2/test_mint_secp256k1_raw.py
+++ b/cardano_node_tests/tests/tests_plutus_v2/test_mint_secp256k1_raw.py
@@ -20,7 +20,6 @@ LOGGER = logging.getLogger(__name__)
 
 pytestmark = [
     common.SKIPIF_PLUTUSV2_UNUSABLE,
-    pytest.mark.smoke,
     pytest.mark.plutus,
 ]
 
@@ -138,6 +137,7 @@ class TestSECP256k1:
     @allure.link(helpers.get_vcs_link())
     @common.PARAM_PLUTUS2ONWARDS_VERSION
     @pytest.mark.parametrize("algorithm", ("ecdsa", "schnorr"))
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_use_secp_builtin_functions(
         self,
@@ -189,6 +189,7 @@ class TestSECP256k1:
         ("invalid_sig", "invalid_pubkey", "no_msg", "no_pubkey", "no_sig"),
     )
     @pytest.mark.parametrize("algorithm", ("ecdsa", "schnorr"))
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_negative_secp_builtin_functions(
         self,

--- a/cardano_node_tests/tests/tests_plutus_v2/test_spend_build.py
+++ b/cardano_node_tests/tests/tests_plutus_v2/test_spend_build.py
@@ -22,7 +22,6 @@ LOGGER = logging.getLogger(__name__)
 pytestmark = [
     common.SKIPIF_BUILD_UNUSABLE,
     common.SKIPIF_PLUTUSV2_UNUSABLE,
-    pytest.mark.smoke,
     pytest.mark.plutus,
 ]
 
@@ -58,6 +57,7 @@ class TestBuildLocking:
     @pytest.mark.parametrize(
         "use_reference_script", (True, False), ids=("reference_script", "script_file")
     )
+    @pytest.mark.smoke
     @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_txout_locking(
@@ -213,6 +213,7 @@ class TestBuildLocking:
         (True, False),
         ids=("with_reference_script", "without_reference_script"),
     )
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_min_required_utxo(
         self,

--- a/cardano_node_tests/tests/tests_plutus_v2/test_spend_collateral_build.py
+++ b/cardano_node_tests/tests/tests_plutus_v2/test_spend_collateral_build.py
@@ -22,7 +22,6 @@ LOGGER = logging.getLogger(__name__)
 pytestmark = [
     common.SKIPIF_BUILD_UNUSABLE,
     common.SKIPIF_PLUTUSV2_UNUSABLE,
-    pytest.mark.smoke,
     pytest.mark.plutus,
 ]
 
@@ -130,6 +129,7 @@ class TestCollateralOutput:
         (True, False),
         ids=("using_total_collateral", "without_total_collateral"),
     )
+    @pytest.mark.smoke
     @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_with_total_return_collateral(
@@ -232,6 +232,7 @@ class TestCollateralOutput:
         tx_view.check_tx_view(cluster_obj=cluster, tx_raw_output=tx_output_redeem)
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.smoke
     @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_collateral_with_tokens(

--- a/cardano_node_tests/tests/tests_plutus_v2/test_spend_collateral_raw.py
+++ b/cardano_node_tests/tests/tests_plutus_v2/test_spend_collateral_raw.py
@@ -21,7 +21,6 @@ LOGGER = logging.getLogger(__name__)
 
 pytestmark = [
     common.SKIPIF_PLUTUSV2_UNUSABLE,
-    pytest.mark.smoke,
     pytest.mark.plutus,
 ]
 
@@ -63,6 +62,7 @@ class TestCollateralOutput:
         (True, False),
         ids=("using_total_collateral", "without_total_collateral"),
     )
+    @pytest.mark.smoke
     @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_with_total_return_collateral(
@@ -208,6 +208,7 @@ class TestCollateralOutput:
         tx_view.check_tx_view(cluster_obj=cluster, tx_raw_output=tx_output_redeem)
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.smoke
     @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_collateral_with_tokens(

--- a/cardano_node_tests/tests/tests_plutus_v2/test_spend_compat_build.py
+++ b/cardano_node_tests/tests/tests_plutus_v2/test_spend_compat_build.py
@@ -20,7 +20,6 @@ LOGGER = logging.getLogger(__name__)
 
 pytestmark = [
     common.SKIPIF_BUILD_UNUSABLE,
-    pytest.mark.smoke,
     pytest.mark.plutus,
 ]
 
@@ -56,6 +55,7 @@ class TestCompatibility:
         VERSIONS.transaction_era >= VERSIONS.BABBAGE,
         reason="runs only with Tx era < Babbage",
     )
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_inline_datum_old_tx_era(
         self,
@@ -101,6 +101,7 @@ class TestCompatibility:
         VERSIONS.transaction_era >= VERSIONS.BABBAGE,
         reason="runs only with Tx era < Babbage",
     )
+    @pytest.mark.smoke
     @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_reference_script_old_tx_era(
@@ -149,6 +150,7 @@ class TestCompatibility:
         VERSIONS.transaction_era >= VERSIONS.BABBAGE,
         reason="runs only with Tx era < Babbage",
     )
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_ro_reference_old_tx_era(
         self,

--- a/cardano_node_tests/tests/tests_plutus_v2/test_spend_compat_raw.py
+++ b/cardano_node_tests/tests/tests_plutus_v2/test_spend_compat_raw.py
@@ -19,7 +19,6 @@ from cardano_node_tests.utils.versions import VERSIONS
 LOGGER = logging.getLogger(__name__)
 
 pytestmark = [
-    pytest.mark.smoke,
     pytest.mark.plutus,
 ]
 
@@ -55,6 +54,7 @@ class TestCompatibility:
         VERSIONS.transaction_era >= VERSIONS.BABBAGE,
         reason="runs only with Tx era < Babbage",
     )
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_inline_datum_old_tx_era(
         self,
@@ -112,6 +112,7 @@ class TestCompatibility:
         VERSIONS.transaction_era >= VERSIONS.BABBAGE,
         reason="runs only with Tx era < Babbage",
     )
+    @pytest.mark.smoke
     @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_reference_script_old_tx_era(
@@ -170,6 +171,7 @@ class TestCompatibility:
         VERSIONS.transaction_era >= VERSIONS.BABBAGE,
         reason="runs only with Tx era < Babbage",
     )
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_ro_reference_old_tx_era(
         self,

--- a/cardano_node_tests/tests/tests_plutus_v2/test_spend_datum_build.py
+++ b/cardano_node_tests/tests/tests_plutus_v2/test_spend_datum_build.py
@@ -24,7 +24,6 @@ LOGGER = logging.getLogger(__name__)
 pytestmark = [
     common.SKIPIF_BUILD_UNUSABLE,
     common.SKIPIF_PLUTUSV2_UNUSABLE,
-    pytest.mark.smoke,
     pytest.mark.plutus,
 ]
 
@@ -56,6 +55,7 @@ class TestInlineDatum:
     """Tests for Tx output with inline datum."""
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_check_inline_datum_cost(self, cluster: clusterlib.ClusterLib):
         """Check that the min UTxO value with an inline datum depends on the size of the datum.
@@ -185,6 +185,7 @@ class TestNegativeInlineDatum:
     @allure.link(helpers.get_vcs_link())
     @hypothesis.given(datum_value=st.text())
     @common.hypothesis_settings()
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_lock_tx_invalid_datum(
         self,
@@ -223,6 +224,7 @@ class TestNegativeInlineDatum:
         assert "JSON object expected. Unexpected value" in err_str, err_str
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.smoke
     @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_lock_tx_v1_script(
@@ -294,6 +296,7 @@ class TestNegativeInlineDatum:
     @allure.link(helpers.get_vcs_link())
     @hypothesis.given(datum_content=st.text(alphabet=string.ascii_letters, min_size=65))
     @common.hypothesis_settings(max_examples=100)
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_lock_tx_big_datum(
         self,
@@ -346,6 +349,7 @@ class TestNegativeInlineDatum:
         ), err_str
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.smoke
     @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_lock_tx_datum_as_witness(

--- a/cardano_node_tests/tests/tests_plutus_v2/test_spend_datum_raw.py
+++ b/cardano_node_tests/tests/tests_plutus_v2/test_spend_datum_raw.py
@@ -23,7 +23,6 @@ LOGGER = logging.getLogger(__name__)
 
 pytestmark = [
     common.SKIPIF_PLUTUSV2_UNUSABLE,
-    pytest.mark.smoke,
     pytest.mark.plutus,
 ]
 
@@ -86,6 +85,7 @@ class TestNegativeInlineDatum:
     @allure.link(helpers.get_vcs_link())
     @hypothesis.given(datum_value=st.text())
     @common.hypothesis_settings()
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_lock_tx_invalid_datum(
         self,
@@ -136,6 +136,7 @@ class TestNegativeInlineDatum:
         assert "JSON object expected. Unexpected value" in err_str, err_str
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.smoke
     @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_lock_tx_v1_script(
@@ -225,6 +226,7 @@ class TestNegativeInlineDatum:
     @allure.link(helpers.get_vcs_link())
     @hypothesis.given(datum_content=st.text(alphabet=string.ascii_letters, min_size=65))
     @common.hypothesis_settings(max_examples=200)
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_lock_tx_big_datum(
         self,
@@ -280,6 +282,7 @@ class TestNegativeInlineDatum:
         ), err_str
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.smoke
     @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_lock_tx_datum_as_witness(

--- a/cardano_node_tests/tests/tests_plutus_v2/test_spend_raw.py
+++ b/cardano_node_tests/tests/tests_plutus_v2/test_spend_raw.py
@@ -21,7 +21,6 @@ LOGGER = logging.getLogger(__name__)
 
 pytestmark = [
     common.SKIPIF_PLUTUSV2_UNUSABLE,
-    pytest.mark.smoke,
     pytest.mark.plutus,
 ]
 
@@ -57,6 +56,7 @@ class TestLockingV2:
     @pytest.mark.parametrize(
         "use_reference_script", (True, False), ids=("reference_script", "script_file")
     )
+    @pytest.mark.smoke
     @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_txout_locking(
@@ -181,6 +181,7 @@ class TestLockingV2:
         assert helpers.is_in_interval(fee, expected_fee_redeem, frac=0.15)
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.smoke
     @pytest.mark.testnets
     @pytest.mark.needs_dbsync
     def test_datum_bytes_in_dbsync(

--- a/cardano_node_tests/tests/tests_plutus_v2/test_spend_ref_inputs_build.py
+++ b/cardano_node_tests/tests/tests_plutus_v2/test_spend_ref_inputs_build.py
@@ -23,7 +23,6 @@ LOGGER = logging.getLogger(__name__)
 pytestmark = [
     common.SKIPIF_BUILD_UNUSABLE,
     common.SKIPIF_PLUTUSV2_UNUSABLE,
-    pytest.mark.smoke,
     pytest.mark.plutus,
 ]
 
@@ -56,6 +55,7 @@ class TestReadonlyReferenceInputs:
 
     @allure.link(helpers.get_vcs_link())
     @pytest.mark.parametrize("reference_input_scenario", ("single", "duplicated"))
+    @pytest.mark.smoke
     @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_use_reference_input(
@@ -163,6 +163,7 @@ class TestReadonlyReferenceInputs:
         dbsync_utils.check_tx(cluster_obj=cluster, tx_raw_output=tx_output_redeem)
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.smoke
     @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_same_input_as_reference_input(
@@ -267,6 +268,7 @@ class TestReadonlyReferenceInputs:
         tx_view.check_tx_view(cluster_obj=cluster, tx_raw_output=tx_output_redeem)
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_use_same_reference_input_multiple_times(
         self,
@@ -343,6 +345,7 @@ class TestReadonlyReferenceInputs:
         ), f"The reference input was spent `{reference_input[0]}`"
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.smoke
     @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_reference_input_non_plutus(
@@ -413,6 +416,7 @@ class TestNegativeReadonlyReferenceInputs:
     """Tests for Tx with readonly reference inputs that are expected to fail."""
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.smoke
     @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_reference_spent_output(
@@ -524,6 +528,7 @@ class TestNegativeReadonlyReferenceInputs:
         ), err_str
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.smoke
     @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_v1_script_with_reference_input(
@@ -609,6 +614,7 @@ class TestNegativeReadonlyReferenceInputs:
                 raise
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_reference_input_without_spend_anything(
         self,

--- a/cardano_node_tests/tests/tests_plutus_v2/test_spend_ref_inputs_raw.py
+++ b/cardano_node_tests/tests/tests_plutus_v2/test_spend_ref_inputs_raw.py
@@ -22,7 +22,6 @@ LOGGER = logging.getLogger(__name__)
 
 pytestmark = [
     common.SKIPIF_PLUTUSV2_UNUSABLE,
-    pytest.mark.smoke,
     pytest.mark.plutus,
 ]
 
@@ -55,6 +54,7 @@ class TestReadonlyReferenceInputs:
 
     @allure.link(helpers.get_vcs_link())
     @pytest.mark.parametrize("reference_input_scenario", ("single", "duplicated"))
+    @pytest.mark.smoke
     @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_use_reference_input(
@@ -153,6 +153,7 @@ class TestReadonlyReferenceInputs:
         tx_view.check_tx_view(cluster_obj=cluster, tx_raw_output=tx_raw_output)
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.smoke
     @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_same_input_as_reference_input(
@@ -255,6 +256,7 @@ class TestReadonlyReferenceInputs:
         tx_view.check_tx_view(cluster_obj=cluster, tx_raw_output=tx_output_redeem)
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.smoke
     @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_reference_input_non_plutus(
@@ -319,6 +321,7 @@ class TestNegativeReadonlyReferenceInputs:
     """Tests for Tx with readonly reference inputs that are expected to fail."""
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.smoke
     @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_reference_spent_output(
@@ -425,6 +428,7 @@ class TestNegativeReadonlyReferenceInputs:
         ), err_str
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.smoke
     @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_v1_script_with_reference_input(
@@ -517,6 +521,7 @@ class TestNegativeReadonlyReferenceInputs:
                 raise
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_reference_input_without_spend_anything(
         self,

--- a/cardano_node_tests/tests/tests_plutus_v2/test_spend_ref_scripts_build.py
+++ b/cardano_node_tests/tests/tests_plutus_v2/test_spend_ref_scripts_build.py
@@ -20,7 +20,6 @@ LOGGER = logging.getLogger(__name__)
 pytestmark = [
     common.SKIPIF_BUILD_UNUSABLE,
     common.SKIPIF_PLUTUSV2_UNUSABLE,
-    pytest.mark.smoke,
     pytest.mark.plutus,
 ]
 
@@ -55,6 +54,7 @@ class TestReferenceScripts:
     @pytest.mark.parametrize(
         "use_same_script", (True, False), ids=("same_script", "multiple_script")
     )
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_reference_multiple_script(
         self,
@@ -231,6 +231,7 @@ class TestReferenceScripts:
         assert helpers.is_in_interval(min_required_utxo, expected_min_required_utxo, frac=0.15)
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_reference_same_script(
         self,
@@ -377,6 +378,7 @@ class TestReferenceScripts:
         ), f"Script address UTxOs were NOT spent - `{script_utxos1}` and `{script_utxos2}`"
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_mix_reference_attached_script(
         self,
@@ -544,6 +546,7 @@ class TestReferenceScripts:
     @allure.link(helpers.get_vcs_link())
     @pytest.mark.parametrize("plutus_version", ("v1", "v2"), ids=("plutus_v1", "plutus_v2"))
     @pytest.mark.parametrize("address_type", ("shelley", "byron"))
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_spend_reference_script(
         self,
@@ -612,6 +615,7 @@ class TestReferenceScripts:
 
     @allure.link(helpers.get_vcs_link())
     @pytest.mark.parametrize("plutus_version", ("v1", "v2"), ids=("plutus_v1", "plutus_v2"))
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_spend_regular_utxo_and_reference_script(
         self,
@@ -707,6 +711,7 @@ class TestNegativeReferenceScripts:
     """Tests for Tx output with reference scripts that are expected to fail."""
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_not_a_script(
         self,
@@ -741,6 +746,7 @@ class TestNegativeReferenceScripts:
         assert "Syntax error in script" in err_str, err_str
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_two_scripts_one_fail(
         self,
@@ -888,6 +894,7 @@ class TestNegativeReferenceScripts:
         assert "The Plutus script evaluation failed" in err_str, err_str
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.smoke
     @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_lock_tx_v1_reference_script(
@@ -964,6 +971,7 @@ class TestNegativeReferenceScripts:
         ), err_str
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_v1_attached_v2_reference(
         self,
@@ -1110,6 +1118,7 @@ class TestNegativeReferenceScripts:
         ), err_str
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.smoke
     @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_lock_byron_reference_script(

--- a/cardano_node_tests/tests/tests_plutus_v2/test_spend_ref_scripts_raw.py
+++ b/cardano_node_tests/tests/tests_plutus_v2/test_spend_ref_scripts_raw.py
@@ -20,7 +20,6 @@ LOGGER = logging.getLogger(__name__)
 
 pytestmark = [
     common.SKIPIF_PLUTUSV2_UNUSABLE,
-    pytest.mark.smoke,
     pytest.mark.plutus,
 ]
 
@@ -55,6 +54,7 @@ class TestReferenceScripts:
     @pytest.mark.parametrize(
         "use_same_script", (True, False), ids=("same_script", "multiple_script")
     )
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_reference_multiple_script(
         self,
@@ -215,6 +215,7 @@ class TestReferenceScripts:
         ), f"Script address UTxOs were NOT spent - `{script_utxos1}` and `{script_utxos2}`"
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_reference_same_script(
         self,
@@ -357,6 +358,7 @@ class TestReferenceScripts:
         ), f"Script address UTxOs were NOT spent - `{script_utxos1}` and `{script_utxos2}`"
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_mix_reference_attached_script(
         self,
@@ -506,6 +508,7 @@ class TestReferenceScripts:
     @allure.link(helpers.get_vcs_link())
     @pytest.mark.parametrize("plutus_version", ("v1", "v2"), ids=("plutus_v1", "plutus_v2"))
     @pytest.mark.parametrize("address_type", ("shelley", "byron"))
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_spend_reference_script(
         self,
@@ -565,6 +568,7 @@ class TestReferenceScripts:
 
     @allure.link(helpers.get_vcs_link())
     @pytest.mark.parametrize("plutus_version", ("v1", "v2"), ids=("plutus_v1", "plutus_v2"))
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_spend_regular_utxo_and_reference_script(
         self,
@@ -640,6 +644,7 @@ class TestReferenceScripts:
         assert utxo_balance == amount, f"Incorrect balance for destination UTxO `{new_utxo}`"
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_reference_script_byron_address(
         self,
@@ -677,6 +682,7 @@ class TestNegativeReferenceScripts:
     """Tests for Tx output with reference scripts that are expected to fail."""
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_not_a_script(
         self,
@@ -720,6 +726,7 @@ class TestNegativeReferenceScripts:
         assert "Syntax error in script" in err_str, err_str
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_two_scripts_one_fail(
         self,
@@ -877,6 +884,7 @@ class TestNegativeReferenceScripts:
             issues.ledger_3731.finish_test()
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.smoke
     @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_lock_tx_v1_reference_script(
@@ -971,6 +979,7 @@ class TestNegativeReferenceScripts:
         ), err_str
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_v1_attached_v2_reference(
         self,
@@ -1121,6 +1130,7 @@ class TestNegativeReferenceScripts:
         ), err_str
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.smoke
     @pytest.mark.testnets
     @pytest.mark.dbsync
     def test_lock_byron_reference_script(

--- a/cardano_node_tests/tests/tests_plutus_v2/test_spend_secp256k1_build.py
+++ b/cardano_node_tests/tests/tests_plutus_v2/test_spend_secp256k1_build.py
@@ -23,7 +23,6 @@ LOGGER = logging.getLogger(__name__)
 pytestmark = [
     common.SKIPIF_BUILD_UNUSABLE,
     common.SKIPIF_PLUTUSV2_UNUSABLE,
-    pytest.mark.smoke,
     pytest.mark.plutus,
 ]
 
@@ -134,6 +133,7 @@ class TestSECP256k1:
 
     @allure.link(helpers.get_vcs_link())
     @pytest.mark.parametrize("build_fund_script_secp", ("ecdsa", "schnorr"), indirect=True)
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_use_secp_builtin_functions(
         self,
@@ -231,6 +231,7 @@ class TestSECP256k1:
         number_of_iterations=st.integers(min_value=1000300, max_value=common.MAX_UINT64)
     )
     @common.hypothesis_settings(max_examples=200)
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_overspending_execution_budget(
         self,

--- a/cardano_node_tests/tests/tests_plutus_v2/test_spend_secp256k1_raw.py
+++ b/cardano_node_tests/tests/tests_plutus_v2/test_spend_secp256k1_raw.py
@@ -19,7 +19,6 @@ LOGGER = logging.getLogger(__name__)
 
 pytestmark = [
     common.SKIPIF_PLUTUSV2_UNUSABLE,
-    pytest.mark.smoke,
     pytest.mark.plutus,
 ]
 
@@ -118,6 +117,7 @@ class TestSECP256k1:
 
     @allure.link(helpers.get_vcs_link())
     @pytest.mark.parametrize("fund_script_secp", ("ecdsa", "schnorr"), indirect=True)
+    @pytest.mark.smoke
     @pytest.mark.testnets
     def test_use_secp_builtin_functions(
         self,


### PR DESCRIPTION
Make sure that the "smoke" marker is used only on individual tests, not on class or module level.