### PR TITLE
fix(tests): fund large amounts of tADA from main faucet

### DIFF
--- a/cardano_node_tests/tests/test_tx_many_utxos.py
+++ b/cardano_node_tests/tests/test_tx_many_utxos.py
@@ -52,7 +52,7 @@ class TestManyUTXOs:
         clusterlib_utils.fund_from_faucet(
             addrs[0],
             cluster_obj=cluster,
-            all_faucets=cluster_manager.cache.addrs_data,
+            faucet_data=cluster_manager.cache.addrs_data["faucet"],
             amount=800_000_000_000,
         )
 

--- a/cardano_node_tests/tests/tests_conway/test_drep.py
+++ b/cardano_node_tests/tests/tests_conway/test_drep.py
@@ -1876,7 +1876,7 @@ class TestDRepActivity:
         clusterlib_utils.fund_from_faucet(
             *drep_users,
             cluster_obj=cluster,
-            all_faucets=cluster_manager.cache.addrs_data,
+            faucet_data=cluster_manager.cache.addrs_data["faucet"],
             # Add a lot of funds so no action can be ratified without the new DReps
             amount=10_000_000_000_000,
         )


### PR DESCRIPTION
Fund large amounts of tADA from the main faucet instead of from the user faucets. User faucets don't need to have that much tADA.