### PR TITLE
refactor: review "order" marker

### DIFF
--- a/cardano_node_tests/tests/test_configuration.py
+++ b/cardano_node_tests/tests/test_configuration.py
@@ -125,8 +125,11 @@ def check_epoch_length(cluster_obj: clusterlib.ClusterLib) -> None:
     assert epoch + 1 == cluster_obj.g_query.get_epoch()
 
 
-@pytest.mark.order(5)
 @common.SKIPIF_WRONG_ERA
+# It takes long time to setup the cluster instance (when starting from Byron).
+# We mark the tests as "long" and set the highest priority, so the setup is done at the
+# beginning of the testrun, instead of needing to respin a cluster that is already running.
+@pytest.mark.order(5)
 @pytest.mark.long
 class TestBasic:
     """Basic tests for node configuration."""

--- a/cardano_node_tests/tests/test_kes.py
+++ b/cardano_node_tests/tests/test_kes.py
@@ -154,6 +154,9 @@ class TestKES:
 
     @allure.link(helpers.get_vcs_link())
     @SKIPIF_HF_SHORTCUT
+    # It takes long time to setup the cluster instance (when starting from Byron).
+    # We mark the tests as "long" and set the highest priority, so the setup is done at the
+    # beginning of the testrun, instead of needing to respin a cluster that is already running.
     @pytest.mark.order(5)
     @pytest.mark.long
     def test_expired_kes(

--- a/cardano_node_tests/tests/test_pool_saturation.py
+++ b/cardano_node_tests/tests/test_pool_saturation.py
@@ -208,10 +208,10 @@ def _check_pool_records(pool_records: tp.Dict[int, PoolRecord]) -> None:
         )
 
 
