### PR TITLE
fix: ensure proper restart of local cluster nodes

### DIFF
--- a/.github/node_upgrade_pytest.sh
+++ b/.github/node_upgrade_pytest.sh
@@ -186,6 +186,8 @@ elif [ "$1" = "step2" ]; then
 
   # Restart local cluster nodes with binaries from new cluster-node version.
   # It is necessary to restart supervisord with new environment.
+  "$STATE_CLUSTER/supervisorctl" stop all
+  sleep 5
   "$STATE_CLUSTER/supervisord_stop"
   sleep 3
   "$STATE_CLUSTER/supervisord_start" || exit 6


### PR DESCRIPTION
Added commands to stop all processes and added a sleep interval before restarting supervisord. This ensures that the local cluster nodes are properly restarted with binaries from the new cluster-node version.