### PR TITLE
feat(tests): run test_consensus_reached only on mainnet

### DIFF
--- a/scripts/test_rollbacks.sh
+++ b/scripts/test_rollbacks.sh
@@ -15,14 +15,14 @@ set -euo pipefail
 
 TOP_DIR="$(readlink -m "${0%/*}/..")"
 
-export NUM_POOLS="${NUM_POOLS:-"10"}"
+export NUM_POOLS="${NUM_POOLS:-"10"}" CLUSTERS_COUNT=1 TEST_THREADS=0
 
 if [ -n "${INTERACTIVE:-""}" ]; then
-  export ROLLBACK_PAUSE=1 SCRIPTS_DIRNAME="${SCRIPTS_DIRNAME:-mainnet_fast}" PYTEST_ARGS="-s -k test_consensus_reached"
+  export ROLLBACK_PAUSE=1 SCRIPTS_DIRNAME="mainnet_fast" PYTEST_ARGS="-s -k test_consensus_reached"
+  "$TOP_DIR/.github/regression.sh"
 else
-  export SCRIPTS_DIRNAME="${SCRIPTS_DIRNAME:-conway_fast}" PYTEST_ARGS="-k TestRollback"
+  export SCRIPTS_DIRNAME="conway_fast" PYTEST_ARGS="-k test_permanent_fork"
+  "$TOP_DIR/.github/regression.sh" || exit "$?"
+  export SCRIPTS_DIRNAME="mainnet_fast" PYTEST_ARGS="-k test_consensus_reached"
+  "$TOP_DIR/.github/regression.sh"
 fi
-
-export CLUSTERS_COUNT=1 TEST_THREADS=0
-
-"$TOP_DIR/.github/regression.sh"


### PR DESCRIPTION
The `securityParam` is too low on local testnet with short epochs.

Also run `test_permanent_fork` only on testnet with short epochs, as `securityParam` is too high on mainnet like testnet.