### PR TITLE
refactor: extract repeated code into get_txins function

### DIFF
--- a/cardano_node_tests/cluster_scripts/conway/start-cluster
+++ b/cardano_node_tests/cluster_scripts/conway/start-cluster
@@ -154,6 +154,28 @@ check_spend_success() {
   return 1
 }
 
+get_txins() {
+  local txin_addr stop_txin_amount txhash txix amount _
+
+  txin_addr="${1:?"Missing TxIn address"}"
+  stop_txin_amount="${2:?"Missing stop TxIn amount"}"
+
+  stop_txin_amount="$((stop_txin_amount + 2000000))"
+
+  TXINS=()
+  TXIN_AMOUNT=0
+  while read -r txhash txix amount _; do
+    TXIN_AMOUNT="$((TXIN_AMOUNT + amount))"
+    TXINS+=("--tx-in" "${txhash}#${txix}")
+    if [ "$TXIN_AMOUNT" -ge "$stop_txin_amount" ]; then
+      break
+    fi
+  done <<< "$(cardano_cli_log latest query utxo --testnet-magic \
+              "$NETWORK_MAGIC" \
+              --address "$txin_addr" |
+              grep -E "lovelace$|[0-9]$|lovelace \+ TxOutDatumNone$")"
+}
+
 ENABLE_SUBMIT_API="$(type cardano-submit-api >/dev/null 2>&1 && echo 1 || echo 0)"
 
 if [ -e "$SCRIPT_DIR/shell_env" ]; then
@@ -725,21 +747,9 @@ DEPOSITS="$(jq '.protocolParams.poolDeposit + (2 * .protocolParams.keyDeposit)' 
 NEEDED_AMOUNT="$(( (POOL_PLEDGE + DEPOSITS) * NUM_POOLS ))"
 STOP_TXIN_AMOUNT="$((NEEDED_AMOUNT + FEE))"
 
-TXINS=()
-TXIN_COUNT=0
-TXIN_AMOUNT=0
-while read -r txhash txix amount _; do
-  TXIN_AMOUNT="$((TXIN_AMOUNT + amount))"
-  TXIN_COUNT="$((TXIN_COUNT + 1))"
-  TXINS+=("--tx-in" "${txhash}#${txix}")
-  if [ "$TXIN_AMOUNT" -ge "$STOP_TXIN_AMOUNT" ]; then
-    break
-  fi
-done <<< "$(cardano_cli_log latest query utxo --testnet-magic \
-            "$NETWORK_MAGIC" \
-            --address "$FAUCET_ADDR" |
-            grep -E "lovelace$|[0-9]$")"
+get_txins "$FAUCET_ADDR" "$STOP_TXIN_AMOUNT"
 
+TXOUT_AMOUNT="$((TXIN_AMOUNT - STOP_TXIN_AMOUNT))"
 TTL="$(get_slot 1000)"
 
 POOL_ARGS=()
@@ -758,8 +768,6 @@ for i in $(seq 1 "$NUM_POOLS"); do
     "--signing-key-file" "$STATE_CLUSTER/nodes/node-pool$i/cold.skey" \
   )
 done
-
-TXOUT_AMOUNT="$((TXIN_AMOUNT - FEE - NEEDED_AMOUNT))"
 
 cardano_cli_log shelley transaction build-raw \
   --ttl    "$TTL" \
@@ -818,22 +826,7 @@ cardano_cli_log allegra query protocol-parameters \
   --testnet-magic "$NETWORK_MAGIC" \
   --out-file "$STATE_CLUSTER/pparams.json"
 
-STOP_TXIN_AMOUNT=$FEE
-
-TXINS=()
-TXIN_COUNT=0
-TXIN_AMOUNT=0
-while read -r txhash txix amount _; do
-  TXIN_AMOUNT="$((TXIN_AMOUNT + amount))"
-  TXIN_COUNT="$((TXIN_COUNT + 1))"
-  TXINS+=("--tx-in" "${txhash}#${txix}")
-  if [ "$TXIN_AMOUNT" -ge "$STOP_TXIN_AMOUNT" ]; then
-    break
-  fi
-done <<< "$(cardano_cli_log latest query utxo --testnet-magic \
-            "$NETWORK_MAGIC" \
-            --address "$FAUCET_ADDR" |
-            grep -E "lovelace$|[0-9]$")"
+get_txins "$FAUCET_ADDR" "$FEE"
 
 TXOUT_AMOUNT="$((TXIN_AMOUNT - FEE))"
 
