### PR TITLE
feat(tests): force mainnet_fast for reconnect test

### DIFF
--- a/cardano_node_tests/tests/test_reconnect.py
+++ b/cardano_node_tests/tests/test_reconnect.py
@@ -242,6 +242,10 @@ class TestNodeReconnect:
     )
     @pytest.mark.skipif(configuration.NUM_POOLS != 3, reason="`NUM_POOLS` must be 3")
     @pytest.mark.skipif(configuration.ENABLE_LEGACY, reason="Works only with P2P topology")
+    @pytest.mark.skipif(
+        "mainnet_fast" not in configuration.SCRIPTS_DIRNAME,
+        reason="Cannot run on testnet with short epochs",
+    )
     def test_metrics_reconnect(
         self,
         cluster_manager: cluster_management.ClusterManager,

--- a/scripts/test_node_reconnect.sh
+++ b/scripts/test_node_reconnect.sh
@@ -11,7 +11,7 @@ TOP_DIR="$(readlink -m "${0%/*}/..")"
 export \
   CLUSTERS_COUNT=1 \
   TEST_THREADS=0 \
-  SCRIPTS_DIRNAME="${SCRIPTS_DIRNAME:-mainnet_fast}" \
+  SCRIPTS_DIRNAME="mainnet_fast" \
   PYTEST_ARGS="-s -k TestNodeReconnect"
 
 "$TOP_DIR/.github/regression.sh"


### PR DESCRIPTION
Added a skip condition to the `test_metrics_reconnect` test to ensure it does not run on testnet with short epochs.