### PR TITLE
fix(tests): handle CLI issue 942 in various tests

### DIFF
--- a/cardano_node_tests/tests/issues.py
+++ b/cardano_node_tests/tests/issues.py
@@ -86,6 +86,12 @@ cli_904 = blockers.GH(
     fixed_in="9.5.0.0",  # Fixed in some release after 9.4.1.0
     message="Negative pparam proposal values overflow to positive.",
 )
+cli_942 = blockers.GH(
+    issue=942,
+    repo="IntersectMBO/cardano-cli",
+    fixed_in="10.0.0.1",  # Fixed in some release after 10.0.0.0
+    message="build command doesn't balance key deposit.",
+)
 
 consensus_973 = blockers.GH(
     issue=973,

--- a/cardano_node_tests/tests/test_addr_registration.py
+++ b/cardano_node_tests/tests/test_addr_registration.py
@@ -161,7 +161,12 @@ class TestRegisterAddr:
                 signing_key_files=tx_files_dereg.signing_key_files,
                 tx_name=f"{temp_template}_dereg",
             )
-            cluster.g_transaction.submit_tx(tx_file=tx_signed, txins=tx_raw_output_dereg.txins)
+            try:
+                cluster.g_transaction.submit_tx(tx_file=tx_signed, txins=tx_raw_output_dereg.txins)
+            except clusterlib.CLIError as exc:
+                if "ValueNotConservedUTxO" in str(exc):
+                    issues.cli_942.finish_test()
+                raise
         else:
             tx_raw_output_dereg = cluster.g_transaction.send_tx(
                 src_address=user_payment.address,

--- a/cardano_node_tests/tests/test_delegation.py
+++ b/cardano_node_tests/tests/test_delegation.py
@@ -11,6 +11,7 @@ from cardano_node_tests.cluster_management import cluster_management
 from cardano_node_tests.cluster_management import resources_management
 from cardano_node_tests.tests import common
 from cardano_node_tests.tests import delegation
+from cardano_node_tests.tests import issues
 from cardano_node_tests.utils import clusterlib_utils
 from cardano_node_tests.utils import dbsync_utils
 from cardano_node_tests.utils import helpers
@@ -819,7 +820,12 @@ class TestDelegateAddr:
                 signing_key_files=tx_files.signing_key_files,
                 tx_name=f"{temp_template}_deleg_dereg",
             )
-            cluster.g_transaction.submit_tx(tx_file=tx_signed, txins=tx_raw_output_deleg.txins)
+            try:
+                cluster.g_transaction.submit_tx(tx_file=tx_signed, txins=tx_raw_output_deleg.txins)
+            except clusterlib.CLIError as exc:
+                if "ValueNotConservedUTxO" in str(exc):
+                    issues.cli_942.finish_test()
+                raise
         else:
             tx_raw_output_deleg = cluster.g_transaction.send_tx(
                 src_address=user_payment.address,

--- a/cardano_node_tests/tests/tests_conway/test_constitution.py
+++ b/cardano_node_tests/tests/tests_conway/test_constitution.py
@@ -238,7 +238,7 @@ def script_dreps_lg(
             cluster_obj=cluster,
             name_template=f"{temp_template}_dereg",
             src_address=pool_users[0].payment.address,
-            use_build_cmd=True,
+            use_build_cmd=False,  # Workaround for CLI issue 942
             tx_files=tx_files,
             withdrawals=withdrawals,
             deposit=-sum(s.delegation_deposit for __, s in pool_users_info),

--- a/cardano_node_tests/tests/tests_plutus/test_delegation.py
+++ b/cardano_node_tests/tests/tests_plutus/test_delegation.py
@@ -13,6 +13,7 @@ import typing as tp
 import allure
 import pytest
 from cardano_clusterlib import clusterlib
+from packaging import version
 
 from cardano_node_tests.cluster_management import cluster_management
 from cardano_node_tests.cluster_management import resources_management
@@ -28,6 +29,8 @@ from cardano_node_tests.utils import tx_view
 from cardano_node_tests.utils.versions import VERSIONS
 
 LOGGER = logging.getLogger(__name__)
+
+CLI_WITH_ISSUE_942 = version.parse("10.0.0.0")
 
 pytestmark = [
     common.SKIPIF_PLUTUS_UNUSABLE,
@@ -630,7 +633,7 @@ class TestRegisterAddr:
             pool_user=pool_user,
             redeemer_file=plutus_common.REDEEMER_42,
             reference_script_utxos=reference_script_utxos,
-            use_build_cmd=use_build_cmd,
+            use_build_cmd=use_build_cmd and VERSIONS.cli != CLI_WITH_ISSUE_942,
         )
 
         if reward_error:
@@ -839,12 +842,12 @@ class TestDelegateAddr:
                 pool_user=pool_user,
                 redeemer_file=plutus_common.REDEEMER_42,
                 reference_script_utxos=reference_script_utxos,
-                use_build_cmd=use_build_cmd,
+                use_build_cmd=use_build_cmd and VERSIONS.cli != CLI_WITH_ISSUE_942,
             )
         except clusterlib.CLIError as exc:
-            if "(MissingRedeemers" not in str(exc):
-                raise
-            issues.cli_299.finish_test()
+            if "(MissingRedeemers" in str(exc):
+                issues.cli_299.finish_test()
+            raise
 
         if reward_error:
             raise AssertionError(reward_error)
@@ -1069,7 +1072,7 @@ class TestDelegateAddr:
             pool_user=pool_user,
             redeemer_file=plutus_common.REDEEMER_42,
             reference_script_utxos=reference_script_utxos,
-            use_build_cmd=use_build_cmd,
+            use_build_cmd=use_build_cmd and VERSIONS.cli != CLI_WITH_ISSUE_942,
         )
 
         if reward_error:


### PR DESCRIPTION
- Added handling for CLI issue 942 in `TestRegisterAddr` and `TestDelegateAddr` classes.
- Updated `script_dreps_lg` to use workaround for CLI issue 942.
- Introduced `CLI_WITH_ISSUE_942` constant to manage version-specific behavior.
- Ensured tests finish appropriately when encountering `ValueNotConservedUTxO` error.