@@ -889,22 +882,7 @@ cardano_cli_log mary query protocol-parameters \
   --testnet-magic "$NETWORK_MAGIC" \
   --out-file "$STATE_CLUSTER/pparams.json"
 
-STOP_TXIN_AMOUNT=$FEE
-
-TXINS=()
-TXIN_COUNT=0
-TXIN_AMOUNT=0
-while read -r txhash txix amount _; do
-  TXIN_AMOUNT="$((TXIN_AMOUNT + amount))"
-  TXIN_COUNT="$((TXIN_COUNT + 1))"
-  TXINS+=("--tx-in" "${txhash}#${txix}")
-  if [ "$TXIN_AMOUNT" -ge "$STOP_TXIN_AMOUNT" ]; then
-    break
-  fi
-done <<< "$(cardano_cli_log latest query utxo --testnet-magic \
-            "$NETWORK_MAGIC" \
-            --address "$FAUCET_ADDR" |
-            grep -E "lovelace$|[0-9]$")"
+get_txins "$FAUCET_ADDR" "$FEE"
 
 TXOUT_AMOUNT="$((TXIN_AMOUNT - FEE))"
 
@@ -961,22 +939,7 @@ cardano_cli_log alonzo query protocol-parameters \
   --testnet-magic "$NETWORK_MAGIC" \
   --out-file "$STATE_CLUSTER/pparams.json"
 
-STOP_TXIN_AMOUNT=$FEE
-
-TXINS=()
-TXIN_COUNT=0
-TXIN_AMOUNT=0
-while read -r txhash txix amount _; do
-  TXIN_AMOUNT="$((TXIN_AMOUNT + amount))"
-  TXIN_COUNT="$((TXIN_COUNT + 1))"
-  TXINS+=("--tx-in" "${txhash}#${txix}")
-  if [ "$TXIN_AMOUNT" -ge "$STOP_TXIN_AMOUNT" ]; then
-    break
-  fi
-done <<< "$(cardano_cli_log latest query utxo --testnet-magic \
-            "$NETWORK_MAGIC" \
-            --address "$FAUCET_ADDR" |
-            grep -E "lovelace \+ TxOutDatumNone$")"
+get_txins "$FAUCET_ADDR" "$FEE"
 
 TXOUT_AMOUNT="$((TXIN_AMOUNT - FEE))"
 
@@ -1042,22 +1005,7 @@ cardano_cli_log legacy governance create-update-proposal \
   --protocol-major-version 7 \
   --protocol-minor-version 0
 
-STOP_TXIN_AMOUNT=$FEE
-
-TXINS=()
-TXIN_COUNT=0
-TXIN_AMOUNT=0
-while read -r txhash txix amount _; do
-  TXIN_AMOUNT="$((TXIN_AMOUNT + amount))"
-  TXIN_COUNT="$((TXIN_COUNT + 1))"
-  TXINS+=("--tx-in" "${txhash}#${txix}")
-  if [ "$TXIN_AMOUNT" -ge "$STOP_TXIN_AMOUNT" ]; then
-    break
-  fi
-done <<< "$(cardano_cli_log latest query utxo --testnet-magic \
-            "$NETWORK_MAGIC" \
-            --address "$FAUCET_ADDR" |
-            grep -E "lovelace \+ TxOutDatumNone$")"
+get_txins "$FAUCET_ADDR" "$FEE"
 
 TXOUT_AMOUNT="$((TXIN_AMOUNT - FEE))"
 
@@ -1114,22 +1062,7 @@ cardano_cli_log babbage query protocol-parameters \
   --testnet-magic "$NETWORK_MAGIC" \
   --out-file "$STATE_CLUSTER/pparams.json"
 
