### PR TITLE
feat: add testnet cleanup on interrupted test run

### DIFF
--- a/.github/setup_venv.sh
+++ b/.github/setup_venv.sh
@@ -1,16 +1,25 @@
 #!/bin/bash
 
-VENV_DIR="${VENV_DIR:-"$WORKDIR/.env"}"
+_VENV_DIR="${_VENV_DIR:-"$WORKDIR/.env"}"
 
 if [ "${1:-""}" = "clean" ]; then
-  rm -rf "$VENV_DIR"
+  rm -rf "$_VENV_DIR"
 fi
 
-python3 -m venv "$VENV_DIR"
+_REQS_INSTALLED="true"
+if [ ! -e "$_VENV_DIR" ]; then
+  _REQS_INSTALLED=""
+  python3 -m venv "$_VENV_DIR"
+fi
+
 # shellcheck disable=SC1090,SC1091
-. "$VENV_DIR/bin/activate"
+. "$_VENV_DIR/bin/activate"
 
 PYTHONPATH="$(echo "$VIRTUAL_ENV"/lib/python3*/site-packages):$PYTHONPATH"
 export PYTHONPATH
 
-pip install -r requirements_freeze.txt
+if [ -z "$_REQS_INSTALLED" ]; then
+  pip install -r requirements_freeze.txt
+fi
+
+unset _VENV_DIR _REQS_INSTALLED


### PR DESCRIPTION
- Introduced `_cleanup_testnet` function to handle testnet cleanup.
- Modified the trap to call `_interrupted` function on SIGINT.
- Added `pytest_keyboard_interrupt` hook to create a status file.
- Updated `setup_venv.sh` to create venv only if it doesn't exist.
- Enhanced `testenv_setup_teardown` to handle interrupted test runs.