### PR TITLE
refactor: remove unused DREPS_NUM constant

### DIFF
--- a/cardano_node_tests/utils/governance_setup.py
+++ b/cardano_node_tests/utils/governance_setup.py
@@ -17,8 +17,6 @@ LOGGER = logging.getLogger(__name__)
 GOV_DATA_DIR = "governance_data"
 GOV_DATA_STORE = "governance_data.pickle"
 
-DREPS_NUM = 5
-
 
 def _get_committee_val(data: tp.Dict[str, tp.Any]) -> tp.Dict[str, tp.Any]:
     return data.get("committee") or data.get("commitee") or {}


### PR DESCRIPTION
The DREPS_NUM constant was removed from governance_setup.py as it was not being used anywhere in the code. This cleanup helps in maintaining the codebase by removing unnecessary variables.