### PR TITLE
feat: make test env setup reusable in another shells

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,12 @@ Sometimes it is useful to run individual tests and keep the local cluster runnin
     ./dev_workdir/conway_fast/stop-cluster
     ```
 
+To reuse the existing testing environment in another nix shell, source the `.source` file that was generated during setup:
+
+```sh
+source ./dev_workdir/.source
+```
+
 ## Variables for configuring testrun
 
 Tests execution can be configured using env variables.

--- a/prepare_test_env.sh
+++ b/prepare_test_env.sh
@@ -52,10 +52,32 @@ if [ ! -d "$_scripts_dest" ]; then
 fi
 unset _scripts_dest
 
+cat > "$WORKDIR/.source" <<EoF
+if [ -z "\${IN_NIX_SHELL:-""}" ]; then
+  echo "WARNING: This script is supposed to be sourced from nix shell." >&2
+fi
+source "$VIRTUAL_ENV/bin/activate"
+PYTHONPATH="$(echo "\$VIRTUAL_ENV"/lib/python3*/site-packages):\$PYTHONPATH"
+export PYTHONPATH
+export CARDANO_NODE_SOCKET_PATH="$PWD/dev_workdir/state-cluster0/bft1.socket"
+export TMPDIR="$PWD/dev_workdir/tmp"
+export DEV_CLUSTER_RUNNING=1
+export CLUSTERS_COUNT=1
+export FORBID_RESTART=1
+export NO_ARTIFACTS=1
+export CLUSTER_ERA="$CLUSTER_ERA"
+export COMMAND_ERA="${COMMAND_ERA:-""}"
+EoF
+
 echo
 echo
-echo "----------------------------------------"
+echo "------------------------"
+echo "|    Test Env Ready    |"
+echo "------------------------"
 echo
 echo "To start local testnet, run:"
 echo "$WORKDIR/${CLUSTER_ERA}_fast/start-cluster"
+echo
+echo "To reuse the test env in another shell, source the env with:"
+echo "source $WORKDIR/.source"
 echo


### PR DESCRIPTION
Running test env setup recreates the whole test env. Sometimes it is useful to activate the same test env in multiple shells. This change enables that.