### PR TITLE
feat: update POOL_COST initialization logic

### DIFF
--- a/cardano_node_tests/cluster_scripts/conway/start-cluster
+++ b/cardano_node_tests/cluster_scripts/conway/start-cluster
@@ -31,7 +31,6 @@ TX_SUBMISSION_DELAY=60
 PROPOSAL_DELAY=5
 SUBMIT_DELAY=5
 POOL_PLEDGE=1000000000000
-POOL_COST=600
 DREP_DELEGATED=500000000000
 
 FEE=5000000
@@ -41,6 +40,10 @@ NETWORK_MAGIC="$(jq '.networkMagic' < "$SCRIPT_DIR/genesis.spec.json")"
 MAX_SUPPLY="$(jq '.maxLovelaceSupply' < "$SCRIPT_DIR/genesis.spec.json")"
 SLOT_LENGTH="$(jq '.slotLength' < "$SCRIPT_DIR/genesis.spec.json")"
 EPOCH_SEC="$(jq '.epochLength * .slotLength | ceil' < "$SCRIPT_DIR/genesis.spec.json")"
+POOL_COST="$(jq '.protocolParams.minPoolCost' < "$SCRIPT_DIR/genesis.spec.json")"
+if [ "$POOL_COST" -eq 0 ]; then
+  POOL_COST=600
+fi
 
 if [ -f "$STATE_CLUSTER/supervisord.pid" ]; then
   echo "Cluster already running. Please run \`$SCRIPT_DIR/stop-cluster\` first!" >&2

--- a/cardano_node_tests/cluster_scripts/conway_fast/start-cluster
+++ b/cardano_node_tests/cluster_scripts/conway_fast/start-cluster
@@ -30,7 +30,6 @@ NUM_DREPS=5
 TX_SUBMISSION_DELAY=60
 SUBMIT_DELAY=5
 POOL_PLEDGE=1000000000000
-POOL_COST=600
 DREP_DELEGATED=500000000000
 BYRON_INIT_SUPPLY=10020000000
 PROTOCOL_VERSION=9
@@ -41,6 +40,10 @@ fi
 SECURITY_PARAM="$(jq '.securityParam' < "$SCRIPT_DIR/genesis.spec.json")"
 NETWORK_MAGIC="$(jq '.networkMagic' < "$SCRIPT_DIR/genesis.spec.json")"
 MAX_SUPPLY="$(jq '.maxLovelaceSupply' < "$SCRIPT_DIR/genesis.spec.json")"
+POOL_COST="$(jq '.protocolParams.minPoolCost' < "$SCRIPT_DIR/genesis.spec.json")"
+if [ "$POOL_COST" -eq 0 ]; then
+  POOL_COST=600
+fi
 
 # There is some weird calculation going on, and the deleg supply needs to have a minimum value,
 # that is somehow based on non-delegated supply.

--- a/cardano_node_tests/cluster_scripts/mainnet_fast/start-cluster
+++ b/cardano_node_tests/cluster_scripts/mainnet_fast/start-cluster
@@ -39,8 +39,11 @@ fi
 
 SECURITY_PARAM="$(jq '.securityParam' < "$SCRIPT_DIR/genesis.spec.json")"
 NETWORK_MAGIC="$(jq '.networkMagic' < "$SCRIPT_DIR/genesis.spec.json")"
-POOL_COST="$(jq '.protocolParams.minPoolCost' < "$SCRIPT_DIR/genesis.spec.json")"
 MAX_SUPPLY="$(jq '.maxLovelaceSupply' < "$SCRIPT_DIR/genesis.spec.json")"
+POOL_COST="$(jq '.protocolParams.minPoolCost' < "$SCRIPT_DIR/genesis.spec.json")"
+if [ "$POOL_COST" -eq 0 ]; then
+  POOL_COST=600
+fi
 
 # There is some weird calculation going on, and the deleg supply needs to have a minimum value,
 # that is somehow based on non-delegated supply.


### PR DESCRIPTION
- Removed hardcoded POOL_COST value from start-cluster scripts.
- Added logic to fetch POOL_COST from genesis.spec.json.
- Set default POOL_COST to 600 if fetched value is 0.