### PR TITLE
Use multiple faucets

### DIFF
--- a/cardano_node_tests/cluster_management/cluster_getter.py
+++ b/cardano_node_tests/cluster_management/cluster_getter.py
@@ -256,8 +256,12 @@ class ClusterGetter:
             fp_out.write(cluster_instance_id)
         self.log(f"c{self.cluster_instance_num}: started cluster instance '{cluster_instance_id}'")
 
-        # Create dir for faucet addresses data
-        addr_data_dir = state_dir / common.ADDRS_DATA_DIRNAME
+        # Create dir for faucet addresses data among tests artifacts, so it can be accessed
+        # during testnet cleanup.
+        addr_data_dir = (
+            temptools.get_pytest_worker_tmp()
+            / f"{common.ADDRS_DATA_DIRNAME}_ci{self.cluster_instance_num}"
+        )
         addr_data_dir.mkdir(parents=True, exist_ok=True)
 
         # Setup faucet addresses

--- a/cardano_node_tests/cluster_management/cluster_getter.py
+++ b/cardano_node_tests/cluster_management/cluster_getter.py
@@ -12,7 +12,6 @@ import typing as tp
 
 import pytest
 from _pytest.config import Config
-from cardano_clusterlib import clusterlib
 
 from cardano_node_tests.cluster_management import common
 from cardano_node_tests.cluster_management import resources
@@ -130,7 +129,7 @@ class ClusterGetter:
 
     def _create_startup_files_dir(self, instance_num: int) -> pl.Path:
         _instance_dir = self.pytest_tmp_dir / f"{common.CLUSTER_DIR_TEMPLATE}{instance_num}"
-        rand_str = clusterlib.get_rand_str(8)
+        rand_str = helpers.get_rand_str(8)
         startup_files_dir = _instance_dir / "startup_files" / rand_str
         startup_files_dir.mkdir(exist_ok=True, parents=True)
         return startup_files_dir
@@ -259,8 +258,8 @@ class ClusterGetter:
         # Create dir for faucet addresses data among tests artifacts, so it can be accessed
         # during testnet cleanup.
         addr_data_dir = (
-            temptools.get_pytest_worker_tmp()
-            / f"{common.ADDRS_DATA_DIRNAME}_ci{self.cluster_instance_num}"
+            temptools.get_pytest_worker_tmp() / f"{common.ADDRS_DATA_DIRNAME}_"
+            f"ci{self.cluster_instance_num}_{cluster_instance_id}"
         )
         addr_data_dir.mkdir(parents=True, exist_ok=True)
 

