### PR TITLE
feat(tests): add conditional markers for Byron tests

### DIFF
--- a/cardano_node_tests/tests/common.py
+++ b/cardano_node_tests/tests/common.py
@@ -9,6 +9,7 @@ from cardano_node_tests.cluster_management import cluster_management
 from cardano_node_tests.tests import issues
 from cardano_node_tests.utils import cluster_nodes
 from cardano_node_tests.utils import clusterlib_utils
+from cardano_node_tests.utils import configuration
 from cardano_node_tests.utils import pytest_utils
 from cardano_node_tests.utils.versions import VERSIONS
 
@@ -17,6 +18,11 @@ LOGGER = logging.getLogger(__name__)
 
 MAX_INT64 = (2**63) - 1
 MAX_UINT64 = (2**64) - 1
+
+ORDER5_BYRON = (
+    pytest.mark.order(5) if "_fast" not in configuration.SCRIPTS_DIRNAME else pytest.mark.noop
+)
+LONG_BYRON = pytest.mark.long if "_fast" not in configuration.SCRIPTS_DIRNAME else pytest.mark.noop
 
 
 _BLD_SKIP_REASON = ""

--- a/cardano_node_tests/tests/test_configuration.py
+++ b/cardano_node_tests/tests/test_configuration.py
@@ -129,8 +129,8 @@ def check_epoch_length(cluster_obj: clusterlib.ClusterLib) -> None:
 # It takes long time to setup the cluster instance (when starting from Byron).
 # We mark the tests as "long" and set the highest priority, so the setup is done at the
 # beginning of the testrun, instead of needing to respin a cluster that is already running.
-@pytest.mark.order(5)
-@pytest.mark.long
+@common.ORDER5_BYRON
+@common.LONG_BYRON
 class TestBasic:
     """Basic tests for node configuration."""
 

--- a/cardano_node_tests/tests/test_kes.py
+++ b/cardano_node_tests/tests/test_kes.py
@@ -157,8 +157,8 @@ class TestKES:
     # It takes long time to setup the cluster instance (when starting from Byron).
     # We mark the tests as "long" and set the highest priority, so the setup is done at the
     # beginning of the testrun, instead of needing to respin a cluster that is already running.
-    @pytest.mark.order(5)
-    @pytest.mark.long
+    @common.ORDER5_BYRON
+    @common.LONG_BYRON
     def test_expired_kes(
         self,
         cluster_kes: clusterlib.ClusterLib,

--- a/cardano_node_tests/tests/test_pools.py
+++ b/cardano_node_tests/tests/test_pools.py
@@ -1776,8 +1776,8 @@ class TestStakePool:
 # It takes long time to setup the cluster instance (when starting from Byron).
 # We mark the tests as "long" and set the highest priority, so the setup is done at the
 # beginning of the testrun, instead of needing to respin a cluster that is already running.
-@pytest.mark.order(5)
-@pytest.mark.long
+@common.ORDER5_BYRON
+@common.LONG_BYRON
 class TestPoolCost:
     """Tests for stake pool cost."""
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -136,4 +136,5 @@ markers = [
     "upgrade: test(s) for upgrade testing",
     "plutus: test(s) for plutus",
     "disabled: temporarily disabled test(s)",
+    "noop: placeholder marker",
 ]


### PR DESCRIPTION
Introduce ORDER5_BYRON and LONG_BYRON markers to conditionally apply pytest marks based on the configuration. This change helps to avoid setting priority for tests when the it is not needed, because the tests run on setup where it is fast to respin the local testnet.

Also, add a new "noop" placeholder marker to the pyproject.toml file.