-STOP_TXIN_AMOUNT=$FEE
-
-TXINS=()
-TXIN_COUNT=0
-TXIN_AMOUNT=0
-while read -r txhash txix amount _; do
-  TXIN_AMOUNT="$((TXIN_AMOUNT + amount))"
-  TXIN_COUNT="$((TXIN_COUNT + 1))"
-  TXINS+=("--tx-in" "${txhash}#${txix}")
-  if [ "$TXIN_AMOUNT" -ge "$STOP_TXIN_AMOUNT" ]; then
-    break
-  fi
-done <<< "$(cardano_cli_log latest query utxo --testnet-magic \
-            "$NETWORK_MAGIC" \
-            --address "$FAUCET_ADDR" |
-            grep -E "lovelace \+ TxOutDatumNone$")"
+get_txins "$FAUCET_ADDR" "$FEE"
 
 TXOUT_AMOUNT="$((TXIN_AMOUNT - FEE))"
 
@@ -1189,22 +1122,7 @@ cardano_cli_log legacy governance create-update-proposal \
   --protocol-major-version 9 \
   --protocol-minor-version 0
 
-STOP_TXIN_AMOUNT=$FEE
-
-TXINS=()
-TXIN_COUNT=0
-TXIN_AMOUNT=0
-while read -r txhash txix amount _; do
-  TXIN_AMOUNT="$((TXIN_AMOUNT + amount))"
-  TXIN_COUNT="$((TXIN_COUNT + 1))"
-  TXINS+=("--tx-in" "${txhash}#${txix}")
-  if [ "$TXIN_AMOUNT" -ge "$STOP_TXIN_AMOUNT" ]; then
-    break
-  fi
-done <<< "$(cardano_cli_log latest query utxo --testnet-magic \
-            "$NETWORK_MAGIC" \
-            --address "$FAUCET_ADDR" |
-            grep -E "lovelace \+ TxOutDatumNone$")"
+get_txins "$FAUCET_ADDR" "$FEE"
 
 TXOUT_AMOUNT="$((TXIN_AMOUNT - FEE))"
 
@@ -1266,20 +1184,7 @@ DREP_DEPOSIT="$((KEY_DEPOSIT + DREP_DEPOSIT))"
 DREP_NEEDED_AMOUNT="$(( (DREP_DELEGATED + DREP_DEPOSIT) * NUM_DREPS ))"
 STOP_TXIN_AMOUNT="$((FEE + DREP_NEEDED_AMOUNT))"
 
-TXINS=()
-TXIN_COUNT=0
-TXIN_AMOUNT=0
-while read -r txhash txix amount _; do
-  TXIN_AMOUNT="$((TXIN_AMOUNT + amount))"
-  TXIN_COUNT="$((TXIN_COUNT + 1))"
-  TXINS+=("--tx-in" "${txhash}#${txix}")
-  if [ "$TXIN_AMOUNT" -ge "$STOP_TXIN_AMOUNT" ]; then
-    break
-  fi
-done <<< "$(cardano_cli_log latest query utxo --testnet-magic \
-            "$NETWORK_MAGIC" \
-            --address "$FAUCET_ADDR" |
-            grep -E "lovelace \+ TxOutDatumNone$")"
+get_txins "$FAUCET_ADDR" "$STOP_TXIN_AMOUNT"
 
 TXOUT_AMOUNT="$((TXIN_AMOUNT - STOP_TXIN_AMOUNT))"
 
@@ -1377,20 +1282,7 @@ if [ -n "${PV10:-""}" ]; then
 
   STOP_TXIN_AMOUNT="$((FEE + GOV_ACTION_DEPOSIT))"
 
-  TXINS=()
-  TXIN_COUNT=0
-  TXIN_AMOUNT=0
-  while read -r txhash txix amount _; do
-    TXIN_AMOUNT="$((TXIN_AMOUNT + amount))"
-    TXIN_COUNT="$((TXIN_COUNT + 1))"
-    TXINS+=("--tx-in" "${txhash}#${txix}")
-    if [ "$TXIN_AMOUNT" -ge "$STOP_TXIN_AMOUNT" ]; then
-      break
-    fi
-  done <<< "$(cardano_cli_log latest query utxo --testnet-magic \
-              "$NETWORK_MAGIC" \
-              --address "$FAUCET_ADDR" |
-              grep -E "lovelace \+ TxOutDatumNone$")"
+  get_txins "$FAUCET_ADDR" "$STOP_TXIN_AMOUNT"
 
   TXOUT_AMOUNT="$((TXIN_AMOUNT - STOP_TXIN_AMOUNT))"
 
