### PR TITLE
feat(tests): add test for top-level `query tip` command

### DIFF
--- a/cardano_node_tests/tests/issues.py
+++ b/cardano_node_tests/tests/issues.py
@@ -92,6 +92,12 @@ cli_942 = blockers.GH(
     fixed_in="10.0.0.1",  # Fixed in some release after 10.0.0.0
     message="build command doesn't balance key deposit.",
 )
+cli_953 = blockers.GH(
+    issue=953,
+    repo="IntersectMBO/cardano-cli",
+    fixed_in="10.1.2.0",  # Fixed in some release after 10.1.1.0
+    message="query tip is not a top level command.",
+)
 
 consensus_973 = blockers.GH(
     issue=973,

--- a/cardano_node_tests/tests/test_cli.py
+++ b/cardano_node_tests/tests/test_cli.py
@@ -64,6 +64,32 @@ class TestCLI:
     @allure.link(helpers.get_vcs_link())
     @pytest.mark.smoke
     @pytest.mark.testnets
+    def test_toplevel_query_tip(self, cluster: clusterlib.ClusterLib):
+        """Check that `query tip` is available in top level."""
+        common.get_test_id(cluster)
+
+        try:
+            cli_out = cluster.cli(
+                [
+                    "cardano-cli",
+                    "query",
+                    "tip",
+                    *cluster.magic_args,
+                ],
+                add_default_args=False,
+            )
+        except clusterlib.CLIError as exc:
+            if "Invalid argument `query'" in str(exc):
+                issues.cli_953.finish_test()
+            raise
+
+        tip = json.loads(cli_out.stdout.decode("utf-8").strip())
+        keys = set(tip)
+        assert {"block", "epoch", "era", "hash", "slot"}.issubset(keys)
+
+    @allure.link(helpers.get_vcs_link())
+    @pytest.mark.smoke
+    @pytest.mark.testnets
     def test_calculate_min_fee(self, cluster: clusterlib.ClusterLib):
         """Check the `calculate-min-fee` command."""
         common.get_test_id(cluster)


### PR DESCRIPTION
Added a new test to verify that the `query tip` command is available at the top level in the CLI. This test ensures that the command is accessible and returns the expected keys in the output. Also, added a blocker for issue 953 in the `cardano-cli` repository.