### PR TITLE
feat(tests): rename test_protocol_mode to test_genesis_cert_not_avail…

### DIFF
--- a/cardano_node_tests/tests/tests_conway/test_conway.py
+++ b/cardano_node_tests/tests/tests_conway/test_conway.py
@@ -25,7 +25,7 @@ class TestConway:
     @allure.link(helpers.get_vcs_link())
     @pytest.mark.smoke
     @pytest.mark.testnets
-    def test_protocol_mode(self, cluster: clusterlib.ClusterLib):
+    def test_genesis_cert_not_available(self, cluster: clusterlib.ClusterLib):
         """Check that the `create-genesis-key-delegation-certificate` command is not available."""
         common.get_test_id(cluster)
 


### PR DESCRIPTION
…able

Renamed the test method `test_protocol_mode` to
`test_genesis_cert_not_available` in the `TestConway` class. This change clarifies the purpose of the test, which is to check that the `create-genesis-key-delegation-certificate` command is not available.