### PR TITLE
Block production epoch

### DIFF
--- a/cardano_node_tests/tests/test_blocks.py
+++ b/cardano_node_tests/tests/test_blocks.py
@@ -390,17 +390,12 @@ class TestDynamicBlockProd:
         """Create new payment addresses."""
         cluster = cluster_singleton
 
-        with cluster_manager.cache_fixture() as fixture_cache:
-            if fixture_cache.value:
-                return fixture_cache.value  # type: ignore
+        addrs = clusterlib_utils.create_payment_addr_records(
+            *[f"addr_dyn_prod_ci{cluster_manager.cluster_instance_num}_{i}" for i in range(20)],
+            cluster_obj=cluster,
+        )
 
-            addrs = clusterlib_utils.create_payment_addr_records(
-                *[f"addr_dyn_prod_ci{cluster_manager.cluster_instance_num}_{i}" for i in range(20)],
-                cluster_obj=cluster,
-            )
-            fixture_cache.value = addrs
-
-        # fund source addresses
+        # Fund source addresses
         clusterlib_utils.fund_from_faucet(
             *addrs,
             cluster_obj=cluster,

--- a/cardano_node_tests/tests/test_blocks.py
+++ b/cardano_node_tests/tests/test_blocks.py
@@ -447,16 +447,8 @@ class TestDynamicBlockProd:
             blocks_before: tp.Dict[str, int] = ledger_state["blocksBefore"]
             return blocks_before
 
-        # Blocks are produced by BFT node in Byron epoch and first Shelley epoch on local cluster
-        # that starts in Byron era.
-        if (
-            cluster_nodes.get_cluster_type().type == cluster_nodes.ClusterType.LOCAL
-            and not cluster_nodes.get_cluster_type().uses_shortcut
-        ):
-            cluster.wait_for_epoch(epoch_no=2)
-
-        # The network needs to be at least in epoch 1
-        cluster.wait_for_epoch(epoch_no=1)
+        # The network needs to be at least in epoch 2
+        cluster.wait_for_epoch(epoch_no=2)
 
         # Wait for the epoch to be at least half way through and not too close to the end.
         # We want the original pool to have time to forge blocks in this epoch, before it becomes


### PR DESCRIPTION
Make sure a testnet is at least in epoch 2. We want to make sure all pools are already forging blocks.