-@pytest.mark.order(5)
-@pytest.mark.long
 class TestPoolSaturation:
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.order(5)
+    @pytest.mark.long
     def test_oversaturated(  # noqa: C901
         self,
         cluster_manager: cluster_management.ClusterManager,

--- a/cardano_node_tests/tests/test_staking_no_rewards.py
+++ b/cardano_node_tests/tests/test_staking_no_rewards.py
@@ -37,10 +37,10 @@ def cluster_lock_pool_use_rewards(
     return cluster_obj, pool_name
 
 
-@pytest.mark.order(6)
-@pytest.mark.long
 class TestNoRewards:
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.order(6)
+    @pytest.mark.long
     def test_no_reward_unmet_pledge1(
         self,
         cluster_manager: cluster_management.ClusterManager,
@@ -204,6 +204,8 @@ class TestNoRewards:
         ), f"Pledge is not met for pool '{pool_name}'!"
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.order(6)
+    @pytest.mark.long
     def test_no_reward_unmet_pledge2(
         self,
         cluster_manager: cluster_management.ClusterManager,
@@ -365,6 +367,8 @@ class TestNoRewards:
             ), "New reward was not received by pool reward address"
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.order(6)
+    @pytest.mark.long
     def test_no_reward_deregistered_stake_addr(
         self,
         cluster_manager: cluster_management.ClusterManager,
@@ -560,6 +564,8 @@ class TestNoRewards:
         ), f"Pledge is not met for pool '{pool_name}'!"
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.order(6)
+    @pytest.mark.long
     def test_no_reward_deregistered_reward_addr(
         self,
         cluster_manager: cluster_management.ClusterManager,
@@ -745,6 +751,8 @@ class TestNoRewards:
         ), f"Pledge is not met for pool '{pool_name}'!"
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.order(6)
+    @pytest.mark.long
     def test_deregister_reward_addr_retire_pool(
         self,
         cluster_manager: cluster_management.ClusterManager,

--- a/cardano_node_tests/tests/test_staking_rewards.py
+++ b/cardano_node_tests/tests/test_staking_rewards.py
@@ -252,17 +252,17 @@ def _get_rew_type_for_cred_hash(key_hash: str, rec: tp.Dict[str, tp.List[dict]])
     return rew_types
 
 
-@pytest.mark.order(6)
-@pytest.mark.long
 class TestRewards:
     """Tests for checking expected rewards."""
 
     @allure.link(helpers.get_vcs_link())
-    @pytest.mark.testnets
     @pytest.mark.skipif(
         cluster_nodes.get_cluster_type().type == cluster_nodes.ClusterType.LOCAL,
         reason="supposed to run on testnet",
     )
+    @pytest.mark.order(6)
+    @pytest.mark.long
+    @pytest.mark.testnets
     def test_reward_simple(
         self,
         cluster_manager: cluster_management.ClusterManager,
@@ -314,6 +314,8 @@ class TestRewards:
         )
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.order(6)
+    @pytest.mark.long
     @pytest.mark.dbsync
     def test_reward_amount(  # noqa: C901
         self,
@@ -621,6 +623,8 @@ class TestRewards:
             )
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.order(6)
+    @pytest.mark.long
     @pytest.mark.needs_dbsync
     def test_reward_addr_delegation(  # noqa: C901
         self,
@@ -1017,6 +1021,8 @@ class TestRewards:
                 assert rtypes_set == {"leader"}
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.order(6)
+    @pytest.mark.long
     def test_decreasing_reward_transferred_funds(
         self,
         cluster_manager: cluster_management.ClusterManager,
@@ -1123,11 +1129,13 @@ class TestRewards:
         assert rewards_rec[-1] < rewards_rec[-2] // 3, "Rewards are not decreasing"
 
     @allure.link(helpers.get_vcs_link())
-    @pytest.mark.needs_dbsync
     @pytest.mark.skipif(
         VERSIONS.transaction_era < VERSIONS.ALLEGRA,
         reason="needs Allegra+ TX to run",
     )
+    @pytest.mark.order(6)
+    @pytest.mark.long
+    @pytest.mark.needs_dbsync
     def test_2_pools_same_reward_addr(  # noqa: C901
         self,
         cluster_manager: cluster_management.ClusterManager,
@@ -1378,6 +1386,8 @@ class TestRewards:
                 assert not rtypes
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.order(6)
+    @pytest.mark.long
     @pytest.mark.dbsync
     def test_redelegation(  # noqa: C901
         self,

--- a/cardano_node_tests/tests/test_tx_many_utxos.py
+++ b/cardano_node_tests/tests/test_tx_many_utxos.py
@@ -25,8 +25,6 @@ LOGGER = logging.getLogger(__name__)
     VERSIONS.cluster_era != VERSIONS.transaction_era,
     reason="expensive test, skip when cluster era is different from TX era",
 )
-@pytest.mark.order(5)
-@pytest.mark.long
 class TestManyUTXOs:
     """Test transaction with many UTxOs and small amounts of Lovelace."""
 
@@ -154,6 +152,8 @@ class TestManyUTXOs:
         return retval
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.order(5)
+    @pytest.mark.long
     @pytest.mark.dbsync
     def test_mini_transactions(
         self,

--- a/cardano_node_tests/tests/test_update_proposals.py
+++ b/cardano_node_tests/tests/test_update_proposals.py
@@ -21,7 +21,6 @@ LOGGER = logging.getLogger(__name__)
 DATA_DIR = pl.Path(__file__).parent / "data"
 
 
-@pytest.mark.order(8)
 @pytest.mark.skipif(
     VERSIONS.cluster_era != VERSIONS.transaction_era,
     reason="Must run with same cluster and Tx era",
@@ -30,7 +29,6 @@ DATA_DIR = pl.Path(__file__).parent / "data"
     VERSIONS.cluster_era >= VERSIONS.CONWAY,
     reason="Doesn't run on cluster era >= Conway",
 )
-@pytest.mark.long
 class TestUpdateProposals:
     """Tests for update proposals."""
 
@@ -72,6 +70,8 @@ class TestUpdateProposals:
         return addr
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.order(8)
+    @pytest.mark.long
     @pytest.mark.dbsync
     def test_update_proposal(
         self,

--- a/cardano_node_tests/tests/tests_plutus/test_delegation.py
+++ b/cardano_node_tests/tests/tests_plutus/test_delegation.py
@@ -649,7 +649,6 @@ class TestRegisterAddr:
 
 # Don't run these tests on testnets as a stake address corresponding to the Plutus script
 # might be already in use.
-@pytest.mark.order(8)
 @common.SKIPIF_BUILD_UNUSABLE
 @common.PARAM_PLUTUS_VERSION
 @common.PARAM_USE_BUILD_CMD
@@ -660,6 +659,8 @@ class TestDelegateAddr:
     @pytest.mark.parametrize(
         "use_reference_script", (True, False), ids=("reference_script", "script_file")
     )
+    @pytest.mark.order(8)
+    @pytest.mark.long
     @pytest.mark.dbsync
     def test_delegate_deregister(  # noqa: C901
         self,
@@ -869,6 +870,8 @@ class TestDelegateAddr:
                 raise
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.order(8)
+    @pytest.mark.long
     @pytest.mark.dbsync
     def test_register_delegate_deregister(
         self,


### PR DESCRIPTION
Make sure that the "order" and "long" markers are used only on individual tests, not on class or module level, where it makes sense.