### PR TITLE
feat(tests): mark test_guardrails as long running

### DIFF
--- a/cardano_node_tests/tests/tests_conway/test_guardrails.py
+++ b/cardano_node_tests/tests/tests_conway/test_guardrails.py
@@ -1564,6 +1564,7 @@ def get_subtests() -> tp.Generator[tp.Callable, None, None]:  # noqa: C901
 
 class TestGovernanceGuardrails:
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.long
     @pytest.mark.testnets
     def test_guardrails(
         self,


### PR DESCRIPTION
Added @pytest.mark.long to the test_guardrails method in TestGovernanceGuardrails class to indicate that it is a long-running test. This helps in scheduling tests based on their execution time.