@@ -1470,24 +1362,9 @@ if [ -n "${PV10:-""}" ]; then
     )
   done
 
-  STOP_TXIN_AMOUNT=$FEE
+  get_txins "$FAUCET_ADDR" "$FEE"
 
-  TXINS=()
-  TXIN_COUNT=0
-  TXIN_AMOUNT=0
-  while read -r txhash txix amount _; do
-    TXIN_AMOUNT="$((TXIN_AMOUNT + amount))"
-    TXIN_COUNT="$((TXIN_COUNT + 1))"
-    TXINS+=("--tx-in" "${txhash}#${txix}")
-    if [ "$TXIN_AMOUNT" -ge "$STOP_TXIN_AMOUNT" ]; then
-      break
-    fi
-  done <<< "$(cardano_cli_log latest query utxo --testnet-magic \
-              "$NETWORK_MAGIC" \
-              --address "$FAUCET_ADDR" |
-              grep -E "lovelace \+ TxOutDatumNone$")"
-
-  TXOUT_AMOUNT="$((TXIN_AMOUNT - STOP_TXIN_AMOUNT))"
+  TXOUT_AMOUNT="$((TXIN_AMOUNT - FEE))"
 
   cardano_cli_log conway transaction build-raw \
     --fee    "$FEE" \

--- a/cardano_node_tests/cluster_scripts/conway_fast/start-cluster
+++ b/cardano_node_tests/cluster_scripts/conway_fast/start-cluster
@@ -92,6 +92,28 @@ check_spend_success() {
   return 1
 }
 
+get_txins() {
+  local txin_addr stop_txin_amount txhash txix amount _
+
+  txin_addr="${1:?"Missing TxIn address"}"
+  stop_txin_amount="${2:?"Missing stop TxIn amount"}"
+
+  stop_txin_amount="$((stop_txin_amount + 2000000))"
+
+  TXINS=()
+  TXIN_AMOUNT=0
+  while read -r txhash txix amount _; do
+    TXIN_AMOUNT="$((TXIN_AMOUNT + amount))"
+    TXINS+=("--tx-in" "${txhash}#${txix}")
+    if [ "$TXIN_AMOUNT" -ge "$stop_txin_amount" ]; then
+      break
+    fi
+  done <<< "$(cardano_cli_log conway query utxo --testnet-magic \
+              "$NETWORK_MAGIC" \
+              --address "$txin_addr" |
+              grep -E "lovelace$|[0-9]$|lovelace \+ TxOutDatumNone$")"
+}
+
 ENABLE_SUBMIT_API="$(command -v cardano-submit-api >/dev/null 2>&1 && echo 1 || echo 0)"
 
 if [ -e "$SCRIPT_DIR/shell_env" ]; then
@@ -581,24 +603,11 @@ DREP_DEPOSIT="$((KEY_DEPOSIT + DREP_DEPOSIT))"
 DREP_NEEDED_AMOUNT="$(( (DREP_DELEGATED + DREP_DEPOSIT) * NUM_DREPS ))"
 NEEDED_AMOUNT="$(( POOL_NEEDED_AMOUNT + DREP_NEEDED_AMOUNT))"
 
-TXIN_ADDR="$(<"$STATE_CLUSTER"/shelley/genesis-utxo.addr)"
 FEE_BUFFER=100000000
+TXIN_ADDR="$(<"$STATE_CLUSTER"/shelley/genesis-utxo.addr)"
 STOP_TXIN_AMOUNT="$((NEEDED_AMOUNT + FEE_BUFFER))"
 
