### PR TITLE
feat(workflows): update regression workflows for conway era

### DIFF
--- a/.github/workflows/regression-dbsync.yaml
+++ b/.github/workflows/regression-dbsync.yaml
@@ -13,18 +13,16 @@ on:
         type: choice
         description: "Cluster era"
         options:
-        - babbage
-        default: babbage
+        - conway 9
+        - conway 10
+        default: conway 9
       tx_era:
         type: choice
         description: "Tx era"
         options:
         - default
+        - conway
         - babbage
-        - alonzo
-        - mary
-        - allegra
-        - shelley
         default: default
       markexpr:
         type: choice
@@ -36,6 +34,7 @@ on:
         - plutus
         - plutus and smoke
         - not long
+        - conway only
         - dbsync and smoke
         - dbsync and plutus
         - dbsync and not long

--- a/.github/workflows/regression.yaml
+++ b/.github/workflows/regression.yaml
@@ -12,7 +12,6 @@ on:
         options:
         - conway 9
         - conway 10
-        - babbage
         default: conway 9
       tx_era:
         type: choice
@@ -21,10 +20,6 @@ on:
         - default
         - conway
         - babbage
-        - alonzo
-        - mary
-        - allegra
-        - shelley
         default: default
       markexpr:
         type: choice


### PR DESCRIPTION
- Added conway 9 and conway 10 options to cluster era in regression-dbsync.yaml
- Set default cluster era to conway 9 in regression-dbsync.yaml
- Added conway option to tx era in regression-dbsync.yaml
- Removed older eras (alonzo, mary, allegra, shelley) from tx era in both regression-dbsync.yaml and regression.yaml
- Added conway only option to markexpr in regression-dbsync.yaml