--- a/cardano_node_tests/tests/common.py
+++ b/cardano_node_tests/tests/common.py
@@ -241,7 +241,7 @@ def detect_fork(
     tx_raw_output = clusterlib_utils.fund_from_faucet(
         payment_rec,
         cluster_obj=cluster_obj,
-        faucet_data=cluster_manager.cache.addrs_data["user1"],
+        all_faucets=cluster_manager.cache.addrs_data,
         amount=2_000_000,
     )
     assert tx_raw_output

--- a/cardano_node_tests/tests/delegation.py
+++ b/cardano_node_tests/tests/delegation.py
@@ -152,7 +152,7 @@ def delegate_stake_addr(
         clusterlib_utils.fund_from_faucet(
             pool_user.payment,
             cluster_obj=cluster_obj,
-            faucet_data=addrs_data["user1"],
+            all_faucets=addrs_data,
             amount=amount,
         )
 

--- a/cardano_node_tests/tests/test_addr_registration.py
+++ b/cardano_node_tests/tests/test_addr_registration.py
@@ -41,7 +41,7 @@ def pool_users(
     clusterlib_utils.fund_from_faucet(
         created_users[0],
         cluster_obj=cluster,
-        faucet_data=cluster_manager.cache.addrs_data["user1"],
+        all_faucets=cluster_manager.cache.addrs_data,
     )
 
     return created_users

--- a/cardano_node_tests/tests/test_blocks.py
+++ b/cardano_node_tests/tests/test_blocks.py
@@ -210,7 +210,7 @@ class TestCollectData:
         clusterlib_utils.fund_from_faucet(
             *addrs,
             cluster_obj=cluster,
-            faucet_data=cluster_manager.cache.addrs_data["user1"],
+            all_faucets=cluster_manager.cache.addrs_data,
         )
         return addrs
 
@@ -404,7 +404,7 @@ class TestDynamicBlockProd:
         clusterlib_utils.fund_from_faucet(
             *addrs,
             cluster_obj=cluster,
-            faucet_data=cluster_manager.cache.addrs_data["user1"],
+            all_faucets=cluster_manager.cache.addrs_data,
         )
         return addrs
 

--- a/cardano_node_tests/tests/test_chain_transactions.py
+++ b/cardano_node_tests/tests/test_chain_transactions.py
@@ -36,7 +36,7 @@ def get_payment_addr(
     clusterlib_utils.fund_from_faucet(
         addr,
         cluster_obj=cluster_obj,
-        faucet_data=cluster_manager.cache.addrs_data["user1"],
+        all_faucets=cluster_manager.cache.addrs_data,
         amount=amount,
     )
 

--- a/cardano_node_tests/tests/test_cli.py
+++ b/cardano_node_tests/tests/test_cli.py
@@ -721,7 +721,7 @@ class TestQueryUTxO:
         clusterlib_utils.fund_from_faucet(
             payment_addrs[0],
             cluster_obj=cluster,
-            faucet_data=cluster_manager.cache.addrs_data["user1"],
+            all_faucets=cluster_manager.cache.addrs_data,
             amount=amount1 + amount2 + 10_000_000,
         )
 

--- a/cardano_node_tests/tests/test_dbsync.py
+++ b/cardano_node_tests/tests/test_dbsync.py
@@ -314,7 +314,7 @@ class TestDBSync:
         clusterlib_utils.fund_from_faucet(
             payment_addrs[0],
             cluster_obj=cluster,
-            faucet_data=cluster_manager.cache.addrs_data["user1"],
+            all_faucets=cluster_manager.cache.addrs_data,
             amount=10_000_000,
         )
 

--- a/cardano_node_tests/tests/test_delegation.py
+++ b/cardano_node_tests/tests/test_delegation.py
@@ -80,7 +80,7 @@ def pool_users(
     clusterlib_utils.fund_from_faucet(
         created_users[0],
         cluster_obj=cluster,
-        faucet_data=cluster_manager.cache.addrs_data["user1"],
+        all_faucets=cluster_manager.cache.addrs_data,
     )
 
     return created_users
@@ -127,7 +127,7 @@ def pool_users_cluster_and_pool(
     clusterlib_utils.fund_from_faucet(
         created_users[0],
         cluster_obj=cluster,
-        faucet_data=cluster_manager.cache.addrs_data["user1"],
+        all_faucets=cluster_manager.cache.addrs_data,
     )
 
     return created_users
@@ -302,7 +302,7 @@ class TestDelegateAddr:
         clusterlib_utils.fund_from_faucet(
             *pool_users,
             cluster_obj=cluster,
-            faucet_data=cluster_manager.cache.addrs_data["user1"],
+            all_faucets=cluster_manager.cache.addrs_data,
         )
 
         # Step: Delegate the stake addresses to 2 different pools
@@ -431,7 +431,7 @@ class TestDelegateAddr:
         clusterlib_utils.fund_from_faucet(
             *payment_addr_recs,
             cluster_obj=cluster,
-            faucet_data=cluster_manager.cache.addrs_data["user1"],
+            all_faucets=cluster_manager.cache.addrs_data,
         )
 
         pool_user = clusterlib.PoolUser(payment=payment_addr_recs[1], stake=stake_addr_rec)

--- a/cardano_node_tests/tests/test_env_network_id.py
+++ b/cardano_node_tests/tests/test_env_network_id.py
@@ -117,7 +117,7 @@ def payment_addrs(
     clusterlib_utils.fund_from_faucet(
         addrs[0],
         cluster_obj=cluster,
-        faucet_data=cluster_manager.cache.addrs_data["user1"],
+        all_faucets=cluster_manager.cache.addrs_data,
         amount=100_000_000,
     )
     return addrs

--- a/cardano_node_tests/tests/test_governance.py
+++ b/cardano_node_tests/tests/test_governance.py
@@ -62,7 +62,7 @@ class TestPoll:
         clusterlib_utils.fund_from_faucet(
             addr,
             cluster_obj=cluster,
-            faucet_data=cluster_manager.cache.addrs_data["user1"],
+            all_faucets=cluster_manager.cache.addrs_data,
             amount=amount,
         )
 

--- a/cardano_node_tests/tests/test_mir_certs.py
+++ b/cardano_node_tests/tests/test_mir_certs.py
@@ -80,7 +80,7 @@ def pool_users(
     clusterlib_utils.fund_from_faucet(
         *created_users,
         cluster_obj=cluster_pots,
-        faucet_data=cluster_manager.cache.addrs_data["user1"],
+        all_faucets=cluster_manager.cache.addrs_data,
     )
 
     return created_users

--- a/cardano_node_tests/tests/test_native_tokens.py
+++ b/cardano_node_tests/tests/test_native_tokens.py
@@ -90,7 +90,7 @@ def issuers_addrs(
     clusterlib_utils.fund_from_faucet(
         addrs[0],
         cluster_obj=cluster,
-        faucet_data=cluster_manager.cache.addrs_data["user1"],
+        all_faucets=cluster_manager.cache.addrs_data,
         amount=9_000_000,
     )
 
@@ -773,7 +773,7 @@ class TestMinting:
             clusterlib_utils.fund_from_faucet(
                 token_mint_addr,
                 cluster_obj=cluster,
-                faucet_data=cluster_manager.cache.addrs_data["user1"],
+                all_faucets=cluster_manager.cache.addrs_data,
                 amount=300_000_000,
             )
 
@@ -799,7 +799,7 @@ class TestMinting:
             clusterlib_utils.fund_from_faucet(
                 token_mint_addr,
                 cluster_obj=cluster,
-                faucet_data=cluster_manager.cache.addrs_data["user1"],
+                all_faucets=cluster_manager.cache.addrs_data,
                 amount=40_000_000,
             )
 
@@ -918,7 +918,7 @@ class TestMinting:
             clusterlib_utils.fund_from_faucet(
                 token_mint_addr,
                 cluster_obj=cluster,
-                faucet_data=cluster_manager.cache.addrs_data["user1"],
+                all_faucets=cluster_manager.cache.addrs_data,
                 amount=300_000_000,
             )
 
@@ -944,7 +944,7 @@ class TestMinting:
             clusterlib_utils.fund_from_faucet(
                 token_mint_addr,
                 cluster_obj=cluster,
-                faucet_data=cluster_manager.cache.addrs_data["user1"],
+                all_faucets=cluster_manager.cache.addrs_data,
                 amount=40_000_000,
             )
 
@@ -1662,7 +1662,7 @@ class TestTransfer:
         clusterlib_utils.fund_from_faucet(
             addrs[0],
             cluster_obj=cluster,
-            faucet_data=cluster_manager.cache.addrs_data["user1"],
+            all_faucets=cluster_manager.cache.addrs_data,
         )
 
         return addrs

--- a/cardano_node_tests/tests/test_node_upgrade.py
+++ b/cardano_node_tests/tests/test_node_upgrade.py
@@ -47,7 +47,7 @@ def payment_addr_locked(
     clusterlib_utils.fund_from_faucet(
         addr,
         cluster_obj=cluster,
-        faucet_data=cluster_manager.cache.addrs_data["user1"],
+        all_faucets=cluster_manager.cache.addrs_data,
     )
 
     return addr
@@ -71,7 +71,7 @@ def payment_addrs_disposable(
     clusterlib_utils.fund_from_faucet(
         addrs[0],
         cluster_obj=cluster,
-        faucet_data=cluster_manager.cache.addrs_data["user1"],
+        all_faucets=cluster_manager.cache.addrs_data,
     )
 
     return addrs

--- a/cardano_node_tests/tests/test_pools.py
+++ b/cardano_node_tests/tests/test_pools.py
@@ -667,7 +667,7 @@ class TestStakePool:
         clusterlib_utils.fund_from_faucet(
             pool_owners[0].payment,
             cluster_obj=cluster,
-            faucet_data=cluster_manager.cache.addrs_data["user1"],
+            all_faucets=cluster_manager.cache.addrs_data,
             amount=900_000_000,
         )
 
@@ -748,7 +748,7 @@ class TestStakePool:
         clusterlib_utils.fund_from_faucet(
             pool_owners[0].payment,
             cluster_obj=cluster,
-            faucet_data=cluster_manager.cache.addrs_data["user1"],
+            all_faucets=cluster_manager.cache.addrs_data,
             amount=900_000_000,
         )
 
@@ -818,7 +818,7 @@ class TestStakePool:
         clusterlib_utils.fund_from_faucet(
             pool_owners[0].payment,
             cluster_obj=cluster,
-            faucet_data=cluster_manager.cache.addrs_data["user1"],
+            all_faucets=cluster_manager.cache.addrs_data,
             amount=900_000_000,
         )
 
@@ -883,7 +883,7 @@ class TestStakePool:
         clusterlib_utils.fund_from_faucet(
             pool_owners[0].payment,
             cluster_obj=cluster,
-            faucet_data=cluster_manager.cache.addrs_data["user1"],
+            all_faucets=cluster_manager.cache.addrs_data,
             amount=900_000_000,
         )
 
@@ -1024,7 +1024,7 @@ class TestStakePool:
         clusterlib_utils.fund_from_faucet(
             pool_owners[0].payment,
             cluster_obj=cluster,
-            faucet_data=cluster_manager.cache.addrs_data["user1"],
+            all_faucets=cluster_manager.cache.addrs_data,
             amount=1_500_000_000,
         )
 
@@ -1185,7 +1185,7 @@ class TestStakePool:
         clusterlib_utils.fund_from_faucet(
             pool_owners[0].payment,
             cluster_obj=cluster,
-            faucet_data=cluster_manager.cache.addrs_data["user1"],
+            all_faucets=cluster_manager.cache.addrs_data,
             amount=1_500_000_000,
         )
 
@@ -1350,7 +1350,7 @@ class TestStakePool:
         clusterlib_utils.fund_from_faucet(
             pool_owners[0].payment,
             cluster_obj=cluster,
-            faucet_data=cluster_manager.cache.addrs_data["user1"],
+            all_faucets=cluster_manager.cache.addrs_data,
             amount=900_000_000 * no_of_addr,
         )
 
@@ -1469,7 +1469,7 @@ class TestStakePool:
         clusterlib_utils.fund_from_faucet(
             pool_owners[0].payment,
             cluster_obj=cluster,
-            faucet_data=cluster_manager.cache.addrs_data["user1"],
+            all_faucets=cluster_manager.cache.addrs_data,
             amount=900_000_000 * no_of_addr,
         )
 
@@ -1570,7 +1570,7 @@ class TestStakePool:
         clusterlib_utils.fund_from_faucet(
             pool_owners[0].payment,
             cluster_obj=cluster,
-            faucet_data=cluster_manager.cache.addrs_data["user1"],
+            all_faucets=cluster_manager.cache.addrs_data,
             amount=900_000_000,
         )
 
@@ -1707,7 +1707,7 @@ class TestStakePool:
         clusterlib_utils.fund_from_faucet(
             pool_owner.payment,
             cluster_obj=cluster,
-            faucet_data=cluster_manager.cache.addrs_data["user1"],
+            all_faucets=cluster_manager.cache.addrs_data,
             amount=900_000_000,
         )
 
@@ -1813,7 +1813,7 @@ class TestPoolCost:
         clusterlib_utils.fund_from_faucet(
             pool_owners[0].payment,
             cluster_obj=cluster,
-            faucet_data=cluster_manager.cache.addrs_data["user1"],
+            all_faucets=cluster_manager.cache.addrs_data,
             amount=900_000_000,
         )
 
@@ -1896,7 +1896,7 @@ class TestPoolCost:
             clusterlib_utils.fund_from_faucet(
                 pool_owners[0].payment,
                 cluster_obj=cluster,
-                faucet_data=cluster_manager.cache.addrs_data["user1"],
+                all_faucets=cluster_manager.cache.addrs_data,
                 amount=900_000_000,
             )
 
@@ -1940,7 +1940,7 @@ class TestNegative:
         clusterlib_utils.fund_from_faucet(
             created_users[0],
             cluster_obj=cluster,
-            faucet_data=cluster_manager.cache.addrs_data["user1"],
+            all_faucets=cluster_manager.cache.addrs_data,
             amount=600_000_000,
         )
 

--- a/cardano_node_tests/tests/test_reconnect.py
+++ b/cardano_node_tests/tests/test_reconnect.py
@@ -63,7 +63,7 @@ class TestNodeReconnect:
         clusterlib_utils.fund_from_faucet(
             *addrs,
             cluster_obj=cluster,
-            faucet_data=cluster_manager.cache.addrs_data["user1"],
+            all_faucets=cluster_manager.cache.addrs_data,
         )
         return addrs
 

--- a/cardano_node_tests/tests/test_rollback.py
+++ b/cardano_node_tests/tests/test_rollback.py
@@ -72,7 +72,7 @@ class TestRollback:
         clusterlib_utils.fund_from_faucet(
             *addrs,
             cluster_obj=cluster,
-            faucet_data=cluster_manager.cache.addrs_data["user1"],
+            all_faucets=cluster_manager.cache.addrs_data,
         )
         return addrs
 

--- a/cardano_node_tests/tests/test_scripts.py
+++ b/cardano_node_tests/tests/test_scripts.py
@@ -159,7 +159,7 @@ class TestBasic:
         clusterlib_utils.fund_from_faucet(
             addrs[0],
             cluster_obj=cluster,
-            faucet_data=cluster_manager.cache.addrs_data["user1"],
+            all_faucets=cluster_manager.cache.addrs_data,
             amount=10_000_000_000,
         )
 
@@ -705,7 +705,7 @@ class TestNegative:
         clusterlib_utils.fund_from_faucet(
             addrs[0],
             cluster_obj=cluster,
-            faucet_data=cluster_manager.cache.addrs_data["user1"],
+            all_faucets=cluster_manager.cache.addrs_data,
         )
 
         return addrs
@@ -949,7 +949,7 @@ class TestTimeLocking:
         clusterlib_utils.fund_from_faucet(
             addrs[0],
             cluster_obj=cluster,
-            faucet_data=cluster_manager.cache.addrs_data["user1"],
+            all_faucets=cluster_manager.cache.addrs_data,
         )
 
         return addrs
@@ -1615,7 +1615,7 @@ class TestAuxiliaryScripts:
         clusterlib_utils.fund_from_faucet(
             addrs[0],
             cluster_obj=cluster,
-            faucet_data=cluster_manager.cache.addrs_data["user1"],
+            all_faucets=cluster_manager.cache.addrs_data,
         )
 
         return addrs
@@ -1849,7 +1849,7 @@ class TestIncrementalSigning:
         clusterlib_utils.fund_from_faucet(
             addrs[0],
             cluster_obj=cluster,
-            faucet_data=cluster_manager.cache.addrs_data["user1"],
+            all_faucets=cluster_manager.cache.addrs_data,
         )
 
         return addrs
@@ -2049,7 +2049,7 @@ class TestDatum:
         clusterlib_utils.fund_from_faucet(
             addrs[0],
             cluster_obj=cluster,
-            faucet_data=cluster_manager.cache.addrs_data["user1"],
+            all_faucets=cluster_manager.cache.addrs_data,
         )
 
         return addrs
@@ -2158,7 +2158,7 @@ class TestReferenceUTxO:
         clusterlib_utils.fund_from_faucet(
             addrs[0],
             cluster_obj=cluster,
-            faucet_data=cluster_manager.cache.addrs_data["user1"],
+            all_faucets=cluster_manager.cache.addrs_data,
             amount=100_000_000,
         )
 
@@ -2432,7 +2432,7 @@ class TestNested:
         clusterlib_utils.fund_from_faucet(
             addrs[0],
             cluster_obj=cluster,
-            faucet_data=cluster_manager.cache.addrs_data["user1"],
+            all_faucets=cluster_manager.cache.addrs_data,
         )
 
         return addrs
@@ -2859,7 +2859,7 @@ class TestCompatibility:
         clusterlib_utils.fund_from_faucet(
             addrs[0],
             cluster_obj=cluster,
-            faucet_data=cluster_manager.cache.addrs_data["user1"],
+            all_faucets=cluster_manager.cache.addrs_data,
         )
 
         return addrs

--- a/cardano_node_tests/tests/test_socket_path.py
+++ b/cardano_node_tests/tests/test_socket_path.py
@@ -109,7 +109,7 @@ def payment_addrs(
     clusterlib_utils.fund_from_faucet(
         addrs[0],
         cluster_obj=cluster,
-        faucet_data=cluster_manager.cache.addrs_data["user1"],
+        all_faucets=cluster_manager.cache.addrs_data,
         amount=100_000_000,
     )
     return addrs

--- a/cardano_node_tests/tests/test_staking_no_rewards.py
+++ b/cardano_node_tests/tests/test_staking_no_rewards.py
@@ -159,7 +159,7 @@ class TestNoRewards:
             clusterlib_utils.fund_from_faucet(
                 pool_owner,
                 cluster_obj=cluster,
-                faucet_data=cluster_manager.cache.addrs_data["user1"],
+                all_faucets=cluster_manager.cache.addrs_data,
                 amount=900_000_000,
                 force=True,
             )
@@ -319,7 +319,7 @@ class TestNoRewards:
             clusterlib_utils.fund_from_faucet(
                 delegation_out.pool_user,
                 cluster_obj=cluster,
-                faucet_data=cluster_manager.cache.addrs_data["user1"],
+                all_faucets=cluster_manager.cache.addrs_data,
                 amount=900_000_000,
                 force=True,
             )
@@ -501,7 +501,7 @@ class TestNoRewards:
             clusterlib_utils.fund_from_faucet(
                 pool_owner,
                 cluster_obj=cluster,
-                faucet_data=cluster_manager.cache.addrs_data["user1"],
+                all_faucets=cluster_manager.cache.addrs_data,
                 amount=900_000_000,
                 force=True,
             )
@@ -697,7 +697,7 @@ class TestNoRewards:
             clusterlib_utils.fund_from_faucet(
                 pool_reward,
                 cluster_obj=cluster,
-                faucet_data=cluster_manager.cache.addrs_data["user1"],
+                all_faucets=cluster_manager.cache.addrs_data,
                 amount=900_000_000,
                 force=True,
             )
@@ -864,7 +864,7 @@ class TestNoRewards:
             clusterlib_utils.fund_from_faucet(
                 pool_owner,
                 cluster_obj=cluster,
-                faucet_data=cluster_manager.cache.addrs_data["user1"],
+                all_faucets=cluster_manager.cache.addrs_data,
                 amount=900_000_000,
                 force=True,
             )

--- a/cardano_node_tests/tests/test_staking_rewards.py
+++ b/cardano_node_tests/tests/test_staking_rewards.py
@@ -369,7 +369,7 @@ class TestRewards:
         clusterlib_utils.fund_from_faucet(
             *payment_addr_recs,
             cluster_obj=cluster,
-            faucet_data=cluster_manager.cache.addrs_data["user1"],
+            all_faucets=cluster_manager.cache.addrs_data,
         )
 
         pool_user = clusterlib.PoolUser(payment=payment_addr_recs[1], stake=stake_addr_rec)
@@ -675,7 +675,7 @@ class TestRewards:
         clusterlib_utils.fund_from_faucet(
             pool_owner,
             cluster_obj=cluster,
-            faucet_data=cluster_manager.cache.addrs_data["user1"],
+            all_faucets=cluster_manager.cache.addrs_data,
             amount=900_000_000,
             force=True,
         )
@@ -1081,7 +1081,7 @@ class TestRewards:
         clusterlib_utils.fund_from_faucet(
             dst_addr_record,
             cluster_obj=cluster,
-            faucet_data=cluster_manager.cache.addrs_data["user1"],
+            all_faucets=cluster_manager.cache.addrs_data,
         )
 
         # transfer all funds from payment address back to faucet, so no funds are staked
@@ -1200,7 +1200,7 @@ class TestRewards:
         clusterlib_utils.fund_from_faucet(
             pool2_owner,
             cluster_obj=cluster,
-            faucet_data=cluster_manager.cache.addrs_data["user1"],
+            all_faucets=cluster_manager.cache.addrs_data,
             amount=900_000_000,
             force=True,
         )

--- a/cardano_node_tests/tests/test_tx_basic.py
+++ b/cardano_node_tests/tests/test_tx_basic.py
@@ -53,7 +53,7 @@ class TestBasicTransactions:
         clusterlib_utils.fund_from_faucet(
             *addrs,
             cluster_obj=cluster,
-            faucet_data=cluster_manager.cache.addrs_data["user1"],
+            all_faucets=cluster_manager.cache.addrs_data,
         )
         return addrs
 
@@ -81,7 +81,7 @@ class TestBasicTransactions:
         clusterlib_utils.fund_from_faucet(
             *new_byron_addrs,
             cluster_obj=cluster,
-            faucet_data=cluster_manager.cache.addrs_data["user1"],
+            all_faucets=cluster_manager.cache.addrs_data,
         )
         return new_byron_addrs
 
@@ -104,7 +104,7 @@ class TestBasicTransactions:
         clusterlib_utils.fund_from_faucet(
             *addrs,
             cluster_obj=cluster,
-            faucet_data=cluster_manager.cache.addrs_data["user1"],
+            all_faucets=cluster_manager.cache.addrs_data,
         )
         return addrs
 
@@ -126,7 +126,7 @@ class TestBasicTransactions:
         clusterlib_utils.fund_from_faucet(
             addrs[0],
             cluster_obj=cluster,
-            faucet_data=cluster_manager.cache.addrs_data["user1"],
+            all_faucets=cluster_manager.cache.addrs_data,
         )
         return addrs
 
@@ -770,7 +770,7 @@ class TestBasicTransactions:
         clusterlib_utils.fund_from_faucet(
             src_record,
             cluster_obj=cluster,
-            faucet_data=cluster_manager.cache.addrs_data["user1"],
+            all_faucets=cluster_manager.cache.addrs_data,
             amount=2_000_000,
         )
 
@@ -1207,7 +1207,7 @@ class TestMultiInOut:
         clusterlib_utils.fund_from_faucet(
             addrs[0],
             cluster_obj=cluster,
-            faucet_data=cluster_manager.cache.addrs_data["user1"],
+            all_faucets=cluster_manager.cache.addrs_data,
             amount=90_000_000_000,
         )
 
@@ -1508,7 +1508,7 @@ class TestIncrementalSigning:
         clusterlib_utils.fund_from_faucet(
             addrs[0],
             cluster_obj=cluster,
-            faucet_data=cluster_manager.cache.addrs_data["user1"],
+            all_faucets=cluster_manager.cache.addrs_data,
         )
 
         return addrs

--- a/cardano_node_tests/tests/test_tx_fees.py
+++ b/cardano_node_tests/tests/test_tx_fees.py
@@ -63,7 +63,7 @@ class TestFee:
         clusterlib_utils.fund_from_faucet(
             addrs[0],
             cluster_obj=cluster,
-            faucet_data=cluster_manager.cache.addrs_data["user1"],
+            all_faucets=cluster_manager.cache.addrs_data,
         )
 
         return addrs
@@ -219,7 +219,7 @@ class TestExpectedFees:
         clusterlib_utils.fund_from_faucet(
             *created_users[:10],
             cluster_obj=cluster,
-            faucet_data=cluster_manager.cache.addrs_data["user1"],
+            all_faucets=cluster_manager.cache.addrs_data,
         )
 
         return created_users

--- a/cardano_node_tests/tests/test_tx_many_utxos.py
+++ b/cardano_node_tests/tests/test_tx_many_utxos.py
@@ -52,7 +52,7 @@ class TestManyUTXOs:
         clusterlib_utils.fund_from_faucet(
             addrs[0],
             cluster_obj=cluster,
-            faucet_data=cluster_manager.cache.addrs_data["user1"],
+            all_faucets=cluster_manager.cache.addrs_data,
             amount=800_000_000_000,
         )
 

--- a/cardano_node_tests/tests/test_tx_mempool.py
+++ b/cardano_node_tests/tests/test_tx_mempool.py
@@ -37,7 +37,7 @@ class TestMempool:
         clusterlib_utils.fund_from_faucet(
             *addrs,
             cluster_obj=cluster_singleton,
-            faucet_data=cluster_manager.cache.addrs_data["user1"],
+            all_faucets=cluster_manager.cache.addrs_data,
         )
         return addrs
 

--- a/cardano_node_tests/tests/test_tx_metadata.py
+++ b/cardano_node_tests/tests/test_tx_metadata.py
@@ -51,7 +51,7 @@ class TestMetadata:
         clusterlib_utils.fund_from_faucet(
             addr,
             cluster_obj=cluster,
-            faucet_data=cluster_manager.cache.addrs_data["user1"],
+            all_faucets=cluster_manager.cache.addrs_data,
         )
 
         return addr
@@ -607,7 +607,7 @@ class TestMetadata:
         clusterlib_utils.fund_from_faucet(
             src_record,
             cluster_obj=cluster,
-            faucet_data=cluster_manager.cache.addrs_data["user1"],
+            all_faucets=cluster_manager.cache.addrs_data,
             amount=2_000_000,
         )
 

--- a/cardano_node_tests/tests/test_tx_negative.py
+++ b/cardano_node_tests/tests/test_tx_negative.py
@@ -89,7 +89,7 @@ class TestNegative:
         clusterlib_utils.fund_from_faucet(
             *created_users,
             cluster_obj=cluster,
-            faucet_data=cluster_manager.cache.addrs_data["user1"],
+            all_faucets=cluster_manager.cache.addrs_data,
         )
 
         return created_users

--- a/cardano_node_tests/tests/test_tx_unbalanced.py
+++ b/cardano_node_tests/tests/test_tx_unbalanced.py
@@ -86,7 +86,7 @@ class TestUnbalanced:
         clusterlib_utils.fund_from_faucet(
             addrs[0],
             cluster_obj=cluster,
-            faucet_data=cluster_manager.cache.addrs_data["user1"],
+            all_faucets=cluster_manager.cache.addrs_data,
         )
 
         return addrs

--- a/cardano_node_tests/tests/test_update_proposals.py
+++ b/cardano_node_tests/tests/test_update_proposals.py
@@ -64,7 +64,7 @@ class TestUpdateProposals:
         clusterlib_utils.fund_from_faucet(
             addr,
             cluster_obj=cluster,
-            faucet_data=cluster_manager.cache.addrs_data["user1"],
+            all_faucets=cluster_manager.cache.addrs_data,
         )
 
         return addr
@@ -390,7 +390,7 @@ class TestNegativeCostModels:
         clusterlib_utils.fund_from_faucet(
             addr,
             cluster_obj=cluster,
-            faucet_data=cluster_manager.cache.addrs_data["user1"],
+            all_faucets=cluster_manager.cache.addrs_data,
         )
 
         return addr

--- a/cardano_node_tests/tests/tests_conway/conway_common.py
+++ b/cardano_node_tests/tests/tests_conway/conway_common.py
@@ -143,7 +143,7 @@ def get_registered_pool_user(
     clusterlib_utils.fund_from_faucet(
         pool_user.payment,
         cluster_obj=cluster_obj,
-        faucet_data=cluster_manager.cache.addrs_data["user1"],
+        all_faucets=cluster_manager.cache.addrs_data,
         amount=fund_amount,
     )
 

--- a/cardano_node_tests/tests/tests_conway/test_committee.py
+++ b/cardano_node_tests/tests/tests_conway/test_committee.py
@@ -56,7 +56,7 @@ def payment_addr_comm(
     clusterlib_utils.fund_from_faucet(
         addr,
         cluster_obj=cluster,
-        faucet_data=cluster_manager.cache.addrs_data["user1"],
+        all_faucets=cluster_manager.cache.addrs_data,
     )
 
     return addr

--- a/cardano_node_tests/tests/tests_conway/test_drep.py
+++ b/cardano_node_tests/tests/tests_conway/test_drep.py
@@ -76,7 +76,7 @@ def get_payment_addr(
     clusterlib_utils.fund_from_faucet(
         addr,
         cluster_obj=cluster_obj,
-        faucet_data=cluster_manager.cache.addrs_data["user1"],
+        all_faucets=cluster_manager.cache.addrs_data,
     )
 
     return addr
@@ -104,7 +104,7 @@ def get_pool_user(
     clusterlib_utils.fund_from_faucet(
         pool_user.payment,
         cluster_obj=cluster_obj,
-        faucet_data=cluster_manager.cache.addrs_data["user1"],
+        all_faucets=cluster_manager.cache.addrs_data,
     )
     return pool_user
 
@@ -1876,7 +1876,7 @@ class TestDRepActivity:
         clusterlib_utils.fund_from_faucet(
             *drep_users,
             cluster_obj=cluster,
-            faucet_data=cluster_manager.cache.addrs_data["user1"],
+            all_faucets=cluster_manager.cache.addrs_data,
             # Add a lot of funds so no action can be ratified without the new DReps
             amount=10_000_000_000_000,
         )

--- a/cardano_node_tests/tests/tests_conway/test_guardrails.py
+++ b/cardano_node_tests/tests/tests_conway/test_guardrails.py
@@ -97,7 +97,7 @@ def payment_addr(
     clusterlib_utils.fund_from_faucet(
         addr,
         cluster_obj=cluster,
-        faucet_data=cluster_manager.cache.addrs_data["user1"],
+        all_faucets=cluster_manager.cache.addrs_data,
         amount=10_000_000_000,
     )
 

--- a/cardano_node_tests/tests/tests_conway/test_pparam_update.py
+++ b/cardano_node_tests/tests/tests_conway/test_pparam_update.py
@@ -1399,7 +1399,7 @@ class TestLegacyProposals:
         clusterlib_utils.fund_from_faucet(
             addr,
             cluster_obj=cluster,
-            faucet_data=cluster_manager.cache.addrs_data["user1"],
+            all_faucets=cluster_manager.cache.addrs_data,
         )
 
         return addr

--- a/cardano_node_tests/tests/tests_conway/test_treasury_donation.py
+++ b/cardano_node_tests/tests/tests_conway/test_treasury_donation.py
@@ -50,7 +50,7 @@ def payment_addr_treasury(
     clusterlib_utils.fund_from_faucet(
         addr,
         cluster_obj=cluster_treasury,
-        faucet_data=cluster_manager.cache.addrs_data["user1"],
+        all_faucets=cluster_manager.cache.addrs_data,
     )
     return addr
 
@@ -73,7 +73,7 @@ def payment_addr_singleton(
     clusterlib_utils.fund_from_faucet(
         addr,
         cluster_obj=cluster_singleton,
-        faucet_data=cluster_manager.cache.addrs_data["user1"],
+        all_faucets=cluster_manager.cache.addrs_data,
     )
     return addr
 

--- a/cardano_node_tests/tests/tests_conway/test_update_plutusv2_builtins.py
+++ b/cardano_node_tests/tests/tests_conway/test_update_plutusv2_builtins.py
@@ -62,7 +62,7 @@ def payment_addrs_lg(
     clusterlib_utils.fund_from_faucet(
         addrs[0],
         cluster_obj=cluster,
-        faucet_data=cluster_manager.cache.addrs_data["user1"],
+        all_faucets=cluster_manager.cache.addrs_data,
         amount=3_000_000_000,
     )
 

--- a/cardano_node_tests/tests/tests_plutus/test_delegation.py
+++ b/cardano_node_tests/tests/tests_plutus/test_delegation.py
@@ -103,7 +103,7 @@ def pool_user(
     clusterlib_utils.fund_from_faucet(
         payment_addr_rec,
         cluster_obj=cluster,
-        faucet_data=cluster_manager.cache.addrs_data["user1"],
+        all_faucets=cluster_manager.cache.addrs_data,
         amount=18_000_000_000,
     )
 

--- a/cardano_node_tests/tests/tests_plutus/test_lobster.py
+++ b/cardano_node_tests/tests/tests_plutus/test_lobster.py
@@ -51,7 +51,7 @@ def payment_addrs(
     clusterlib_utils.fund_from_faucet(
         addrs[0],
         cluster_obj=cluster,
-        faucet_data=cluster_manager.cache.addrs_data["user1"],
+        all_faucets=cluster_manager.cache.addrs_data,
         amount=3_000_000_000,
     )
 

--- a/cardano_node_tests/tests/tests_plutus/test_mint_build.py
+++ b/cardano_node_tests/tests/tests_plutus/test_mint_build.py
@@ -50,7 +50,7 @@ def payment_addrs(
     clusterlib_utils.fund_from_faucet(
         addrs[0],
         cluster_obj=cluster,
-        faucet_data=cluster_manager.cache.addrs_data["user1"],
+        all_faucets=cluster_manager.cache.addrs_data,
         amount=3_000_000_000,
     )
 

--- a/cardano_node_tests/tests/tests_plutus/test_mint_negative_build.py
+++ b/cardano_node_tests/tests/tests_plutus/test_mint_negative_build.py
@@ -51,7 +51,7 @@ def payment_addrs(
     clusterlib_utils.fund_from_faucet(
         addrs[0],
         cluster_obj=cluster,
-        faucet_data=cluster_manager.cache.addrs_data["user1"],
+        all_faucets=cluster_manager.cache.addrs_data,
         amount=3_000_000_000,
     )
 

--- a/cardano_node_tests/tests/tests_plutus/test_mint_negative_raw.py
+++ b/cardano_node_tests/tests/tests_plutus/test_mint_negative_raw.py
@@ -43,7 +43,7 @@ def payment_addrs(
     clusterlib_utils.fund_from_faucet(
         addrs[0],
         cluster_obj=cluster,
-        faucet_data=cluster_manager.cache.addrs_data["user1"],
+        all_faucets=cluster_manager.cache.addrs_data,
         amount=3_000_000_000,
     )
 

--- a/cardano_node_tests/tests/tests_plutus/test_mint_raw.py
+++ b/cardano_node_tests/tests/tests_plutus/test_mint_raw.py
@@ -46,7 +46,7 @@ def payment_addrs(
     clusterlib_utils.fund_from_faucet(
         addrs[0],
         cluster_obj=cluster,
-        faucet_data=cluster_manager.cache.addrs_data["user1"],
+        all_faucets=cluster_manager.cache.addrs_data,
         amount=3_000_000_000,
     )
 

--- a/cardano_node_tests/tests/tests_plutus/test_spend_build.py
+++ b/cardano_node_tests/tests/tests_plutus/test_spend_build.py
@@ -45,7 +45,7 @@ def payment_addrs(
     clusterlib_utils.fund_from_faucet(
         addrs[0],
         cluster_obj=cluster,
-        faucet_data=cluster_manager.cache.addrs_data["user1"],
+        all_faucets=cluster_manager.cache.addrs_data,
         amount=1_000_000_000,
     )
 
@@ -69,7 +69,7 @@ def pool_users(
     clusterlib_utils.fund_from_faucet(
         created_users[0],
         cluster_obj=cluster,
-        faucet_data=cluster_manager.cache.addrs_data["user1"],
+        all_faucets=cluster_manager.cache.addrs_data,
         amount=3_000_000_000,
     )
 

--- a/cardano_node_tests/tests/tests_plutus/test_spend_compat_build.py
+++ b/cardano_node_tests/tests/tests_plutus/test_spend_compat_build.py
@@ -39,7 +39,7 @@ def payment_addrs(
     clusterlib_utils.fund_from_faucet(
         addrs[0],
         cluster_obj=cluster,
-        faucet_data=cluster_manager.cache.addrs_data["user1"],
+        all_faucets=cluster_manager.cache.addrs_data,
         amount=1_000_000_000,
     )
 

--- a/cardano_node_tests/tests/tests_plutus/test_spend_compat_raw.py
+++ b/cardano_node_tests/tests/tests_plutus/test_spend_compat_raw.py
@@ -38,7 +38,7 @@ def payment_addrs(
     clusterlib_utils.fund_from_faucet(
         addrs[0],
         cluster_obj=cluster,
-        faucet_data=cluster_manager.cache.addrs_data["user1"],
+        all_faucets=cluster_manager.cache.addrs_data,
         amount=3_000_000_000,
     )
 

--- a/cardano_node_tests/tests/tests_plutus/test_spend_datum_build.py
+++ b/cardano_node_tests/tests/tests_plutus/test_spend_datum_build.py
@@ -46,7 +46,7 @@ def payment_addrs(
     clusterlib_utils.fund_from_faucet(
         addrs[0],
         cluster_obj=cluster,
-        faucet_data=cluster_manager.cache.addrs_data["user1"],
+        all_faucets=cluster_manager.cache.addrs_data,
         amount=1_000_000_000,
     )
 

--- a/cardano_node_tests/tests/tests_plutus/test_spend_datum_raw.py
+++ b/cardano_node_tests/tests/tests_plutus/test_spend_datum_raw.py
@@ -43,7 +43,7 @@ def payment_addrs(
     clusterlib_utils.fund_from_faucet(
         addrs[0],
         cluster_obj=cluster,
-        faucet_data=cluster_manager.cache.addrs_data["user1"],
+        all_faucets=cluster_manager.cache.addrs_data,
         amount=3_000_000_000,
     )
 

--- a/cardano_node_tests/tests/tests_plutus/test_spend_negative_build.py
+++ b/cardano_node_tests/tests/tests_plutus/test_spend_negative_build.py
@@ -44,7 +44,7 @@ def payment_addrs(
     clusterlib_utils.fund_from_faucet(
         addrs[0],
         cluster_obj=cluster,
-        faucet_data=cluster_manager.cache.addrs_data["user1"],
+        all_faucets=cluster_manager.cache.addrs_data,
         amount=1_000_000_000,
     )
 

--- a/cardano_node_tests/tests/tests_plutus/test_spend_negative_raw.py
+++ b/cardano_node_tests/tests/tests_plutus/test_spend_negative_raw.py
@@ -50,7 +50,7 @@ def payment_addrs(
     clusterlib_utils.fund_from_faucet(
         addrs[0],
         cluster_obj=cluster,
-        faucet_data=cluster_manager.cache.addrs_data["user1"],
+        all_faucets=cluster_manager.cache.addrs_data,
         amount=3_000_000_000,
     )
 
@@ -720,7 +720,7 @@ class TestNegativeRedeemer:
         clusterlib_utils.fund_from_faucet(
             payment_addrs[0],
             cluster_obj=cluster_obj,
-            faucet_data=cluster_manager.cache.addrs_data["user1"],
+            all_faucets=cluster_manager.cache.addrs_data,
             amount=3_000_000_000,
         )
 

--- a/cardano_node_tests/tests/tests_plutus/test_spend_raw.py
+++ b/cardano_node_tests/tests/tests_plutus/test_spend_raw.py
@@ -49,7 +49,7 @@ def payment_addrs(
     clusterlib_utils.fund_from_faucet(
         addrs[0],
         cluster_obj=cluster,
-        faucet_data=cluster_manager.cache.addrs_data["user1"],
+        all_faucets=cluster_manager.cache.addrs_data,
         amount=3_000_000_000,
     )
 
@@ -73,7 +73,7 @@ def pool_users(
     clusterlib_utils.fund_from_faucet(
         created_users[0],
         cluster_obj=cluster,
-        faucet_data=cluster_manager.cache.addrs_data["user1"],
+        all_faucets=cluster_manager.cache.addrs_data,
         amount=3_000_000_000,
     )
 

--- a/cardano_node_tests/tests/tests_plutus_v2/test_mint_build.py
+++ b/cardano_node_tests/tests/tests_plutus_v2/test_mint_build.py
@@ -42,7 +42,7 @@ def payment_addrs(
     clusterlib_utils.fund_from_faucet(
         addrs[0],
         cluster_obj=cluster,
-        faucet_data=cluster_manager.cache.addrs_data["user1"],
+        all_faucets=cluster_manager.cache.addrs_data,
         amount=3_000_000_000,
     )
 

--- a/cardano_node_tests/tests/tests_plutus_v2/test_mint_negative_build.py
+++ b/cardano_node_tests/tests/tests_plutus_v2/test_mint_negative_build.py
@@ -39,7 +39,7 @@ def payment_addrs(
     clusterlib_utils.fund_from_faucet(
         addrs[0],
         cluster_obj=cluster,
-        faucet_data=cluster_manager.cache.addrs_data["user1"],
+        all_faucets=cluster_manager.cache.addrs_data,
         amount=3_000_000_000,
     )
 

--- a/cardano_node_tests/tests/tests_plutus_v2/test_mint_negative_raw.py
+++ b/cardano_node_tests/tests/tests_plutus_v2/test_mint_negative_raw.py
@@ -38,7 +38,7 @@ def payment_addrs(
     clusterlib_utils.fund_from_faucet(
         addrs[0],
         cluster_obj=cluster,
-        faucet_data=cluster_manager.cache.addrs_data["user1"],
+        all_faucets=cluster_manager.cache.addrs_data,
         amount=3_000_000_000,
     )
 

--- a/cardano_node_tests/tests/tests_plutus_v2/test_mint_raw.py
+++ b/cardano_node_tests/tests/tests_plutus_v2/test_mint_raw.py
@@ -42,7 +42,7 @@ def payment_addrs(
     clusterlib_utils.fund_from_faucet(
         addrs[0],
         cluster_obj=cluster,
-        faucet_data=cluster_manager.cache.addrs_data["user1"],
+        all_faucets=cluster_manager.cache.addrs_data,
         amount=3_000_000_000,
     )
 

--- a/cardano_node_tests/tests/tests_plutus_v2/test_mint_secp256k1_build.py
+++ b/cardano_node_tests/tests/tests_plutus_v2/test_mint_secp256k1_build.py
@@ -40,7 +40,7 @@ def payment_addrs(
     clusterlib_utils.fund_from_faucet(
         addrs[0],
         cluster_obj=cluster,
-        faucet_data=cluster_manager.cache.addrs_data["user1"],
+        all_faucets=cluster_manager.cache.addrs_data,
         amount=3_000_000_000,
     )
 

--- a/cardano_node_tests/tests/tests_plutus_v2/test_mint_secp256k1_raw.py
+++ b/cardano_node_tests/tests/tests_plutus_v2/test_mint_secp256k1_raw.py
@@ -40,7 +40,7 @@ def payment_addrs(
     clusterlib_utils.fund_from_faucet(
         addrs[0],
         cluster_obj=cluster,
-        faucet_data=cluster_manager.cache.addrs_data["user1"],
+        all_faucets=cluster_manager.cache.addrs_data,
         amount=3_000_000_000,
     )
 

--- a/cardano_node_tests/tests/tests_plutus_v2/test_spend_build.py
+++ b/cardano_node_tests/tests/tests_plutus_v2/test_spend_build.py
@@ -42,7 +42,7 @@ def payment_addrs(
     clusterlib_utils.fund_from_faucet(
         addrs[0],
         cluster_obj=cluster,
-        faucet_data=cluster_manager.cache.addrs_data["user1"],
+        all_faucets=cluster_manager.cache.addrs_data,
         amount=1_000_000_000,
     )
 

--- a/cardano_node_tests/tests/tests_plutus_v2/test_spend_collateral_build.py
+++ b/cardano_node_tests/tests/tests_plutus_v2/test_spend_collateral_build.py
@@ -42,7 +42,7 @@ def payment_addrs(
     clusterlib_utils.fund_from_faucet(
         addrs[0],
         cluster_obj=cluster,
-        faucet_data=cluster_manager.cache.addrs_data["user1"],
+        all_faucets=cluster_manager.cache.addrs_data,
         amount=1_000_000_000,
     )
 

--- a/cardano_node_tests/tests/tests_plutus_v2/test_spend_collateral_raw.py
+++ b/cardano_node_tests/tests/tests_plutus_v2/test_spend_collateral_raw.py
@@ -41,7 +41,7 @@ def payment_addrs(
     clusterlib_utils.fund_from_faucet(
         addrs[0],
         cluster_obj=cluster,
-        faucet_data=cluster_manager.cache.addrs_data["user1"],
+        all_faucets=cluster_manager.cache.addrs_data,
         amount=3_000_000_000,
     )
 

--- a/cardano_node_tests/tests/tests_plutus_v2/test_spend_compat_build.py
+++ b/cardano_node_tests/tests/tests_plutus_v2/test_spend_compat_build.py
@@ -40,7 +40,7 @@ def payment_addrs(
     clusterlib_utils.fund_from_faucet(
         addrs[0],
         cluster_obj=cluster,
-        faucet_data=cluster_manager.cache.addrs_data["user1"],
+        all_faucets=cluster_manager.cache.addrs_data,
         amount=1_000_000_000,
     )
 

--- a/cardano_node_tests/tests/tests_plutus_v2/test_spend_compat_raw.py
+++ b/cardano_node_tests/tests/tests_plutus_v2/test_spend_compat_raw.py
@@ -39,7 +39,7 @@ def payment_addrs(
     clusterlib_utils.fund_from_faucet(
         addrs[0],
         cluster_obj=cluster,
-        faucet_data=cluster_manager.cache.addrs_data["user1"],
+        all_faucets=cluster_manager.cache.addrs_data,
         amount=3_000_000_000,
     )
 

--- a/cardano_node_tests/tests/tests_plutus_v2/test_spend_datum_build.py
+++ b/cardano_node_tests/tests/tests_plutus_v2/test_spend_datum_build.py
@@ -44,7 +44,7 @@ def payment_addrs(
     clusterlib_utils.fund_from_faucet(
         addrs[0],
         cluster_obj=cluster,
-        faucet_data=cluster_manager.cache.addrs_data["user1"],
+        all_faucets=cluster_manager.cache.addrs_data,
         amount=1_000_000_000,
     )
 

--- a/cardano_node_tests/tests/tests_plutus_v2/test_spend_datum_raw.py
+++ b/cardano_node_tests/tests/tests_plutus_v2/test_spend_datum_raw.py
@@ -43,7 +43,7 @@ def payment_addrs(
     clusterlib_utils.fund_from_faucet(
         addrs[0],
         cluster_obj=cluster,
-        faucet_data=cluster_manager.cache.addrs_data["user1"],
+        all_faucets=cluster_manager.cache.addrs_data,
         amount=3_000_000_000,
     )
 

--- a/cardano_node_tests/tests/tests_plutus_v2/test_spend_raw.py
+++ b/cardano_node_tests/tests/tests_plutus_v2/test_spend_raw.py
@@ -41,7 +41,7 @@ def payment_addrs(
     clusterlib_utils.fund_from_faucet(
         addrs[0],
         cluster_obj=cluster,
-        faucet_data=cluster_manager.cache.addrs_data["user1"],
+        all_faucets=cluster_manager.cache.addrs_data,
         amount=3_000_000_000,
     )
 

--- a/cardano_node_tests/tests/tests_plutus_v2/test_spend_ref_inputs_build.py
+++ b/cardano_node_tests/tests/tests_plutus_v2/test_spend_ref_inputs_build.py
@@ -43,7 +43,7 @@ def payment_addrs(
     clusterlib_utils.fund_from_faucet(
         addrs[0],
         cluster_obj=cluster,
-        faucet_data=cluster_manager.cache.addrs_data["user1"],
+        all_faucets=cluster_manager.cache.addrs_data,
         amount=1_000_000_000,
     )
 
@@ -290,7 +290,7 @@ class TestReadonlyReferenceInputs:
         clusterlib_utils.fund_from_faucet(
             payment_addrs[1],
             cluster_obj=cluster,
-            faucet_data=cluster_manager.cache.addrs_data["user1"],
+            all_faucets=cluster_manager.cache.addrs_data,
         )
 
         # create the reference input

--- a/cardano_node_tests/tests/tests_plutus_v2/test_spend_ref_inputs_raw.py
+++ b/cardano_node_tests/tests/tests_plutus_v2/test_spend_ref_inputs_raw.py
@@ -42,7 +42,7 @@ def payment_addrs(
     clusterlib_utils.fund_from_faucet(
         addrs[0],
         cluster_obj=cluster,
-        faucet_data=cluster_manager.cache.addrs_data["user1"],
+        all_faucets=cluster_manager.cache.addrs_data,
         amount=3_000_000_000,
     )
 

--- a/cardano_node_tests/tests/tests_plutus_v2/test_spend_ref_scripts_build.py
+++ b/cardano_node_tests/tests/tests_plutus_v2/test_spend_ref_scripts_build.py
@@ -40,7 +40,7 @@ def payment_addrs(
     clusterlib_utils.fund_from_faucet(
         addrs[0],
         cluster_obj=cluster,
-        faucet_data=cluster_manager.cache.addrs_data["user1"],
+        all_faucets=cluster_manager.cache.addrs_data,
         amount=1_000_000_000,
     )
 

--- a/cardano_node_tests/tests/tests_plutus_v2/test_spend_ref_scripts_raw.py
+++ b/cardano_node_tests/tests/tests_plutus_v2/test_spend_ref_scripts_raw.py
@@ -40,7 +40,7 @@ def payment_addrs(
     clusterlib_utils.fund_from_faucet(
         addrs[0],
         cluster_obj=cluster,
-        faucet_data=cluster_manager.cache.addrs_data["user1"],
+        all_faucets=cluster_manager.cache.addrs_data,
         amount=3_000_000_000,
     )
 

--- a/cardano_node_tests/tests/tests_plutus_v2/test_spend_secp256k1_build.py
+++ b/cardano_node_tests/tests/tests_plutus_v2/test_spend_secp256k1_build.py
@@ -43,7 +43,7 @@ def payment_addrs(
     clusterlib_utils.fund_from_faucet(
         addrs[0],
         cluster_obj=cluster,
-        faucet_data=cluster_manager.cache.addrs_data["user1"],
+        all_faucets=cluster_manager.cache.addrs_data,
         amount=1_000_000_000,
     )
 

--- a/cardano_node_tests/tests/tests_plutus_v2/test_spend_secp256k1_raw.py
+++ b/cardano_node_tests/tests/tests_plutus_v2/test_spend_secp256k1_raw.py
@@ -39,7 +39,7 @@ def payment_addrs(
     clusterlib_utils.fund_from_faucet(
         addrs[0],
         cluster_obj=cluster,
-        faucet_data=cluster_manager.cache.addrs_data["user1"],
+        all_faucets=cluster_manager.cache.addrs_data,
         amount=3_000_000_000,
     )
 

--- a/cardano_node_tests/utils/governance_setup.py
+++ b/cardano_node_tests/utils/governance_setup.py
@@ -113,7 +113,7 @@ def create_vote_stake(
     clusterlib_utils.fund_from_faucet(
         *pool_users,
         cluster_obj=cluster_obj,
-        faucet_data=cluster_manager.cache.addrs_data["user1"],
+        faucet_data=cluster_manager.cache.addrs_data["faucet"],
         amount=500_000_000_000,
         destination_dir=destination_dir,
     )


### PR DESCRIPTION
When running tests in parallel, having single faucet can be a bottleneck.
Only single test can use the faucet address at a time (otherwise multiple tests would be spending the same UTxOs). It can take a lot of time to gain access to the faucet on slower testnets.
Having multiple faucet addresses speed things up, because the time needed for gaining exclusive access to a faucet address is reduced.