-TXINS=()
-TXIN_COUNT=0
-TXIN_AMOUNT=0
-while read -r txhash txix amount _; do
-  TXIN_AMOUNT="$((TXIN_AMOUNT + amount))"
-  TXIN_COUNT="$((TXIN_COUNT + 1))"
-  TXINS+=("--tx-in" "${txhash}#${txix}")
-  if [ "$TXIN_AMOUNT" -ge "$STOP_TXIN_AMOUNT" ]; then
-    break
-  fi
-done <<< "$(cardano_cli_log conway query utxo --testnet-magic \
-            "$NETWORK_MAGIC" \
-            --address "$TXIN_ADDR" |
-            grep -E "lovelace$|[0-9]$|lovelace \+ TxOutDatumNone$")"
+get_txins "$TXIN_ADDR" "$STOP_TXIN_AMOUNT"
 
 POOL_ARGS=()
 POOL_SIGNING=()

--- a/cardano_node_tests/cluster_scripts/mainnet_fast/start-cluster
+++ b/cardano_node_tests/cluster_scripts/mainnet_fast/start-cluster
@@ -92,6 +92,28 @@ check_spend_success() {
   return 1
 }
 
+get_txins() {
+  local txin_addr stop_txin_amount txhash txix amount _
+
+  txin_addr="${1:?"Missing TxIn address"}"
+  stop_txin_amount="${2:?"Missing stop TxIn amount"}"
+
+  stop_txin_amount="$((stop_txin_amount + 2000000))"
+
+  TXINS=()
+  TXIN_AMOUNT=0
+  while read -r txhash txix amount _; do
+    TXIN_AMOUNT="$((TXIN_AMOUNT + amount))"
+    TXINS+=("--tx-in" "${txhash}#${txix}")
+    if [ "$TXIN_AMOUNT" -ge "$stop_txin_amount" ]; then
+      break
+    fi
+  done <<< "$(cardano_cli_log conway query utxo --testnet-magic \
+              "$NETWORK_MAGIC" \
+              --address "$txin_addr" |
+              grep -E "lovelace$|[0-9]$|lovelace \+ TxOutDatumNone$")"
+}
+
 ENABLE_SUBMIT_API="$(command -v cardano-submit-api >/dev/null 2>&1 && echo 1 || echo 0)"
 
 if [ -e "$SCRIPT_DIR/shell_env" ]; then
@@ -581,24 +603,11 @@ DREP_DEPOSIT="$((KEY_DEPOSIT + DREP_DEPOSIT))"
 DREP_NEEDED_AMOUNT="$(( (DREP_DELEGATED + DREP_DEPOSIT) * NUM_DREPS ))"
 NEEDED_AMOUNT="$(( POOL_NEEDED_AMOUNT + DREP_NEEDED_AMOUNT))"
 
-TXIN_ADDR="$(<"$STATE_CLUSTER"/shelley/genesis-utxo.addr)"
 FEE_BUFFER=100000000
+TXIN_ADDR="$(<"$STATE_CLUSTER"/shelley/genesis-utxo.addr)"
 STOP_TXIN_AMOUNT="$((NEEDED_AMOUNT + FEE_BUFFER))"
 
-TXINS=()
-TXIN_COUNT=0
-TXIN_AMOUNT=0
-while read -r txhash txix amount _; do
-  TXIN_AMOUNT="$((TXIN_AMOUNT + amount))"
-  TXIN_COUNT="$((TXIN_COUNT + 1))"
-  TXINS+=("--tx-in" "${txhash}#${txix}")
-  if [ "$TXIN_AMOUNT" -ge "$STOP_TXIN_AMOUNT" ]; then
-    break
-  fi
-done <<< "$(cardano_cli_log conway query utxo --testnet-magic \
-            "$NETWORK_MAGIC" \
-            --address "$TXIN_ADDR" |
-            grep -E "lovelace$|[0-9]$|lovelace \+ TxOutDatumNone$")"
+get_txins "$TXIN_ADDR" "$STOP_TXIN_AMOUNT"
 
 POOL_ARGS=()
 POOL_SIGNING=()


### PR DESCRIPTION
This commit refactors the start-cluster scripts by extracting the repeated code for fetching transaction inputs into a new function called get_txins. This improves code readability and maintainability by reducing redundancy and centralizing the logic for querying UTXOs.