### PR TITLE
fix(start-cluster): unify varaibles notation

### DIFF
--- a/cardano_node_tests/cluster_scripts/conway/start-cluster
+++ b/cardano_node_tests/cluster_scripts/conway/start-cluster
@@ -35,18 +35,18 @@ DREP_DELEGATED=500000000000
 
 FEE=5000000
 
-SECURITY_PARAM="$(jq '.securityParam' < "$SCRIPT_DIR/genesis.spec.json")"
-NETWORK_MAGIC="$(jq '.networkMagic' < "$SCRIPT_DIR/genesis.spec.json")"
-MAX_SUPPLY="$(jq '.maxLovelaceSupply' < "$SCRIPT_DIR/genesis.spec.json")"
-SLOT_LENGTH="$(jq '.slotLength' < "$SCRIPT_DIR/genesis.spec.json")"
-EPOCH_SEC="$(jq '.epochLength * .slotLength | ceil' < "$SCRIPT_DIR/genesis.spec.json")"
-POOL_COST="$(jq '.protocolParams.minPoolCost' < "$SCRIPT_DIR/genesis.spec.json")"
+SECURITY_PARAM="$(jq '.securityParam' < "${SCRIPT_DIR}/genesis.spec.json")"
+NETWORK_MAGIC="$(jq '.networkMagic' < "${SCRIPT_DIR}/genesis.spec.json")"
+MAX_SUPPLY="$(jq '.maxLovelaceSupply' < "${SCRIPT_DIR}/genesis.spec.json")"
+SLOT_LENGTH="$(jq '.slotLength' < "${SCRIPT_DIR}/genesis.spec.json")"
+EPOCH_SEC="$(jq '.epochLength * .slotLength | ceil' < "${SCRIPT_DIR}/genesis.spec.json")"
+POOL_COST="$(jq '.protocolParams.minPoolCost' < "${SCRIPT_DIR}/genesis.spec.json")"
 if [ "$POOL_COST" -eq 0 ]; then
   POOL_COST=600
 fi
 
-if [ -f "$STATE_CLUSTER/supervisord.pid" ]; then
-  echo "Cluster already running. Please run \`$SCRIPT_DIR/stop-cluster\` first!" >&2
+if [ -f "${STATE_CLUSTER}/supervisord.pid" ]; then
+  echo "Cluster already running. Please run \`${SCRIPT_DIR}/stop-cluster\` first!" >&2
   exit 1
 fi
 
@@ -59,7 +59,7 @@ cardano_cli_log() {
   local out
   local retval
 
-  echo cardano-cli "$@" >> "$STATE_CLUSTER/start_cluster_cmds.log"
+  echo cardano-cli "$@" >> "${STATE_CLUSTER}/start_cluster_cmds.log"
 
   for _ in {1..3}; do
     set +e
@@ -181,22 +181,22 @@ get_txins() {
 
 ENABLE_SUBMIT_API="$(type cardano-submit-api >/dev/null 2>&1 && echo 1 || echo 0)"
 
-if [ -e "$SCRIPT_DIR/shell_env" ]; then
+if [ -e "${SCRIPT_DIR}/shell_env" ]; then
   # shellcheck disable=SC1090,SC1091
-  source "$SCRIPT_DIR/shell_env"
+  source "${SCRIPT_DIR}/shell_env"
 fi
 
 rm -rf "$STATE_CLUSTER"
 mkdir -p "$STATE_CLUSTER"/{shelley,webserver,db-sync}
-cd "$STATE_CLUSTER/.."
+cd "${STATE_CLUSTER}/.."
 
 cp "$SCRIPT_DIR"/cardano-node-* "$STATE_CLUSTER"
-cp "$SCRIPT_DIR/run-cardano-submit-api" "$STATE_CLUSTER"
-cp "$SCRIPT_DIR/byron-params.json" "$STATE_CLUSTER"
-cp "$SCRIPT_DIR/dbsync-config.yaml" "$STATE_CLUSTER"
-cp "$SCRIPT_DIR/submit-api-config.json" "$STATE_CLUSTER"
-cp "$SCRIPT_DIR/supervisor.conf" "$STATE_CLUSTER"
-cp "$SCRIPT_DIR"/*genesis*.spec.json "$STATE_CLUSTER/shelley/"
+cp "${SCRIPT_DIR}/run-cardano-submit-api" "$STATE_CLUSTER"
+cp "${SCRIPT_DIR}/byron-params.json" "$STATE_CLUSTER"
+cp "${SCRIPT_DIR}/dbsync-config.yaml" "$STATE_CLUSTER"
+cp "${SCRIPT_DIR}/submit-api-config.json" "$STATE_CLUSTER"
+cp "${SCRIPT_DIR}/supervisor.conf" "$STATE_CLUSTER"
+cp "$SCRIPT_DIR"/*genesis*.spec.json "${STATE_CLUSTER}/shelley/"
 
 if [ -z "${ENABLE_LEGACY:-""}" ]; then
   # use P2P topology files
@@ -210,7 +210,7 @@ fi
 
 case "${UTXO_BACKEND:=""}" in
   "" | mem | disk)
-    echo "$UTXO_BACKEND" > "$STATE_CLUSTER/utxo_backend"
+    echo "$UTXO_BACKEND" > "${STATE_CLUSTER}/utxo_backend"
     ;;
   *)
     echo "Unknown \`UTXO_BACKEND\`: '$UTXO_BACKEND', line $LINENO" >&2
@@ -220,20 +220,20 @@ esac
 
 # enable db-sync service
 if [ -n "${DBSYNC_REPO:-""}" ]; then
-  [ -e "$DBSYNC_REPO/db-sync-node/bin/cardano-db-sync" ] || \
-    { echo "The \`$DBSYNC_REPO/db-sync-node/bin/cardano-db-sync\` not found, line $LINENO" >&2; exit 1; }  # assert
+  [ -e "${DBSYNC_REPO}/db-sync-node/bin/cardano-db-sync" ] || \
+    { echo "The \`${DBSYNC_REPO}/db-sync-node/bin/cardano-db-sync\` not found, line $LINENO" >&2; exit 1; }  # assert
 
   # create clean database
   if [ -z "${DRY_RUN:-""}" ]; then
-    "$SCRIPT_DIR/postgres-setup.sh"
+    "${SCRIPT_DIR}/postgres-setup.sh"
   fi
 
-  cat >> "$STATE_CLUSTER/supervisor.conf" <<EoF
+  cat >> "${STATE_CLUSTER}/supervisor.conf" <<EoF
 
 [program:dbsync]
-command=$SCRIPT_DIR/run-cardano-dbsync
-stderr_logfile=./$STATE_CLUSTER_NAME/dbsync.stderr
-stdout_logfile=./$STATE_CLUSTER_NAME/dbsync.stdout
+command=${SCRIPT_DIR}/run-cardano-dbsync
+stderr_logfile=./${STATE_CLUSTER_NAME}/dbsync.stderr
+stdout_logfile=./${STATE_CLUSTER_NAME}/dbsync.stdout
 autostart=false
 autorestart=false
 startsecs=5
@@ -242,12 +242,12 @@ fi
 
 # enable cardano-submit-api service
 if [ "$ENABLE_SUBMIT_API" -eq 1 ]; then
-  cat >> "$STATE_CLUSTER/supervisor.conf" <<EoF
+  cat >> "${STATE_CLUSTER}/supervisor.conf" <<EoF
 
 [program:submit_api]
-command=$SCRIPT_DIR/run-cardano-submit-api
-stderr_logfile=./$STATE_CLUSTER_NAME/submit_api.stderr
-stdout_logfile=./$STATE_CLUSTER_NAME/submit_api.stdout
+command=${SCRIPT_DIR}/run-cardano-submit-api
+stderr_logfile=./${STATE_CLUSTER_NAME}/submit_api.stderr
+stdout_logfile=./${STATE_CLUSTER_NAME}/submit_api.stdout
 autostart=false
 autorestart=false
 startsecs=5
@@ -257,9 +257,9 @@ fi
 FUNDS_PER_GENESIS_ADDRESS="$((MAX_SUPPLY / NUM_BFT_NODES))"
 FUNDS_PER_BYRON_ADDRESS="$((FUNDS_PER_GENESIS_ADDRESS * 8 / 10))"
 
-START_TIME_SHELLEY=$(date --utc +"%Y-%m-%dT%H:%M:%SZ" --date="5 seconds")
-START_TIME=$(date +%s --date="$START_TIME_SHELLEY")
-echo "$START_TIME" > "$STATE_CLUSTER/cluster_start_time"
+START_TIME_SHELLEY="$(date --utc +"%Y-%m-%dT%H:%M:%SZ" --date="5 seconds")"
+START_TIME="$(date +%s --date="$START_TIME_SHELLEY")"
+echo "$START_TIME" > "${STATE_CLUSTER}/cluster_start_time"
 
 cardano_cli_log byron genesis genesis \
   --protocol-magic "$NETWORK_MAGIC" \
@@ -270,14 +270,14 @@ cardano_cli_log byron genesis genesis \
   --delegate-share 1 \
   --avvm-entry-count 0 \
   --avvm-entry-balance 0 \
-  --protocol-parameters-file "$STATE_CLUSTER/byron-params.json" \
-  --genesis-output-dir "$STATE_CLUSTER/byron" \
+  --protocol-parameters-file "${STATE_CLUSTER}/byron-params.json" \
+  --genesis-output-dir "${STATE_CLUSTER}/byron" \
   --start-time "$START_TIME"
 
-mv "$STATE_CLUSTER/byron-params.json" "$STATE_CLUSTER/byron/params.json"
+mv "${STATE_CLUSTER}/byron-params.json" "${STATE_CLUSTER}/byron/params.json"
 
 cardano_cli_log legacy genesis create \
-  --genesis-dir "$STATE_CLUSTER/shelley" \
+  --genesis-dir "${STATE_CLUSTER}/shelley" \
   --testnet-magic "$NETWORK_MAGIC" \
   --gen-genesis-keys "$NUM_BFT_NODES" \
   --start-time "$START_TIME_SHELLEY" \
@@ -285,60 +285,60 @@ cardano_cli_log legacy genesis create \
 
 jq -r '
   .initialFunds = {}' \
-  < "$STATE_CLUSTER/shelley/genesis.json" > "$STATE_CLUSTER/shelley/genesis.json_jq"
-cat "$STATE_CLUSTER/shelley/genesis.json_jq" > "$STATE_CLUSTER/shelley/genesis.json"
-rm -f "$STATE_CLUSTER/shelley/genesis.json_jq"
+  < "${STATE_CLUSTER}/shelley/genesis.json" > "${STATE_CLUSTER}/shelley/genesis.json_jq"
+cat "${STATE_CLUSTER}/shelley/genesis.json_jq" > "${STATE_CLUSTER}/shelley/genesis.json"
+rm -f "${STATE_CLUSTER}/shelley/genesis.json_jq"
 
-mkdir -p "$STATE_CLUSTER/governance_data"
+mkdir -p "${STATE_CLUSTER}/governance_data"
 
 # Create committee keys
 if [ -z "${NO_CC:-""}" ]; then
   for i in $(seq 1 "$NUM_CC"); do
     cardano_cli_log conway governance committee key-gen-cold \
-      --cold-verification-key-file "$STATE_CLUSTER/governance_data/cc_member${i}_committee_cold.vkey" \
-      --cold-signing-key-file "$STATE_CLUSTER/governance_data/cc_member${i}_committee_cold.skey"
+      --cold-verification-key-file "${STATE_CLUSTER}/governance_data/cc_member${i}_committee_cold.vkey" \
+      --cold-signing-key-file "${STATE_CLUSTER}/governance_data/cc_member${i}_committee_cold.skey"
     cardano_cli_log conway governance committee key-gen-hot \
-      --verification-key-file "$STATE_CLUSTER/governance_data/cc_member${i}_committee_hot.vkey" \
-      --signing-key-file "$STATE_CLUSTER/governance_data/cc_member${i}_committee_hot.skey"
+      --verification-key-file "${STATE_CLUSTER}/governance_data/cc_member${i}_committee_hot.vkey" \
+      --signing-key-file "${STATE_CLUSTER}/governance_data/cc_member${i}_committee_hot.skey"
     cardano_cli_log conway governance committee create-hot-key-authorization-certificate \
-      --cold-verification-key-file "$STATE_CLUSTER/governance_data/cc_member${i}_committee_cold.vkey" \
-      --hot-verification-key-file "$STATE_CLUSTER/governance_data/cc_member${i}_committee_hot.vkey" \
-      --out-file "$STATE_CLUSTER/governance_data/cc_member${i}_committee_hot_auth.cert"
+      --cold-verification-key-file "${STATE_CLUSTER}/governance_data/cc_member${i}_committee_cold.vkey" \
+      --hot-verification-key-file "${STATE_CLUSTER}/governance_data/cc_member${i}_committee_hot.vkey" \
+      --out-file "${STATE_CLUSTER}/governance_data/cc_member${i}_committee_hot_auth.cert"
     cardano_cli_log conway governance committee key-hash \
-      --verification-key-file "$STATE_CLUSTER/governance_data/cc_member${i}_committee_cold.vkey" \
-      > "$STATE_CLUSTER/governance_data/cc_member${i}_committee_cold.hash"
+      --verification-key-file "${STATE_CLUSTER}/governance_data/cc_member${i}_committee_cold.vkey" \
+      > "${STATE_CLUSTER}/governance_data/cc_member${i}_committee_cold.hash"
   done
 
   # Pre-register committee in genesis
-  KEY_HASH_JSON=$(jq -nR '[inputs | {("keyHash-" + .): 10000}] | add' \
-    "$STATE_CLUSTER"/governance_data/cc_member*_committee_cold.hash)
+  KEY_HASH_JSON="$(jq -nR '[inputs | {("keyHash-" + .): 10000}] | add' \
+    "$STATE_CLUSTER"/governance_data/cc_member*_committee_cold.hash)"
   jq \
     --argjson keyHashJson "$KEY_HASH_JSON" \
     '.committee.members = $keyHashJson
     | .committee.threshold = 0.6
     | .committeeMinSize = 2' \
-    "$STATE_CLUSTER/shelley/genesis.conway.json" > "$STATE_CLUSTER/shelley/genesis.conway.json_jq"
-  cat "$STATE_CLUSTER/shelley/genesis.conway.json_jq" > "$STATE_CLUSTER/shelley/genesis.conway.json"
-  rm -f "$STATE_CLUSTER/shelley/genesis.conway.json_jq"
+    "${STATE_CLUSTER}/shelley/genesis.conway.json" > "${STATE_CLUSTER}/shelley/genesis.conway.json_jq"
+  cat "${STATE_CLUSTER}/shelley/genesis.conway.json_jq" > "${STATE_CLUSTER}/shelley/genesis.conway.json"
+  rm -f "${STATE_CLUSTER}/shelley/genesis.conway.json_jq"
 fi
 
 KEY_DEPOSIT="$(jq '.protocolParams.keyDeposit' \
-  < "$STATE_CLUSTER/shelley/genesis.json")"
+  < "${STATE_CLUSTER}/shelley/genesis.json")"
 POOL_DEPOSIT="$(jq '.protocolParams.poolDeposit' \
-  < "$STATE_CLUSTER/shelley/genesis.json")"
+  < "${STATE_CLUSTER}/shelley/genesis.json")"
 DREP_DEPOSIT="$(jq '.dRepDeposit' \
-  < "$STATE_CLUSTER/shelley/genesis.conway.json")"
+  < "${STATE_CLUSTER}/shelley/genesis.conway.json")"
 GOV_ACTION_DEPOSIT="$(jq '.govActionDeposit' \
-  < "$STATE_CLUSTER/shelley/genesis.conway.json")"
+  < "${STATE_CLUSTER}/shelley/genesis.conway.json")"
 
 BYRON_GENESIS_HASH="$(cardano_cli_log byron genesis print-genesis-hash --genesis-json \
-  "$STATE_CLUSTER/byron/genesis.json")"
+  "${STATE_CLUSTER}/byron/genesis.json")"
 SHELLEY_GENESIS_HASH="$(cardano_cli_log legacy genesis hash --genesis \
-  "$STATE_CLUSTER/shelley/genesis.json")"
+  "${STATE_CLUSTER}/shelley/genesis.json")"
 ALONZO_GENESIS_HASH="$(cardano_cli_log legacy genesis hash --genesis \
-  "$STATE_CLUSTER/shelley/genesis.alonzo.json")"
+  "${STATE_CLUSTER}/shelley/genesis.alonzo.json")"
 CONWAY_GENESIS_HASH="$(cardano_cli_log legacy genesis hash --genesis \
-  "$STATE_CLUSTER/shelley/genesis.conway.json")"
+  "${STATE_CLUSTER}/shelley/genesis.conway.json")"
 
 for conf in "$SCRIPT_DIR"/config-*.json; do
   fname="${conf##*/}"
@@ -351,7 +351,7 @@ for conf in "$SCRIPT_DIR"/config-*.json; do
     | .ShelleyGenesisHash = $shelley_hash
     | .AlonzoGenesisHash = $alonzo_hash
     | .ConwayGenesisHash = $conway_hash' \
-    "$conf" > "$STATE_CLUSTER/$fname"
+    "$conf" > "${STATE_CLUSTER}/${fname}"
 
   # enable P2P
   if [ -z "${ENABLE_LEGACY:-""}" ]; then
@@ -368,7 +368,7 @@ for conf in "$SCRIPT_DIR"/config-*.json; do
       pool_num="${fname##*-pool}"
       pool_num="${pool_num%.json}"
       if [ "$((pool_num % 2))" != 0 ]; then
-        cp -f "$SCRIPT_DIR/topology-pool${pool_num}.json" "$STATE_CLUSTER"
+        cp -f "${SCRIPT_DIR}/topology-pool${pool_num}.json" "$STATE_CLUSTER"
         continue
       fi
     fi
@@ -384,172 +384,172 @@ for conf in "$SCRIPT_DIR"/config-*.json; do
       | .ExperimentalProtocolsEnabled = true
       | .TraceBlockFetchClient = true
       | .TraceChainSyncClient = true' \
-      "$STATE_CLUSTER/$fname" > "$STATE_CLUSTER/${fname}_jq"
-    cat "$STATE_CLUSTER/${fname}_jq" > "$STATE_CLUSTER/$fname"
-    rm -f "$STATE_CLUSTER/${fname}_jq"
+      "${STATE_CLUSTER}/${fname}" > "${STATE_CLUSTER}/${fname}_jq"
+    cat "${STATE_CLUSTER}/${fname}_jq" > "${STATE_CLUSTER}/${fname}"
+    rm -f "${STATE_CLUSTER}/${fname}_jq"
   fi
 done
 
-for i in $(seq 1 $NUM_BFT_NODES); do
-  mkdir -p "$STATE_CLUSTER/nodes/node-bft$i"
-  ln -s "../../shelley/delegate-keys/delegate$i.vrf.skey" "$STATE_CLUSTER/nodes/node-bft$i/vrf.skey"
-  ln -s "../../shelley/delegate-keys/delegate$i.vrf.vkey" "$STATE_CLUSTER/nodes/node-bft$i/vrf.vkey"
+for i in $(seq 1 "$NUM_BFT_NODES"); do
+  mkdir -p "${STATE_CLUSTER}/nodes/node-bft$i"
+  ln -s "../../shelley/delegate-keys/delegate${i}.vrf.skey" "${STATE_CLUSTER}/nodes/node-bft${i}/vrf.skey"
+  ln -s "../../shelley/delegate-keys/delegate${i}.vrf.vkey" "${STATE_CLUSTER}/nodes/node-bft${i}/vrf.vkey"
 
   cardano_cli_log latest node key-gen-KES \
-    --verification-key-file "$STATE_CLUSTER/nodes/node-bft$i/kes.vkey" \
-    --signing-key-file "$STATE_CLUSTER/nodes/node-bft$i/kes.skey"
+    --verification-key-file "${STATE_CLUSTER}/nodes/node-bft${i}/kes.vkey" \
+    --signing-key-file "${STATE_CLUSTER}/nodes/node-bft${i}/kes.skey"
 
   cardano_cli_log latest node issue-op-cert \
     --kes-period 0 \
-    --cold-signing-key-file "$STATE_CLUSTER/shelley/delegate-keys/delegate$i.skey" \
-    --kes-verification-key-file "$STATE_CLUSTER/nodes/node-bft$i/kes.vkey" \
+    --cold-signing-key-file "${STATE_CLUSTER}/shelley/delegate-keys/delegate${i}.skey" \
+    --kes-verification-key-file "${STATE_CLUSTER}/nodes/node-bft${i}/kes.vkey" \
     --operational-certificate-issue-counter-file \
-      "$STATE_CLUSTER/shelley/delegate-keys/delegate$i.counter" \
-    --out-file "$STATE_CLUSTER/nodes/node-bft$i/op.cert"
+      "${STATE_CLUSTER}/shelley/delegate-keys/delegate${i}.counter" \
+    --out-file "${STATE_CLUSTER}/nodes/node-bft${i}/op.cert"
 
   INDEX="$(printf "%03d" $((i - 1)))"
 
   cardano_cli_log byron key keygen \
-    --secret "$STATE_CLUSTER/byron/payment-keys.$INDEX.key"
+    --secret "${STATE_CLUSTER}/byron/payment-keys.${INDEX}.key"
 
   cardano_cli_log byron key signing-key-address \
     --byron-formats \
     --testnet-magic "$NETWORK_MAGIC" \
-    --secret "$STATE_CLUSTER/byron/payment-keys.$INDEX.key" > "$STATE_CLUSTER/byron/address-$INDEX"
+    --secret "${STATE_CLUSTER}/byron/payment-keys.${INDEX}.key" > "${STATE_CLUSTER}/byron/address-${INDEX}"
 
   # write Genesis addresses to files
   cardano_cli_log byron key signing-key-address \
     --byron-formats  \
     --testnet-magic "$NETWORK_MAGIC" \
-    --secret "$STATE_CLUSTER/byron/genesis-keys.$INDEX.key" \
-      > "$STATE_CLUSTER/byron/genesis-address-$INDEX"
+    --secret "${STATE_CLUSTER}/byron/genesis-keys.${INDEX}.key" \
+      > "${STATE_CLUSTER}/byron/genesis-address-${INDEX}"
 
-  ln -s "../../byron/delegate-keys.$INDEX.key" "$STATE_CLUSTER/nodes/node-bft$i/byron-deleg.key"
-  ln -s "../../byron/delegation-cert.$INDEX.json" "$STATE_CLUSTER/nodes/node-bft$i/byron-deleg.json"
+  ln -s "../../byron/delegate-keys.${INDEX}.key" "${STATE_CLUSTER}/nodes/node-bft${i}/byron-deleg.key"
+  ln -s "../../byron/delegation-cert.${INDEX}.json" "${STATE_CLUSTER}/nodes/node-bft${i}/byron-deleg.json"
 
   # create Byron address that moves funds out of the genesis UTxO into a regular address
   cardano_cli_log byron transaction issue-genesis-utxo-expenditure \
-    --genesis-json "$STATE_CLUSTER/byron/genesis.json" \
+    --genesis-json "${STATE_CLUSTER}/byron/genesis.json" \
     --testnet-magic "$NETWORK_MAGIC" \
     --byron-formats \
-    --tx "$STATE_CLUSTER/byron/tx$i.tx" \
-    --wallet-key "$STATE_CLUSTER/nodes/node-bft$i/byron-deleg.key" \
-    --rich-addr-from "$(head -n 1 "$STATE_CLUSTER/byron/genesis-address-$INDEX")" \
-    --txout "(\"$(head -n 1 "$STATE_CLUSTER/byron/address-$INDEX")\", $FUNDS_PER_BYRON_ADDRESS)"
+    --tx "${STATE_CLUSTER}/byron/tx${i}.tx" \
+    --wallet-key "${STATE_CLUSTER}/nodes/node-bft${i}/byron-deleg.key" \
+    --rich-addr-from "$(head -n 1 "${STATE_CLUSTER}/byron/genesis-address-${INDEX}")" \
+    --txout "(\"$(head -n 1 "${STATE_CLUSTER}/byron/address-${INDEX}")\", ${FUNDS_PER_BYRON_ADDRESS})"
 
   # convert to Shelley addresses and keys
   cardano_cli_log latest key convert-byron-key \
-    --byron-signing-key-file "$STATE_CLUSTER/byron/payment-keys.$INDEX.key" \
-    --out-file "$STATE_CLUSTER/byron/payment-keys.$INDEX-converted.skey" \
+    --byron-signing-key-file "${STATE_CLUSTER}/byron/payment-keys.${INDEX}.key" \
+    --out-file "${STATE_CLUSTER}/byron/payment-keys.${INDEX}-converted.skey" \
     --byron-payment-key-type
 
   cardano_cli_log latest key verification-key \
-    --signing-key-file "$STATE_CLUSTER/byron/payment-keys.$INDEX-converted.skey" \
-    --verification-key-file "$STATE_CLUSTER/byron/payment-keys.$INDEX-converted.vkey"
+    --signing-key-file "${STATE_CLUSTER}/byron/payment-keys.${INDEX}-converted.skey" \
+    --verification-key-file "${STATE_CLUSTER}/byron/payment-keys.${INDEX}-converted.vkey"
 
   cardano_cli_log latest address build \
     --testnet-magic "$NETWORK_MAGIC" \
-    --payment-verification-key-file "$STATE_CLUSTER/byron/payment-keys.$INDEX-converted.vkey" \
-    > "$STATE_CLUSTER/byron/address-$INDEX-converted"
+    --payment-verification-key-file "${STATE_CLUSTER}/byron/payment-keys.${INDEX}-converted.vkey" \
+    > "${STATE_CLUSTER}/byron/address-${INDEX}-converted"
 
-  BFT_PORT=$(("%%NODE_PORT_BASE%%" + (i - 1) * "%%PORTS_PER_NODE%%" ))
-  echo "$BFT_PORT" > "$STATE_CLUSTER/nodes/node-bft$i/port"
+  BFT_PORT="$(("%%NODE_PORT_BASE%%" + (i - 1) * "%%PORTS_PER_NODE%%" ))"
+  echo "$BFT_PORT" > "${STATE_CLUSTER}/nodes/node-bft${i}/port"
 done
 
 for i in $(seq 1 "$NUM_POOLS"); do
-  mkdir -p "$STATE_CLUSTER/nodes/node-pool$i"
+  mkdir -p "${STATE_CLUSTER}/nodes/node-pool$i"
   echo "Generating Pool $i Secrets"
 
   # pool owner addresses and keys
   cardano_cli_log latest address key-gen \
-    --signing-key-file "$STATE_CLUSTER/nodes/node-pool$i/owner-utxo.skey" \
-    --verification-key-file "$STATE_CLUSTER/nodes/node-pool$i/owner-utxo.vkey"
+    --signing-key-file "${STATE_CLUSTER}/nodes/node-pool${i}/owner-utxo.skey" \
+    --verification-key-file "${STATE_CLUSTER}/nodes/node-pool${i}/owner-utxo.vkey"
   cardano_cli_log latest stake-address key-gen \
-    --signing-key-file "$STATE_CLUSTER/nodes/node-pool$i/owner-stake.skey" \
-    --verification-key-file "$STATE_CLUSTER/nodes/node-pool$i/owner-stake.vkey"
+    --signing-key-file "${STATE_CLUSTER}/nodes/node-pool${i}/owner-stake.skey" \
+    --verification-key-file "${STATE_CLUSTER}/nodes/node-pool${i}/owner-stake.vkey"
   #   payment address
   cardano_cli_log latest address build \
-    --payment-verification-key-file "$STATE_CLUSTER/nodes/node-pool$i/owner-utxo.vkey" \
-    --stake-verification-key-file "$STATE_CLUSTER/nodes/node-pool$i/owner-stake.vkey" \
+    --payment-verification-key-file "${STATE_CLUSTER}/nodes/node-pool${i}/owner-utxo.vkey" \
+    --stake-verification-key-file "${STATE_CLUSTER}/nodes/node-pool${i}/owner-stake.vkey" \
     --testnet-magic "$NETWORK_MAGIC" \
-    --out-file "$STATE_CLUSTER/nodes/node-pool$i/owner.addr"
+    --out-file "${STATE_CLUSTER}/nodes/node-pool${i}/owner.addr"
   #   stake address
   cardano_cli_log latest stake-address build \
-    --stake-verification-key-file "$STATE_CLUSTER/nodes/node-pool$i/owner-stake.vkey" \
+    --stake-verification-key-file "${STATE_CLUSTER}/nodes/node-pool${i}/owner-stake.vkey" \
     --testnet-magic "$NETWORK_MAGIC" \
-    --out-file "$STATE_CLUSTER/nodes/node-pool$i/owner-stake.addr"
+    --out-file "${STATE_CLUSTER}/nodes/node-pool${i}/owner-stake.addr"
   #   stake address registration cert
   cardano_cli_log shelley stake-address registration-certificate \
-    --stake-verification-key-file "$STATE_CLUSTER/nodes/node-pool$i/owner-stake.vkey" \
-    --out-file "$STATE_CLUSTER/nodes/node-pool$i/stake.reg.cert"
+    --stake-verification-key-file "${STATE_CLUSTER}/nodes/node-pool${i}/owner-stake.vkey" \
+    --out-file "${STATE_CLUSTER}/nodes/node-pool${i}/stake.reg.cert"
 
   # stake reward keys
   cardano_cli_log latest stake-address key-gen \
-    --signing-key-file "$STATE_CLUSTER/nodes/node-pool$i/reward.skey" \
-    --verification-key-file "$STATE_CLUSTER/nodes/node-pool$i/reward.vkey"
+    --signing-key-file "${STATE_CLUSTER}/nodes/node-pool${i}/reward.skey" \
+    --verification-key-file "${STATE_CLUSTER}/nodes/node-pool${i}/reward.vkey"
   # stake reward address registration cert
   cardano_cli_log shelley stake-address registration-certificate \
-    --stake-verification-key-file "$STATE_CLUSTER/nodes/node-pool$i/reward.vkey" \
-    --out-file "$STATE_CLUSTER/nodes/node-pool$i/stake-reward.shelley_reg.cert"
+    --stake-verification-key-file "${STATE_CLUSTER}/nodes/node-pool${i}/reward.vkey" \
+    --out-file "${STATE_CLUSTER}/nodes/node-pool${i}/stake-reward.shelley_reg.cert"
   # stake reward delegation to alwaysAbstain DRep cert
   cardano_cli_log conway stake-address vote-delegation-certificate \
-    --stake-verification-key-file "$STATE_CLUSTER/nodes/node-pool${i}/reward.vkey" \
+    --stake-verification-key-file "${STATE_CLUSTER}/nodes/node-pool${i}/reward.vkey" \
     --always-abstain \
-    --out-file "$STATE_CLUSTER/nodes/node-pool${i}/stake-reward_vote_deleg.cert"
+    --out-file "${STATE_CLUSTER}/nodes/node-pool${i}/stake-reward_vote_deleg.cert"
   if [ -n "${PV10:-""}" ]; then
     # stake reward address registration and vote delegation cert, to be used later in tests
     # when re-registering the reward address in Conway
     cardano_cli_log conway stake-address registration-and-vote-delegation-certificate \
-      --stake-verification-key-file "$STATE_CLUSTER/nodes/node-pool$i/reward.vkey" \
+      --stake-verification-key-file "${STATE_CLUSTER}/nodes/node-pool${i}/reward.vkey" \
       --always-abstain \
       --key-reg-deposit-amt "$KEY_DEPOSIT" \
-      --out-file "$STATE_CLUSTER/nodes/node-pool$i/stake-reward.reg.cert"
+      --out-file "${STATE_CLUSTER}/nodes/node-pool${i}/stake-reward.reg.cert"
   else
     ln \
-      "$STATE_CLUSTER/nodes/node-pool$i/stake-reward.shelley_reg.cert" \
-      "$STATE_CLUSTER/nodes/node-pool$i/stake-reward.reg.cert"
+      "${STATE_CLUSTER}/nodes/node-pool${i}/stake-reward.shelley_reg.cert" \
+      "${STATE_CLUSTER}/nodes/node-pool${i}/stake-reward.reg.cert"
   fi
 
   # pool keys
   cardano_cli_log latest node key-gen \
-    --cold-verification-key-file "$STATE_CLUSTER/nodes/node-pool$i/cold.vkey" \
-    --cold-signing-key-file "$STATE_CLUSTER/nodes/node-pool$i/cold.skey" \
-    --operational-certificate-issue-counter-file "$STATE_CLUSTER/nodes/node-pool$i/cold.counter"
+    --cold-verification-key-file "${STATE_CLUSTER}/nodes/node-pool${i}/cold.vkey" \
+    --cold-signing-key-file "${STATE_CLUSTER}/nodes/node-pool${i}/cold.skey" \
+    --operational-certificate-issue-counter-file "${STATE_CLUSTER}/nodes/node-pool${i}/cold.counter"
   cardano_cli_log latest node key-gen-KES \
-    --verification-key-file "$STATE_CLUSTER/nodes/node-pool$i/kes.vkey" \
-    --signing-key-file "$STATE_CLUSTER/nodes/node-pool$i/kes.skey"
+    --verification-key-file "${STATE_CLUSTER}/nodes/node-pool${i}/kes.vkey" \
+    --signing-key-file "${STATE_CLUSTER}/nodes/node-pool${i}/kes.skey"
   cardano_cli_log latest node key-gen-VRF \
-    --verification-key-file "$STATE_CLUSTER/nodes/node-pool$i/vrf.vkey" \
-    --signing-key-file "$STATE_CLUSTER/nodes/node-pool$i/vrf.skey"
+    --verification-key-file "${STATE_CLUSTER}/nodes/node-pool${i}/vrf.vkey" \
+    --signing-key-file "${STATE_CLUSTER}/nodes/node-pool${i}/vrf.skey"
 
   # stake address delegation certs
   cardano_cli_log shelley stake-address stake-delegation-certificate \
-    --stake-verification-key-file "$STATE_CLUSTER/nodes/node-pool$i/owner-stake.vkey" \
-    --cold-verification-key-file  "$STATE_CLUSTER/nodes/node-pool$i/cold.vkey" \
-    --out-file "$STATE_CLUSTER/nodes/node-pool$i/owner-stake.deleg.cert"
+    --stake-verification-key-file "${STATE_CLUSTER}/nodes/node-pool${i}/owner-stake.vkey" \
+    --cold-verification-key-file  "${STATE_CLUSTER}/nodes/node-pool${i}/cold.vkey" \
+    --out-file "${STATE_CLUSTER}/nodes/node-pool${i}/owner-stake.deleg.cert"
 
   # pool opcert
   cardano_cli_log latest node issue-op-cert \
     --kes-period 0 \
-    --cold-signing-key-file "$STATE_CLUSTER/nodes/node-pool$i/cold.skey" \
-    --kes-verification-key-file "$STATE_CLUSTER/nodes/node-pool$i/kes.vkey" \
-    --operational-certificate-issue-counter-file "$STATE_CLUSTER/nodes/node-pool$i/cold.counter" \
-    --out-file "$STATE_CLUSTER/nodes/node-pool$i/op.cert"
+    --cold-signing-key-file "${STATE_CLUSTER}/nodes/node-pool${i}/cold.skey" \
+    --kes-verification-key-file "${STATE_CLUSTER}/nodes/node-pool${i}/kes.vkey" \
+    --operational-certificate-issue-counter-file "${STATE_CLUSTER}/nodes/node-pool${i}/cold.counter" \
+    --out-file "${STATE_CLUSTER}/nodes/node-pool${i}/op.cert"
 
-  POOL_NAME="TestPool$i"
+  POOL_NAME="TestPool${i}"
   POOL_DESC="Test Pool $i"
-  POOL_TICKER="TP$i"
+  POOL_TICKER="TP${i}"
 
-  cat > "$STATE_CLUSTER/webserver/pool$i.html" <<EoF
+  cat > "${STATE_CLUSTER}/webserver/pool${i}.html" <<EoF
 <!DOCTYPE html>
 <html>
 <head>
-<title>$POOL_NAME</title>
+<title>${POOL_NAME}</title>
 </head>
 <body>
-name: <strong>$POOL_NAME</strong><br>
-description: <strong>$POOL_DESC</strong><br>
-ticker: <strong>$POOL_TICKER</strong><br>
+name: <strong>${POOL_NAME}</strong><br>
+description: <strong>${POOL_DESC}</strong><br>
+ticker: <strong>${POOL_TICKER}</strong><br>
 </body>
 </html>
 EoF
@@ -559,109 +559,109 @@ EoF
     --arg name "$POOL_NAME" \
     --arg description "$POOL_DESC" \
     --arg ticker "$POOL_TICKER" \
-    --arg homepage "http://localhost:%%WEBSERVER_PORT%%/pool$i.html" \
+    --arg homepage "http://localhost:%%WEBSERVER_PORT%%/pool${i}.html" \
     '{"name": $name, "description": $description, "ticker": $ticker, "homepage": $homepage}' \
-    > "$STATE_CLUSTER/webserver/pool$i.json"
+    > "${STATE_CLUSTER}/webserver/pool${i}.json"
 
-  METADATA_URL="http://localhost:%%WEBSERVER_PORT%%/pool$i.json"
-  METADATA_HASH=$(cardano_cli_log latest stake-pool metadata-hash --pool-metadata-file \
-    "$STATE_CLUSTER/webserver/pool$i.json")
-      POOL_PORT=$(("%%NODE_PORT_BASE%%" + ("$NUM_BFT_NODES" + i - 1) * "%%PORTS_PER_NODE%%"))
-  echo "$POOL_PORT" > "$STATE_CLUSTER/nodes/node-pool$i/port"
-  echo $POOL_PLEDGE > "$STATE_CLUSTER/nodes/node-pool$i/pledge"
+  METADATA_URL="http://localhost:%%WEBSERVER_PORT%%/pool${i}.json"
+  METADATA_HASH="$(cardano_cli_log latest stake-pool metadata-hash --pool-metadata-file \
+    "${STATE_CLUSTER}/webserver/pool${i}.json")"
+  POOL_PORT="$(("%%NODE_PORT_BASE%%" + (NUM_BFT_NODES + i - 1) * "%%PORTS_PER_NODE%%"))"
+  echo "$POOL_PORT" > "${STATE_CLUSTER}/nodes/node-pool${i}/port"
+  echo "$POOL_PLEDGE" > "${STATE_CLUSTER}/nodes/node-pool${i}/pledge"
 
   cardano_cli_log shelley stake-pool registration-certificate \
-    --cold-verification-key-file "$STATE_CLUSTER/nodes/node-pool$i/cold.vkey" \
-    --vrf-verification-key-file "$STATE_CLUSTER/nodes/node-pool$i/vrf.vkey" \
+    --cold-verification-key-file "${STATE_CLUSTER}/nodes/node-pool${i}/cold.vkey" \
+    --vrf-verification-key-file "${STATE_CLUSTER}/nodes/node-pool${i}/vrf.vkey" \
     --pool-pledge "$POOL_PLEDGE" \
     --pool-margin 0.35 \
     --pool-cost "$POOL_COST" \
-    --pool-reward-account-verification-key-file "$STATE_CLUSTER/nodes/node-pool$i/reward.vkey" \
-    --pool-owner-stake-verification-key-file "$STATE_CLUSTER/nodes/node-pool$i/owner-stake.vkey" \
+    --pool-reward-account-verification-key-file "${STATE_CLUSTER}/nodes/node-pool${i}/reward.vkey" \
+    --pool-owner-stake-verification-key-file "${STATE_CLUSTER}/nodes/node-pool${i}/owner-stake.vkey" \
     --metadata-url "$METADATA_URL" \
     --metadata-hash "$METADATA_HASH" \
     --pool-relay-port "$POOL_PORT" \
     --pool-relay-ipv4 "127.0.0.1" \
     --testnet-magic "$NETWORK_MAGIC" \
-    --out-file "$STATE_CLUSTER/nodes/node-pool$i/register.cert"
+    --out-file "${STATE_CLUSTER}/nodes/node-pool${i}/register.cert"
 done
 
-mv "$STATE_CLUSTER/shelley/utxo-keys/utxo1.vkey" "$STATE_CLUSTER/shelley/genesis-utxo.vkey"
-mv "$STATE_CLUSTER/shelley/utxo-keys/utxo1.skey" "$STATE_CLUSTER/shelley/genesis-utxo.skey"
-rmdir "$STATE_CLUSTER/shelley/utxo-keys"
+mv "${STATE_CLUSTER}/shelley/utxo-keys/utxo1.vkey" "${STATE_CLUSTER}/shelley/genesis-utxo.vkey"
+mv "${STATE_CLUSTER}/shelley/utxo-keys/utxo1.skey" "${STATE_CLUSTER}/shelley/genesis-utxo.skey"
+rmdir "${STATE_CLUSTER}/shelley/utxo-keys"
 
 for i in $(seq 1 "$NUM_DREPS"); do
   # DRep keys
   cardano_cli_log conway governance drep key-gen \
-    --signing-key-file "$STATE_CLUSTER/governance_data/default_drep_${i}_drep.skey" \
-    --verification-key-file "$STATE_CLUSTER/governance_data/default_drep_${i}_drep.vkey"
+    --signing-key-file "${STATE_CLUSTER}/governance_data/default_drep_${i}_drep.skey" \
+    --verification-key-file "${STATE_CLUSTER}/governance_data/default_drep_${i}_drep.vkey"
 
   # DRep registration
   cardano_cli_log conway governance drep registration-certificate \
-    --drep-verification-key-file "$STATE_CLUSTER/governance_data/default_drep_${i}_drep.vkey" \
+    --drep-verification-key-file "${STATE_CLUSTER}/governance_data/default_drep_${i}_drep.vkey" \
     --key-reg-deposit-amt "$DREP_DEPOSIT" \
-    --out-file "$STATE_CLUSTER/governance_data/default_drep_${i}_drep_reg.cert"
+    --out-file "${STATE_CLUSTER}/governance_data/default_drep_${i}_drep_reg.cert"
 
   # delegatee payment keys
   cardano_cli_log conway address key-gen \
-    --signing-key-file "$STATE_CLUSTER/governance_data/vote_stake_addr${i}.skey" \
-    --verification-key-file "$STATE_CLUSTER/governance_data/vote_stake_addr${i}.vkey"
+    --signing-key-file "${STATE_CLUSTER}/governance_data/vote_stake_addr${i}.skey" \
+    --verification-key-file "${STATE_CLUSTER}/governance_data/vote_stake_addr${i}.vkey"
 
   # delegatee stake keys
   cardano_cli_log conway stake-address key-gen \
-    --signing-key-file "$STATE_CLUSTER/governance_data/vote_stake_addr${i}_stake.skey" \
-    --verification-key-file "$STATE_CLUSTER/governance_data/vote_stake_addr${i}_stake.vkey"
+    --signing-key-file "${STATE_CLUSTER}/governance_data/vote_stake_addr${i}_stake.skey" \
+    --verification-key-file "${STATE_CLUSTER}/governance_data/vote_stake_addr${i}_stake.vkey"
 
   # delegatee payment address
   cardano_cli_log conway address build \
-    --payment-verification-key-file "$STATE_CLUSTER/governance_data/vote_stake_addr${i}.vkey" \
-    --stake-verification-key-file "$STATE_CLUSTER/governance_data/vote_stake_addr${i}_stake.vkey" \
+    --payment-verification-key-file "${STATE_CLUSTER}/governance_data/vote_stake_addr${i}.vkey" \
+    --stake-verification-key-file "${STATE_CLUSTER}/governance_data/vote_stake_addr${i}_stake.vkey" \
     --testnet-magic "$NETWORK_MAGIC" \
-    --out-file "$STATE_CLUSTER/governance_data/vote_stake_addr${i}.addr"
+    --out-file "${STATE_CLUSTER}/governance_data/vote_stake_addr${i}.addr"
 
   # delegatee stake address
   cardano_cli_log conway stake-address build \
-    --stake-verification-key-file "$STATE_CLUSTER/governance_data/vote_stake_addr${i}_stake.vkey" \
+    --stake-verification-key-file "${STATE_CLUSTER}/governance_data/vote_stake_addr${i}_stake.vkey" \
     --testnet-magic "$NETWORK_MAGIC" \
-    --out-file "$STATE_CLUSTER/governance_data/vote_stake_addr${i}_stake.addr"
+    --out-file "${STATE_CLUSTER}/governance_data/vote_stake_addr${i}_stake.addr"
 
   # delegatee stake address registration cert
   cardano_cli_log conway stake-address registration-certificate \
-    --stake-verification-key-file "$STATE_CLUSTER/governance_data/vote_stake_addr${i}_stake.vkey" \
+    --stake-verification-key-file "${STATE_CLUSTER}/governance_data/vote_stake_addr${i}_stake.vkey" \
     --key-reg-deposit-amt "$KEY_DEPOSIT" \
-    --out-file "$STATE_CLUSTER/governance_data/vote_stake_addr${i}_stake.reg.cert"
+    --out-file "${STATE_CLUSTER}/governance_data/vote_stake_addr${i}_stake.reg.cert"
 
   # delegatee vote delegation cert
   cardano_cli_log conway stake-address vote-delegation-certificate \
-    --stake-verification-key-file "$STATE_CLUSTER/governance_data/vote_stake_addr${i}_stake.vkey" \
-    --drep-verification-key-file "$STATE_CLUSTER/governance_data/default_drep_${i}_drep.vkey" \
-    --out-file "$STATE_CLUSTER/governance_data/vote_stake_addr${i}_stake.vote_deleg.cert"
+    --stake-verification-key-file "${STATE_CLUSTER}/governance_data/vote_stake_addr${i}_stake.vkey" \
+    --drep-verification-key-file "${STATE_CLUSTER}/governance_data/default_drep_${i}_drep.vkey" \
+    --out-file "${STATE_CLUSTER}/governance_data/vote_stake_addr${i}_stake.vote_deleg.cert"
 done
 
 # create scripts for cluster starting / stopping
-printf "#!/bin/sh\n\nsupervisorctl -s http://127.0.0.1:%%SUPERVISOR_PORT%% start all" > "$STATE_CLUSTER/supervisorctl_start"
-printf "#!/bin/sh\n\nsupervisorctl -s http://127.0.0.1:%%SUPERVISOR_PORT%% restart nodes:" > "$STATE_CLUSTER/supervisorctl_restart_nodes"
-printf "#!/bin/sh\n\nsupervisorctl -s http://127.0.0.1:%%SUPERVISOR_PORT%% \"\$@\"" > "$STATE_CLUSTER/supervisorctl"
+printf "#!/bin/sh\n\nsupervisorctl -s http://127.0.0.1:%%SUPERVISOR_PORT%% start all" > "${STATE_CLUSTER}/supervisorctl_start"
+printf "#!/bin/sh\n\nsupervisorctl -s http://127.0.0.1:%%SUPERVISOR_PORT%% restart nodes:" > "${STATE_CLUSTER}/supervisorctl_restart_nodes"
+printf "#!/bin/sh\n\nsupervisorctl -s http://127.0.0.1:%%SUPERVISOR_PORT%% \"\$@\"" > "${STATE_CLUSTER}/supervisorctl"
 
-cat > "$STATE_CLUSTER/supervisord_start" <<EoF
+cat > "${STATE_CLUSTER}/supervisord_start" <<EoF
 #!/usr/bin/env bash
 
 set -uo pipefail
 
 SCRIPT_DIR="\$(readlink -m "\${0%/*}")"
 
-cd "\$SCRIPT_DIR/.."
+cd "\${SCRIPT_DIR}/.."
 
-supervisord --config "\$SCRIPT_DIR/supervisor.conf"
+supervisord --config "\${SCRIPT_DIR}/supervisor.conf"
 EoF
 
-cat > "$STATE_CLUSTER/supervisord_stop" <<EoF
+cat > "${STATE_CLUSTER}/supervisord_stop" <<EoF
 #!/usr/bin/env bash
 
 set -uo pipefail
 
 SCRIPT_DIR="\$(readlink -m "\${0%/*}")"
-PID_FILE="\$SCRIPT_DIR/supervisord.pid"
+PID_FILE="\${SCRIPT_DIR}/supervisord.pid"
 
 supervisorctl -s http://127.0.0.1:%%SUPERVISOR_PORT%% stop all
 
@@ -692,7 +692,7 @@ if [ -n "${DRY_RUN:-""}" ]; then
   exit 0
 fi
 
-supervisord --config "$STATE_CLUSTER/supervisor.conf"
+supervisord --config "${STATE_CLUSTER}/supervisor.conf"
 
 for _ in {1..5}; do
   if [ -S "$CARDANO_NODE_SOCKET_PATH" ]; then
@@ -707,10 +707,10 @@ echo "Sleeping for initial Tx submission delay of $TX_SUBMISSION_DELAY seconds"
 sleep "$TX_SUBMISSION_DELAY"
 
 echo "Moving funds out of Byron genesis"
-for i in $(seq 1 $NUM_BFT_NODES); do
+for i in $(seq 1 "$NUM_BFT_NODES"); do
   cardano_cli_log byron transaction submit-tx \
     --testnet-magic "$NETWORK_MAGIC" \
-    --tx "$STATE_CLUSTER/byron/tx$i.tx"
+    --tx "${STATE_CLUSTER}/byron/tx${i}.tx"
 done
 
 echo "Waiting for Shelley era to start"
@@ -739,7 +739,7 @@ for skey in "$STATE_CLUSTER"/shelley/delegate-keys/delegate?.skey; do
 done
 
 FAUCET_ADDR="$(<"$STATE_CLUSTER"/byron/address-000-converted)"
-FAUCET_SKEY="$STATE_CLUSTER/byron/payment-keys.000-converted.skey"
+FAUCET_SKEY="${STATE_CLUSTER}/byron/payment-keys.000-converted.skey"
 
 
 wait_for_era "Shelley"
@@ -754,8 +754,8 @@ fi
 sleep "$PROPOSAL_DELAY"
 echo "Submitting update proposal to transfer to Allegra, transferring funds to pool owners, registering pools and delegations"
 
-ALLEGRA_HF_PROPOSAL_FILE="$STATE_CLUSTER/shelley/update-proposal-allegra.proposal"
-ALLEGRA_TX_BASE="$STATE_CLUSTER/shelley/transfer-register-delegate"
+ALLEGRA_HF_PROPOSAL_FILE="${STATE_CLUSTER}/shelley/update-proposal-allegra.proposal"
+ALLEGRA_TX_BASE="${STATE_CLUSTER}/shelley/transfer-register-delegate"
 
 cardano_cli_log legacy governance create-update-proposal \
   --out-file "$ALLEGRA_HF_PROPOSAL_FILE" \
@@ -779,16 +779,16 @@ POOL_ARGS=()
 POOL_SIGNING=()
 for i in $(seq 1 "$NUM_POOLS"); do
   POOL_ARGS+=( \
-    "--tx-out" "$(<"$STATE_CLUSTER/nodes/node-pool$i/owner.addr")+$POOL_PLEDGE" \
-    "--certificate-file" "$STATE_CLUSTER/nodes/node-pool$i/stake.reg.cert" \
-    "--certificate-file" "$STATE_CLUSTER/nodes/node-pool$i/stake-reward.shelley_reg.cert" \
-    "--certificate-file" "$STATE_CLUSTER/nodes/node-pool$i/register.cert" \
-    "--certificate-file" "$STATE_CLUSTER/nodes/node-pool$i/owner-stake.deleg.cert" \
+    "--tx-out" "$(<"${STATE_CLUSTER}/nodes/node-pool${i}/owner.addr")+${POOL_PLEDGE}" \
+    "--certificate-file" "${STATE_CLUSTER}/nodes/node-pool${i}/stake.reg.cert" \
+    "--certificate-file" "${STATE_CLUSTER}/nodes/node-pool${i}/stake-reward.shelley_reg.cert" \
+    "--certificate-file" "${STATE_CLUSTER}/nodes/node-pool${i}/register.cert" \
+    "--certificate-file" "${STATE_CLUSTER}/nodes/node-pool${i}/owner-stake.deleg.cert" \
   )
   POOL_SIGNING+=( \
-    "--signing-key-file" "$STATE_CLUSTER/nodes/node-pool$i/owner-stake.skey" \
-    "--signing-key-file" "$STATE_CLUSTER/nodes/node-pool$i/reward.skey" \
-    "--signing-key-file" "$STATE_CLUSTER/nodes/node-pool$i/cold.skey" \
+    "--signing-key-file" "${STATE_CLUSTER}/nodes/node-pool${i}/owner-stake.skey" \
+    "--signing-key-file" "${STATE_CLUSTER}/nodes/node-pool${i}/reward.skey" \
+    "--signing-key-file" "${STATE_CLUSTER}/nodes/node-pool${i}/cold.skey" \
   )
 done
 
@@ -796,7 +796,7 @@ cardano_cli_log shelley transaction build-raw \
   --ttl    "$TTL" \
   --fee    "$FEE" \
   "${TXINS[@]}" \
-  --tx-out "$FAUCET_ADDR+$TXOUT_AMOUNT" \
+  --tx-out "${FAUCET_ADDR}+${TXOUT_AMOUNT}" \
   "${POOL_ARGS[@]}" \
   --update-proposal-file "$ALLEGRA_HF_PROPOSAL_FILE" \
   --out-file         "${ALLEGRA_TX_BASE}-tx.txbody"
@@ -835,7 +835,7 @@ ALLEGRA_EPOCH="$(get_epoch)"
 sleep "$PROPOSAL_DELAY"
 echo "Submitting update proposal to transfer to Mary, set d = 0"
 
-MARY_HF_PROPOSAL="$STATE_CLUSTER/shelley/update-proposal-mary"
+MARY_HF_PROPOSAL="${STATE_CLUSTER}/shelley/update-proposal-mary"
 
 cardano_cli_log legacy governance create-update-proposal \
   --out-file "${MARY_HF_PROPOSAL}.proposal" \
@@ -852,7 +852,7 @@ TXOUT_AMOUNT="$((TXIN_AMOUNT - FEE))"
 cardano_cli_log allegra transaction build-raw \
   --fee    "$FEE" \
   "${TXINS[@]}" \
-  --tx-out "$FAUCET_ADDR+$TXOUT_AMOUNT" \
+  --tx-out "${FAUCET_ADDR}+${TXOUT_AMOUNT}" \
   --update-proposal-file "${MARY_HF_PROPOSAL}.proposal" \
   --out-file         "${MARY_HF_PROPOSAL}-tx.txbody"
 
@@ -888,7 +888,7 @@ MARY_EPOCH="$(get_epoch)"
 sleep "$PROPOSAL_DELAY"
 echo "Submitting update proposal to transfer to Alonzo"
 
-ALONZO_UPDATE_PROPOSAL="$STATE_CLUSTER/shelley/update-proposal-alonzo"
+ALONZO_UPDATE_PROPOSAL="${STATE_CLUSTER}/shelley/update-proposal-alonzo"
 
 cardano_cli_log legacy governance create-update-proposal \
   --out-file "${ALONZO_UPDATE_PROPOSAL}.proposal" \
@@ -904,7 +904,7 @@ TXOUT_AMOUNT="$((TXIN_AMOUNT - FEE))"
 cardano_cli_log mary transaction build-raw \
   --fee    "$FEE" \
   "${TXINS[@]}" \
-  --tx-out "$FAUCET_ADDR+$TXOUT_AMOUNT" \
+  --tx-out "${FAUCET_ADDR}+${TXOUT_AMOUNT}" \
   --update-proposal-file "${ALONZO_UPDATE_PROPOSAL}.proposal" \
   --out-file "${ALONZO_UPDATE_PROPOSAL}-tx.txbody"
 
@@ -940,7 +940,7 @@ ALONZO_EPOCH="$(get_epoch)"
 sleep "$PROPOSAL_DELAY"
 echo "Submitting update proposal to update to PV6"
 
-ALONZO_UPDATE_PROPOSAL_PV6="$STATE_CLUSTER/shelley/update-proposal-alonzo-pv6"
+ALONZO_UPDATE_PROPOSAL_PV6="${STATE_CLUSTER}/shelley/update-proposal-alonzo-pv6"
 
 # protocol version + dapps parameters update
 cardano_cli_log legacy governance create-update-proposal \
@@ -957,7 +957,7 @@ TXOUT_AMOUNT="$((TXIN_AMOUNT - FEE))"
 cardano_cli_log alonzo transaction build-raw \
   --fee    "$FEE" \
   "${TXINS[@]}" \
-  --tx-out "$FAUCET_ADDR+$TXOUT_AMOUNT" \
+  --tx-out "${FAUCET_ADDR}+${TXOUT_AMOUNT}" \
   --update-proposal-file "${ALONZO_UPDATE_PROPOSAL_PV6}.proposal" \
   --out-file "${ALONZO_UPDATE_PROPOSAL_PV6}-tx.txbody"
 
@@ -997,16 +997,16 @@ fi
 
 cardano_cli_log alonzo query protocol-parameters \
   --testnet-magic "$NETWORK_MAGIC" \
-  --out-file "$STATE_CLUSTER/pparams.json"
+  --out-file "${STATE_CLUSTER}/pparams.json"
 
-PROTOCOL_VERSION="$(jq ".protocolVersion.major" < "$STATE_CLUSTER/pparams.json")"
+PROTOCOL_VERSION="$(jq ".protocolVersion.major" < "${STATE_CLUSTER}/pparams.json")"
 
 [ "$PROTOCOL_VERSION" = 6 ] || { echo "Unexpected protocol version '$PROTOCOL_VERSION' on line $LINENO" >&2; exit 1; }  # assert
 
 sleep "$PROPOSAL_DELAY"
 echo "Submitting update proposal to update to Babbage"
 
-BABBAGE_UPDATE_PROPOSAL="$STATE_CLUSTER/shelley/update-proposal-babbage"
+BABBAGE_UPDATE_PROPOSAL="${STATE_CLUSTER}/shelley/update-proposal-babbage"
 
 # protocol version + dapps parameters update
 cardano_cli_log legacy governance create-update-proposal \
@@ -1023,7 +1023,7 @@ TXOUT_AMOUNT="$((TXIN_AMOUNT - FEE))"
 cardano_cli_log alonzo transaction build-raw \
   --fee    "$FEE" \
   "${TXINS[@]}" \
-  --tx-out "$FAUCET_ADDR+$TXOUT_AMOUNT" \
+  --tx-out "${FAUCET_ADDR}+${TXOUT_AMOUNT}" \
   --update-proposal-file "${BABBAGE_UPDATE_PROPOSAL}.proposal" \
   --out-file "${BABBAGE_UPDATE_PROPOSAL}-tx.txbody"
 
@@ -1059,7 +1059,7 @@ BABBAGE_EPOCH="$(get_epoch)"
 sleep "$PROPOSAL_DELAY"
 echo "Submitting update proposal to update to PV8"
 
-BABBAGE_UPDATE_PROPOSAL_PV8="$STATE_CLUSTER/shelley/update-proposal-babbage-pv8"
+BABBAGE_UPDATE_PROPOSAL_PV8="${STATE_CLUSTER}/shelley/update-proposal-babbage-pv8"
 
 # protocol version 8
 cardano_cli_log legacy governance create-update-proposal \
@@ -1076,7 +1076,7 @@ TXOUT_AMOUNT="$((TXIN_AMOUNT - FEE))"
 cardano_cli_log babbage transaction build-raw \
   --fee    "$FEE" \
   "${TXINS[@]}" \
-  --tx-out "$FAUCET_ADDR+$TXOUT_AMOUNT" \
+  --tx-out "${FAUCET_ADDR}+${TXOUT_AMOUNT}" \
   --update-proposal-file "${BABBAGE_UPDATE_PROPOSAL_PV8}.proposal" \
   --out-file "${BABBAGE_UPDATE_PROPOSAL_PV8}-tx.txbody"
 
@@ -1109,9 +1109,9 @@ BABBAGE_PV8_EPOCH="$(get_epoch)"
 
 cardano_cli_log babbage query protocol-parameters \
   --testnet-magic "$NETWORK_MAGIC" \
-  --out-file "$STATE_CLUSTER/pparams.json"
+  --out-file "${STATE_CLUSTER}/pparams.json"
 
-PROTOCOL_VERSION="$(jq ".protocolVersion.major" < "$STATE_CLUSTER/pparams.json")"
+PROTOCOL_VERSION="$(jq ".protocolVersion.major" < "${STATE_CLUSTER}/pparams.json")"
 
 [ "$PROTOCOL_VERSION" = 8 ] || { echo "Unexpected protocol version '$PROTOCOL_VERSION' on line $LINENO" >&2; exit 1; }  # assert
 
@@ -1119,7 +1119,7 @@ PROTOCOL_VERSION="$(jq ".protocolVersion.major" < "$STATE_CLUSTER/pparams.json")
 sleep "$PROPOSAL_DELAY"
 echo "Submitting update proposal to update to Conway"
 
-CONWAY_UPDATE_PROPOSAL="$STATE_CLUSTER/shelley/update-proposal-conway"
+CONWAY_UPDATE_PROPOSAL="${STATE_CLUSTER}/shelley/update-proposal-conway"
 
 # protocol version 9
 cardano_cli_log legacy governance create-update-proposal \
@@ -1136,7 +1136,7 @@ TXOUT_AMOUNT="$((TXIN_AMOUNT - FEE))"
 cardano_cli_log babbage transaction build-raw \
   --fee    "$FEE" \
   "${TXINS[@]}" \
-  --tx-out "$FAUCET_ADDR+$TXOUT_AMOUNT" \
+  --tx-out "${FAUCET_ADDR}+${TXOUT_AMOUNT}" \
   --update-proposal-file "${CONWAY_UPDATE_PROPOSAL}.proposal" \
   --out-file "${CONWAY_UPDATE_PROPOSAL}-tx.txbody"
 
@@ -1171,9 +1171,9 @@ CONWAY_PV9_EPOCH="$(get_epoch)"
 
 cardano_cli_log conway query protocol-parameters \
   --testnet-magic "$NETWORK_MAGIC" \
-  --out-file "$STATE_CLUSTER/pparams.json"
+  --out-file "${STATE_CLUSTER}/pparams.json"
 
-PROTOCOL_VERSION="$(jq ".protocolVersion.major" < "$STATE_CLUSTER/pparams.json")"
+PROTOCOL_VERSION="$(jq ".protocolVersion.major" < "${STATE_CLUSTER}/pparams.json")"
 
 [ "$PROTOCOL_VERSION" = 9 ] || { echo "Unexpected protocol version '$PROTOCOL_VERSION' on line $LINENO" >&2; exit 1; }  # assert
 
@@ -1187,7 +1187,7 @@ get_txins "$FAUCET_ADDR" "$STOP_TXIN_AMOUNT"
 
 TXOUT_AMOUNT="$((TXIN_AMOUNT - STOP_TXIN_AMOUNT))"
 
-V9_TX="$STATE_CLUSTER/governance_data/setup_governance"
+V9_TX="${STATE_CLUSTER}/governance_data/setup_governance"
 
 CC_ARGS=()
 for f in "$STATE_CLUSTER"/governance_data/cc_member*_committee_hot_auth.cert; do
@@ -1205,15 +1205,15 @@ DREPS_ARGS=()
 DREPS_SIGNING=()
 for i in $(seq 1 "$NUM_DREPS"); do
   DREPS_ARGS+=( \
-    "--tx-out" "$(<"$STATE_CLUSTER/governance_data/vote_stake_addr${i}.addr")+$DREP_DELEGATED" \
-    "--certificate-file" "$STATE_CLUSTER/governance_data/default_drep_${i}_drep_reg.cert" \
-    "--certificate-file" "$STATE_CLUSTER/governance_data/vote_stake_addr${i}_stake.reg.cert" \
-    "--certificate-file" "$STATE_CLUSTER/governance_data/vote_stake_addr${i}_stake.vote_deleg.cert" \
+    "--tx-out" "$(<"${STATE_CLUSTER}/governance_data/vote_stake_addr${i}.addr")+${DREP_DELEGATED}" \
+    "--certificate-file" "${STATE_CLUSTER}/governance_data/default_drep_${i}_drep_reg.cert" \
+    "--certificate-file" "${STATE_CLUSTER}/governance_data/vote_stake_addr${i}_stake.reg.cert" \
+    "--certificate-file" "${STATE_CLUSTER}/governance_data/vote_stake_addr${i}_stake.vote_deleg.cert" \
   )
   DREPS_SIGNING+=( \
-    "--signing-key-file" "$STATE_CLUSTER/governance_data/default_drep_${i}_drep.skey" \
-    "--signing-key-file" "$STATE_CLUSTER/governance_data/vote_stake_addr${i}.skey" \
-    "--signing-key-file" "$STATE_CLUSTER/governance_data/vote_stake_addr${i}_stake.skey" \
+    "--signing-key-file" "${STATE_CLUSTER}/governance_data/default_drep_${i}_drep.skey" \
+    "--signing-key-file" "${STATE_CLUSTER}/governance_data/vote_stake_addr${i}.skey" \
+    "--signing-key-file" "${STATE_CLUSTER}/governance_data/vote_stake_addr${i}_stake.skey" \
   )
 done
 
@@ -1221,10 +1221,10 @@ POOL_ARGS=()
 POOL_SIGNING=()
 for i in $(seq 1 "$NUM_POOLS"); do
   POOL_ARGS+=( \
-    "--certificate-file" "$STATE_CLUSTER/nodes/node-pool${i}/stake-reward_vote_deleg.cert" \
+    "--certificate-file" "${STATE_CLUSTER}/nodes/node-pool${i}/stake-reward_vote_deleg.cert" \
   )
   POOL_SIGNING+=( \
-    "--signing-key-file" "$STATE_CLUSTER/nodes/node-pool${i}/reward.skey" \
+    "--signing-key-file" "${STATE_CLUSTER}/nodes/node-pool${i}/reward.skey" \
   )
 done
 
@@ -1234,7 +1234,7 @@ cardano_cli_log conway transaction build-raw \
   "${CC_ARGS[@]}" \
   "${DREPS_ARGS[@]}" \
   "${POOL_ARGS[@]}" \
-  --tx-out "$FAUCET_ADDR+$TXOUT_AMOUNT" \
+  --tx-out "${FAUCET_ADDR}+${TXOUT_AMOUNT}" \
   --out-file "${V9_TX}-tx.txbody"
 
 cardano_cli_log conway transaction sign \
@@ -1266,19 +1266,19 @@ fi
 # Hard fork to Conway protocol version 10
 
 if [ -n "${PV10:-""}" ]; then
-  PV10_ACTION="$STATE_CLUSTER/governance_data/hardfork_pv10_action"
+  PV10_ACTION="${STATE_CLUSTER}/governance_data/hardfork_pv10_action"
 
   echo "Submitting hard fork proposal to update to Conway PV10"
 
   cardano_cli_log conway governance action create-hardfork \
     --testnet \
     --governance-action-deposit "$GOV_ACTION_DEPOSIT" \
-    --deposit-return-stake-verification-key-file "$STATE_CLUSTER/nodes/node-pool1/reward.vkey" \
+    --deposit-return-stake-verification-key-file "${STATE_CLUSTER}/nodes/node-pool1/reward.vkey" \
     --anchor-url "http://www.hardfork-pv10.com" \
     --anchor-data-hash 5d372dca1a4cc90d7d16d966c48270e33e3aa0abcb0e78f0d5ca7ff330d2245d \
     --protocol-major-version 10 \
     --protocol-minor-version 0 \
-    --out-file "$PV10_ACTION.action"
+    --out-file "${PV10_ACTION}.action"
 
   STOP_TXIN_AMOUNT="$((FEE + GOV_ACTION_DEPOSIT))"
 
@@ -1289,8 +1289,8 @@ if [ -n "${PV10:-""}" ]; then
   cardano_cli_log conway transaction build-raw \
     --fee    "$FEE" \
     "${TXINS[@]}" \
-    --proposal-file "$PV10_ACTION.action" \
-    --tx-out "$FAUCET_ADDR+$TXOUT_AMOUNT" \
+    --proposal-file "${PV10_ACTION}.action" \
+    --tx-out "${FAUCET_ADDR}+${TXOUT_AMOUNT}" \
     --out-file "${PV10_ACTION}-tx.txbody"
 
   cardano_cli_log conway transaction sign \
@@ -1342,7 +1342,7 @@ if [ -n "${PV10:-""}" ]; then
 
   # Submit the votes
 
-  PV10_VOTES="$STATE_CLUSTER/governance_data/hardfork_pv10_votes"
+  PV10_VOTES="${STATE_CLUSTER}/governance_data/hardfork_pv10_votes"
 
   VOTE_FILES=()
   for f in "$PV10_ACTION"_*.vote; do
@@ -1370,7 +1370,7 @@ if [ -n "${PV10:-""}" ]; then
     --fee    "$FEE" \
     "${TXINS[@]}" \
     "${VOTE_FILES[@]}" \
-    --tx-out "$FAUCET_ADDR+$TXOUT_AMOUNT" \
+    --tx-out "${FAUCET_ADDR}+${TXOUT_AMOUNT}" \
     --out-file "${PV10_VOTES}-tx.txbody"
 
   cardano_cli_log conway transaction sign \
@@ -1396,11 +1396,11 @@ if [ -n "${PV10:-""}" ]; then
 
   cardano_cli_log conway query protocol-parameters \
     --testnet-magic "$NETWORK_MAGIC" \
-    --out-file "$STATE_CLUSTER/pparams.json"
+    --out-file "${STATE_CLUSTER}/pparams.json"
 
-  PROTOCOL_VERSION="$(jq ".protocolVersion.major" < "$STATE_CLUSTER/pparams.json")"
+  PROTOCOL_VERSION="$(jq ".protocolVersion.major" < "${STATE_CLUSTER}/pparams.json")"
 
   [ "$PROTOCOL_VERSION" = 10 ] || { echo "Unexpected protocol version '$PROTOCOL_VERSION' on line $LINENO" >&2; exit 1; }  # assert
 fi
 
-echo "Cluster started. Run \`$SCRIPT_DIR/stop-cluster\` to stop"
+echo "Cluster started. Run \`${SCRIPT_DIR}/stop-cluster\` to stop"

--- a/cardano_node_tests/cluster_scripts/conway_fast/start-cluster
+++ b/cardano_node_tests/cluster_scripts/conway_fast/start-cluster
@@ -37,10 +37,10 @@ if [ -n "${PV10:-""}" ]; then
   PROTOCOL_VERSION=10
 fi
 
-SECURITY_PARAM="$(jq '.securityParam' < "$SCRIPT_DIR/genesis.spec.json")"
-NETWORK_MAGIC="$(jq '.networkMagic' < "$SCRIPT_DIR/genesis.spec.json")"
-MAX_SUPPLY="$(jq '.maxLovelaceSupply' < "$SCRIPT_DIR/genesis.spec.json")"
-POOL_COST="$(jq '.protocolParams.minPoolCost' < "$SCRIPT_DIR/genesis.spec.json")"
+SECURITY_PARAM="$(jq '.securityParam' < "${SCRIPT_DIR}/genesis.spec.json")"
+NETWORK_MAGIC="$(jq '.networkMagic' < "${SCRIPT_DIR}/genesis.spec.json")"
+MAX_SUPPLY="$(jq '.maxLovelaceSupply' < "${SCRIPT_DIR}/genesis.spec.json")"
+POOL_COST="$(jq '.protocolParams.minPoolCost' < "${SCRIPT_DIR}/genesis.spec.json")"
 if [ "$POOL_COST" -eq 0 ]; then
   POOL_COST=600
 fi
@@ -51,8 +51,8 @@ DELEG_MAGIC_VALUE=3340000000000000
 DELEG_SUPPLY="$((POOL_PLEDGE * NUM_POOLS + DELEG_MAGIC_VALUE))"
 NONDELEG_SUPPLY="$(( (MAX_SUPPLY - DELEG_SUPPLY) * 8 / 10))"
 
-if [ -f "$STATE_CLUSTER/supervisord.pid" ]; then
-  echo "Cluster already running. Please run \`$SCRIPT_DIR/stop-cluster\` first!" >&2
+if [ -f "${STATE_CLUSTER}/supervisord.pid" ]; then
+  echo "Cluster already running. Please run \`${SCRIPT_DIR}/stop-cluster\` first!" >&2
   exit 1
 fi
 
@@ -62,7 +62,7 @@ if [ "$NUM_POOLS" -lt 3 ]; then
 fi
 
 cardano_cli_log() {
-  echo cardano-cli "$@" >> "$STATE_CLUSTER/start_cluster_cmds.log"
+  echo cardano-cli "$@" >> "${STATE_CLUSTER}/start_cluster_cmds.log"
 
   for _ in {1..3}; do
     set +e
@@ -119,22 +119,22 @@ get_txins() {
 
 ENABLE_SUBMIT_API="$(command -v cardano-submit-api >/dev/null 2>&1 && echo 1 || echo 0)"
 
-if [ -e "$SCRIPT_DIR/shell_env" ]; then
+if [ -e "${SCRIPT_DIR}/shell_env" ]; then
   # shellcheck disable=SC1090,SC1091
-  source "$SCRIPT_DIR/shell_env"
+  source "${SCRIPT_DIR}/shell_env"
 fi
 
 rm -rf "$STATE_CLUSTER"
 mkdir -p "$STATE_CLUSTER"/{shelley,webserver,db-sync,create_staked}
-cd "$STATE_CLUSTER/.."
+cd "${STATE_CLUSTER}/.."
 
 cp "$SCRIPT_DIR"/cardano-node-* "$STATE_CLUSTER"
-cp "$SCRIPT_DIR/run-cardano-submit-api" "$STATE_CLUSTER"
-cp "$SCRIPT_DIR/byron-params.json" "$STATE_CLUSTER"
-cp "$SCRIPT_DIR/dbsync-config.yaml" "$STATE_CLUSTER"
-cp "$SCRIPT_DIR/submit-api-config.json" "$STATE_CLUSTER"
-cp "$SCRIPT_DIR/supervisor.conf" "$STATE_CLUSTER"
-cp "$SCRIPT_DIR"/*genesis*.spec.json "$STATE_CLUSTER/create_staked/"
+cp "${SCRIPT_DIR}/run-cardano-submit-api" "$STATE_CLUSTER"
+cp "${SCRIPT_DIR}/byron-params.json" "$STATE_CLUSTER"
+cp "${SCRIPT_DIR}/dbsync-config.yaml" "$STATE_CLUSTER"
+cp "${SCRIPT_DIR}/submit-api-config.json" "$STATE_CLUSTER"
+cp "${SCRIPT_DIR}/supervisor.conf" "$STATE_CLUSTER"
+cp "$SCRIPT_DIR"/*genesis*.spec.json "${STATE_CLUSTER}/create_staked/"
 
 if [ -z "${ENABLE_LEGACY:-""}" ]; then
   # use P2P topology files
@@ -148,7 +148,7 @@ fi
 
 case "${UTXO_BACKEND:=""}" in
   "" | mem | disk)
-    echo "$UTXO_BACKEND" > "$STATE_CLUSTER/utxo_backend"
+    echo "$UTXO_BACKEND" > "${STATE_CLUSTER}/utxo_backend"
     ;;
   *)
     echo "Unknown \`UTXO_BACKEND\`: '$UTXO_BACKEND', line $LINENO" >&2
@@ -158,20 +158,20 @@ esac
 
 # enable db-sync service
 if [ -n "${DBSYNC_REPO:-""}" ]; then
-  [ -e "$DBSYNC_REPO/db-sync-node/bin/cardano-db-sync" ] || \
-    { echo "The \`$DBSYNC_REPO/db-sync-node/bin/cardano-db-sync\` not found, line $LINENO" >&2; exit 1; }  # assert
+  [ -e "${DBSYNC_REPO}/db-sync-node/bin/cardano-db-sync" ] || \
+    { echo "The \`${DBSYNC_REPO}/db-sync-node/bin/cardano-db-sync\` not found, line $LINENO" >&2; exit 1; }  # assert
 
   # create clean database
   if [ -z "${DRY_RUN:-""}" ]; then
-    "$SCRIPT_DIR/postgres-setup.sh"
+    "${SCRIPT_DIR}/postgres-setup.sh"
   fi
 
-  cat >> "$STATE_CLUSTER/supervisor.conf" <<EoF
+  cat >> "${STATE_CLUSTER}/supervisor.conf" <<EoF
 
 [program:dbsync]
-command=$SCRIPT_DIR/run-cardano-dbsync
-stderr_logfile=./$STATE_CLUSTER_NAME/dbsync.stderr
-stdout_logfile=./$STATE_CLUSTER_NAME/dbsync.stdout
+command=${SCRIPT_DIR}/run-cardano-dbsync
+stderr_logfile=./${STATE_CLUSTER_NAME}/dbsync.stderr
+stdout_logfile=./${STATE_CLUSTER_NAME}/dbsync.stdout
 autostart=false
 autorestart=false
 startsecs=5
@@ -180,21 +180,21 @@ fi
 
 # enable cardano-submit-api service
 if [ "$ENABLE_SUBMIT_API" -eq 1 ]; then
-  cat >> "$STATE_CLUSTER/supervisor.conf" <<EoF
+  cat >> "${STATE_CLUSTER}/supervisor.conf" <<EoF
 
 [program:submit_api]
-command=$SCRIPT_DIR/run-cardano-submit-api
-stderr_logfile=./$STATE_CLUSTER_NAME/submit_api.stderr
-stdout_logfile=./$STATE_CLUSTER_NAME/submit_api.stdout
+command=${SCRIPT_DIR}/run-cardano-submit-api
+stderr_logfile=./${STATE_CLUSTER_NAME}/submit_api.stderr
+stdout_logfile=./${STATE_CLUSTER_NAME}/submit_api.stdout
 autostart=false
 autorestart=false
 startsecs=5
 EoF
 fi
 
-START_TIME_SHELLEY=$(date --utc +"%Y-%m-%dT%H:%M:%SZ" --date="5 seconds")
-START_TIME=$(date +%s --date="$START_TIME_SHELLEY")
-echo "$START_TIME" > "$STATE_CLUSTER/cluster_start_time"
+START_TIME_SHELLEY="$(date --utc +"%Y-%m-%dT%H:%M:%SZ" --date="5 seconds")"
+START_TIME="$(date +%s --date="$START_TIME_SHELLEY")"
+echo "$START_TIME" > "${STATE_CLUSTER}/cluster_start_time"
 
 cardano_cli_log byron genesis genesis \
   --protocol-magic "$NETWORK_MAGIC" \
@@ -205,14 +205,14 @@ cardano_cli_log byron genesis genesis \
   --delegate-share 1 \
   --avvm-entry-count 0 \
   --avvm-entry-balance 0 \
-  --protocol-parameters-file "$STATE_CLUSTER/byron-params.json" \
-  --genesis-output-dir "$STATE_CLUSTER/byron" \
+  --protocol-parameters-file "${STATE_CLUSTER}/byron-params.json" \
+  --genesis-output-dir "${STATE_CLUSTER}/byron" \
   --start-time "$START_TIME"
 
-mv "$STATE_CLUSTER/byron-params.json" "$STATE_CLUSTER/byron/params.json"
+mv "${STATE_CLUSTER}/byron-params.json" "${STATE_CLUSTER}/byron/params.json"
 
 cardano_cli_log legacy genesis create-staked \
-  --genesis-dir "$STATE_CLUSTER/create_staked" \
+  --genesis-dir "${STATE_CLUSTER}/create_staked" \
   --testnet-magic "$NETWORK_MAGIC" \
   --gen-pools "$NUM_POOLS" \
   --gen-utxo-keys 1 \
@@ -221,72 +221,72 @@ cardano_cli_log legacy genesis create-staked \
   --supply-delegated "$DELEG_SUPPLY" \
   --start-time "$START_TIME_SHELLEY"
 
-mkdir -p "$STATE_CLUSTER/governance_data"
+mkdir -p "${STATE_CLUSTER}/governance_data"
 
 # Create committee keys
 if [ -z "${NO_CC:-""}" ]; then
   for i in $(seq 1 "$NUM_CC"); do
     cardano_cli_log conway governance committee key-gen-cold \
-      --cold-verification-key-file "$STATE_CLUSTER/governance_data/cc_member${i}_committee_cold.vkey" \
-      --cold-signing-key-file "$STATE_CLUSTER/governance_data/cc_member${i}_committee_cold.skey"
+      --cold-verification-key-file "${STATE_CLUSTER}/governance_data/cc_member${i}_committee_cold.vkey" \
+      --cold-signing-key-file "${STATE_CLUSTER}/governance_data/cc_member${i}_committee_cold.skey"
     cardano_cli_log conway governance committee key-gen-hot \
-      --verification-key-file "$STATE_CLUSTER/governance_data/cc_member${i}_committee_hot.vkey" \
-      --signing-key-file "$STATE_CLUSTER/governance_data/cc_member${i}_committee_hot.skey"
+      --verification-key-file "${STATE_CLUSTER}/governance_data/cc_member${i}_committee_hot.vkey" \
+      --signing-key-file "${STATE_CLUSTER}/governance_data/cc_member${i}_committee_hot.skey"
     cardano_cli_log conway governance committee create-hot-key-authorization-certificate \
-      --cold-verification-key-file "$STATE_CLUSTER/governance_data/cc_member${i}_committee_cold.vkey" \
-      --hot-verification-key-file "$STATE_CLUSTER/governance_data/cc_member${i}_committee_hot.vkey" \
-      --out-file "$STATE_CLUSTER/governance_data/cc_member${i}_committee_hot_auth.cert"
+      --cold-verification-key-file "${STATE_CLUSTER}/governance_data/cc_member${i}_committee_cold.vkey" \
+      --hot-verification-key-file "${STATE_CLUSTER}/governance_data/cc_member${i}_committee_hot.vkey" \
+      --out-file "${STATE_CLUSTER}/governance_data/cc_member${i}_committee_hot_auth.cert"
     cardano_cli_log conway governance committee key-hash \
-      --verification-key-file "$STATE_CLUSTER/governance_data/cc_member${i}_committee_cold.vkey" \
-      > "$STATE_CLUSTER/governance_data/cc_member${i}_committee_cold.hash"
+      --verification-key-file "${STATE_CLUSTER}/governance_data/cc_member${i}_committee_cold.vkey" \
+      > "${STATE_CLUSTER}/governance_data/cc_member${i}_committee_cold.hash"
   done
 
   # Pre-register committee in genesis
-  KEY_HASH_JSON=$(jq -nR '[inputs | {("keyHash-" + .): 10000}] | add' \
-    "$STATE_CLUSTER"/governance_data/cc_member*_committee_cold.hash)
+  KEY_HASH_JSON="$(jq -nR '[inputs | {("keyHash-" + .): 10000}] | add' \
+    "$STATE_CLUSTER"/governance_data/cc_member*_committee_cold.hash)"
   jq \
     --argjson keyHashJson "$KEY_HASH_JSON" \
     '.committee.members = $keyHashJson
     | .committee.threshold = 0.6
     | .committeeMinSize = 2' \
-    "$STATE_CLUSTER/create_staked/genesis.conway.json" > "$STATE_CLUSTER/create_staked/genesis.conway.json_jq"
-  cat "$STATE_CLUSTER/create_staked/genesis.conway.json_jq" > "$STATE_CLUSTER/create_staked/genesis.conway.json"
-  rm -f "$STATE_CLUSTER/create_staked/genesis.conway.json_jq"
+    "${STATE_CLUSTER}/create_staked/genesis.conway.json" > "${STATE_CLUSTER}/create_staked/genesis.conway.json_jq"
+  cat "${STATE_CLUSTER}/create_staked/genesis.conway.json_jq" > "${STATE_CLUSTER}/create_staked/genesis.conway.json"
+  rm -f "${STATE_CLUSTER}/create_staked/genesis.conway.json_jq"
 fi
 
-mv "$STATE_CLUSTER/create_staked/delegate-keys" "$STATE_CLUSTER/shelley/delegate-keys"
-mv "$STATE_CLUSTER/create_staked/genesis-keys" "$STATE_CLUSTER/shelley/genesis-keys"
+mv "${STATE_CLUSTER}/create_staked/delegate-keys" "${STATE_CLUSTER}/shelley/delegate-keys"
+mv "${STATE_CLUSTER}/create_staked/genesis-keys" "${STATE_CLUSTER}/shelley/genesis-keys"
 jq \
   --argjson max_supply "$MAX_SUPPLY" \
   --argjson prot_ver "$PROTOCOL_VERSION" \
   '.protocolParams.protocolVersion.major = $prot_ver
   | .maxLovelaceSupply = $max_supply' \
-  "$STATE_CLUSTER/create_staked/genesis.json" > "$STATE_CLUSTER/shelley/genesis.json"
-rm -f "$STATE_CLUSTER/create_staked/genesis.json"
-mv "$STATE_CLUSTER"/create_staked/genesis*.json "$STATE_CLUSTER/shelley/"
+  "${STATE_CLUSTER}/create_staked/genesis.json" > "${STATE_CLUSTER}/shelley/genesis.json"
+rm -f "${STATE_CLUSTER}/create_staked/genesis.json"
+mv "$STATE_CLUSTER"/create_staked/genesis*.json "${STATE_CLUSTER}/shelley/"
 
-mv "$STATE_CLUSTER/create_staked/utxo-keys/utxo1.skey" "$STATE_CLUSTER/shelley/genesis-utxo.skey"
-mv "$STATE_CLUSTER/create_staked/utxo-keys/utxo1.vkey" "$STATE_CLUSTER/shelley/genesis-utxo.vkey"
+mv "${STATE_CLUSTER}/create_staked/utxo-keys/utxo1.skey" "${STATE_CLUSTER}/shelley/genesis-utxo.skey"
+mv "${STATE_CLUSTER}/create_staked/utxo-keys/utxo1.vkey" "${STATE_CLUSTER}/shelley/genesis-utxo.vkey"
 cardano_cli_log conway address build --payment-verification-key-file \
-  "$STATE_CLUSTER/shelley/genesis-utxo.vkey" \
-  --out-file "$STATE_CLUSTER/shelley/genesis-utxo.addr" \
+  "${STATE_CLUSTER}/shelley/genesis-utxo.vkey" \
+  --out-file "${STATE_CLUSTER}/shelley/genesis-utxo.addr" \
   --testnet-magic "$NETWORK_MAGIC"
 
-mv "$STATE_CLUSTER/create_staked/stake-delegator-keys" "$STATE_CLUSTER/shelley/stake-delegator-keys"
+mv "${STATE_CLUSTER}/create_staked/stake-delegator-keys" "${STATE_CLUSTER}/shelley/stake-delegator-keys"
 
 KEY_DEPOSIT="$(jq '.protocolParams.keyDeposit' \
-  < "$STATE_CLUSTER/shelley/genesis.json")"
+  < "${STATE_CLUSTER}/shelley/genesis.json")"
 DREP_DEPOSIT="$(jq '.dRepDeposit' \
-  < "$STATE_CLUSTER/shelley/genesis.conway.json")"
+  < "${STATE_CLUSTER}/shelley/genesis.conway.json")"
 
 BYRON_GENESIS_HASH="$(cardano_cli_log byron genesis print-genesis-hash --genesis-json \
-  "$STATE_CLUSTER/byron/genesis.json")"
+  "${STATE_CLUSTER}/byron/genesis.json")"
 SHELLEY_GENESIS_HASH="$(cardano_cli_log legacy genesis hash --genesis \
-  "$STATE_CLUSTER/shelley/genesis.json")"
+  "${STATE_CLUSTER}/shelley/genesis.json")"
 ALONZO_GENESIS_HASH="$(cardano_cli_log legacy genesis hash --genesis \
-  "$STATE_CLUSTER/shelley/genesis.alonzo.json")"
+  "${STATE_CLUSTER}/shelley/genesis.alonzo.json")"
 CONWAY_GENESIS_HASH="$(cardano_cli_log legacy genesis hash --genesis \
-  "$STATE_CLUSTER/shelley/genesis.conway.json")"
+  "${STATE_CLUSTER}/shelley/genesis.conway.json")"
 
 for conf in "$SCRIPT_DIR"/config-*.json; do
   fname="${conf##*/}"
@@ -301,7 +301,7 @@ for conf in "$SCRIPT_DIR"/config-*.json; do
     | .AlonzoGenesisHash = $alonzo_hash
     | .ConwayGenesisHash = $conway_hash
     | ."LastKnownBlockVersion-Major" = $prot_ver' \
-    "$conf" > "$STATE_CLUSTER/$fname"
+    "$conf" > "${STATE_CLUSTER}/${fname}"
 
   # enable P2P
   if [ -z "${ENABLE_LEGACY:-""}" ]; then
@@ -318,7 +318,7 @@ for conf in "$SCRIPT_DIR"/config-*.json; do
       pool_num="${fname##*-pool}"
       pool_num="${pool_num%.json}"
       if [ "$((pool_num % 2))" != 0 ]; then
-        cp -f "$SCRIPT_DIR/topology-pool${pool_num}.json" "$STATE_CLUSTER"
+        cp -f "${SCRIPT_DIR}/topology-pool${pool_num}.json" "$STATE_CLUSTER"
         continue
       fi
     fi
@@ -333,107 +333,107 @@ for conf in "$SCRIPT_DIR"/config-*.json; do
       | .TargetNumberOfActivePeers = 20
       | .TraceBlockFetchClient = true
       | .TraceChainSyncClient = true' \
-      "$STATE_CLUSTER/$fname" > "$STATE_CLUSTER/${fname}_jq"
-    cat "$STATE_CLUSTER/${fname}_jq" > "$STATE_CLUSTER/$fname"
-    rm -f "$STATE_CLUSTER/${fname}_jq"
+      "${STATE_CLUSTER}/${fname}" > "${STATE_CLUSTER}/${fname}_jq"
+    cat "${STATE_CLUSTER}/${fname}_jq" > "${STATE_CLUSTER}/${fname}"
+    rm -f "${STATE_CLUSTER}/${fname}_jq"
   fi
 done
 
-for i in $(seq 1 $NUM_BFT_NODES); do
-  mkdir -p "$STATE_CLUSTER/nodes/node-bft$i"
-  BFT_PORT=$(("%%NODE_PORT_BASE%%" + (i - 1) * "%%PORTS_PER_NODE%%" ))
-  echo "$BFT_PORT" > "$STATE_CLUSTER/nodes/node-bft$i/port"
+for i in $(seq 1 "$NUM_BFT_NODES"); do
+  mkdir -p "${STATE_CLUSTER}/nodes/node-bft$i"
+  BFT_PORT="$(("%%NODE_PORT_BASE%%" + (i - 1) * "%%PORTS_PER_NODE%%" ))"
+  echo "$BFT_PORT" > "${STATE_CLUSTER}/nodes/node-bft${i}/port"
 done
 
 for i in $(seq 1 "$NUM_POOLS"); do
-  mkdir -p "$STATE_CLUSTER/nodes/node-pool$i"
-  mv "$STATE_CLUSTER/create_staked/pools/cold$i.skey" "$STATE_CLUSTER/nodes/node-pool$i/cold.skey"
-  mv "$STATE_CLUSTER/create_staked/pools/cold$i.vkey" "$STATE_CLUSTER/nodes/node-pool$i/cold.vkey"
+  mkdir -p "${STATE_CLUSTER}/nodes/node-pool$i"
+  mv "${STATE_CLUSTER}/create_staked/pools/cold${i}.skey" "${STATE_CLUSTER}/nodes/node-pool${i}/cold.skey"
+  mv "${STATE_CLUSTER}/create_staked/pools/cold${i}.vkey" "${STATE_CLUSTER}/nodes/node-pool${i}/cold.vkey"
 
-  mv "$STATE_CLUSTER/create_staked/pools/kes$i.skey" "$STATE_CLUSTER/nodes/node-pool$i/kes.skey"
-  mv "$STATE_CLUSTER/create_staked/pools/kes$i.vkey" "$STATE_CLUSTER/nodes/node-pool$i/kes.vkey"
+  mv "${STATE_CLUSTER}/create_staked/pools/kes${i}.skey" "${STATE_CLUSTER}/nodes/node-pool${i}/kes.skey"
+  mv "${STATE_CLUSTER}/create_staked/pools/kes${i}.vkey" "${STATE_CLUSTER}/nodes/node-pool${i}/kes.vkey"
 
-  mv "$STATE_CLUSTER/create_staked/pools/opcert$i.cert" "$STATE_CLUSTER/nodes/node-pool$i/op.cert"
-  mv "$STATE_CLUSTER/create_staked/pools/opcert$i.counter" "$STATE_CLUSTER/nodes/node-pool$i/cold.counter"
+  mv "${STATE_CLUSTER}/create_staked/pools/opcert${i}.cert" "${STATE_CLUSTER}/nodes/node-pool${i}/op.cert"
+  mv "${STATE_CLUSTER}/create_staked/pools/opcert${i}.counter" "${STATE_CLUSTER}/nodes/node-pool${i}/cold.counter"
 
   # stake reward keys
-  mv "$STATE_CLUSTER/create_staked/pools/staking-reward$i.skey" "$STATE_CLUSTER/nodes/node-pool$i/reward.skey"
-  mv "$STATE_CLUSTER/create_staked/pools/staking-reward$i.vkey" "$STATE_CLUSTER/nodes/node-pool$i/reward.vkey"
+  mv "${STATE_CLUSTER}/create_staked/pools/staking-reward${i}.skey" "${STATE_CLUSTER}/nodes/node-pool${i}/reward.skey"
+  mv "${STATE_CLUSTER}/create_staked/pools/staking-reward${i}.vkey" "${STATE_CLUSTER}/nodes/node-pool${i}/reward.vkey"
 
-  mv "$STATE_CLUSTER/create_staked/pools/vrf$i.skey" "$STATE_CLUSTER/nodes/node-pool$i/vrf.skey"
-  mv "$STATE_CLUSTER/create_staked/pools/vrf$i.vkey" "$STATE_CLUSTER/nodes/node-pool$i/vrf.vkey"
+  mv "${STATE_CLUSTER}/create_staked/pools/vrf${i}.skey" "${STATE_CLUSTER}/nodes/node-pool${i}/vrf.skey"
+  mv "${STATE_CLUSTER}/create_staked/pools/vrf${i}.vkey" "${STATE_CLUSTER}/nodes/node-pool${i}/vrf.vkey"
 
   echo "Generating Pool $i Secrets"
 
   # pool owner addresses and keys
   cardano_cli_log conway address key-gen \
-    --signing-key-file "$STATE_CLUSTER/nodes/node-pool$i/owner-utxo.skey" \
-    --verification-key-file "$STATE_CLUSTER/nodes/node-pool$i/owner-utxo.vkey"
+    --signing-key-file "${STATE_CLUSTER}/nodes/node-pool${i}/owner-utxo.skey" \
+    --verification-key-file "${STATE_CLUSTER}/nodes/node-pool${i}/owner-utxo.vkey"
   cardano_cli_log conway stake-address key-gen \
-    --signing-key-file "$STATE_CLUSTER/nodes/node-pool$i/owner-stake.skey" \
-    --verification-key-file "$STATE_CLUSTER/nodes/node-pool$i/owner-stake.vkey"
+    --signing-key-file "${STATE_CLUSTER}/nodes/node-pool${i}/owner-stake.skey" \
+    --verification-key-file "${STATE_CLUSTER}/nodes/node-pool${i}/owner-stake.vkey"
 
   #   payment address
   cardano_cli_log conway address build \
-    --payment-verification-key-file "$STATE_CLUSTER/nodes/node-pool$i/owner-utxo.vkey" \
-    --stake-verification-key-file "$STATE_CLUSTER/nodes/node-pool$i/owner-stake.vkey" \
+    --payment-verification-key-file "${STATE_CLUSTER}/nodes/node-pool${i}/owner-utxo.vkey" \
+    --stake-verification-key-file "${STATE_CLUSTER}/nodes/node-pool${i}/owner-stake.vkey" \
     --testnet-magic "$NETWORK_MAGIC" \
-    --out-file "$STATE_CLUSTER/nodes/node-pool$i/owner.addr"
+    --out-file "${STATE_CLUSTER}/nodes/node-pool${i}/owner.addr"
 
   #   stake address
   cardano_cli_log conway stake-address build \
-    --stake-verification-key-file "$STATE_CLUSTER/nodes/node-pool$i/owner-stake.vkey" \
+    --stake-verification-key-file "${STATE_CLUSTER}/nodes/node-pool${i}/owner-stake.vkey" \
     --testnet-magic "$NETWORK_MAGIC" \
-    --out-file "$STATE_CLUSTER/nodes/node-pool$i/owner-stake.addr"
+    --out-file "${STATE_CLUSTER}/nodes/node-pool${i}/owner-stake.addr"
 
   #   stake address registration cert
   cardano_cli_log conway stake-address registration-certificate \
-    --stake-verification-key-file "$STATE_CLUSTER/nodes/node-pool$i/owner-stake.vkey" \
+    --stake-verification-key-file "${STATE_CLUSTER}/nodes/node-pool${i}/owner-stake.vkey" \
     --key-reg-deposit-amt "$KEY_DEPOSIT" \
-    --out-file "$STATE_CLUSTER/nodes/node-pool$i/stake.reg.cert"
+    --out-file "${STATE_CLUSTER}/nodes/node-pool${i}/stake.reg.cert"
 
   if [ -n "${PV10:-""}" ]; then
     # stake reward address registration and vote delegation cert
     cardano_cli_log conway stake-address registration-and-vote-delegation-certificate \
-      --stake-verification-key-file "$STATE_CLUSTER/nodes/node-pool$i/reward.vkey" \
+      --stake-verification-key-file "${STATE_CLUSTER}/nodes/node-pool${i}/reward.vkey" \
       --always-abstain \
       --key-reg-deposit-amt "$KEY_DEPOSIT" \
-      --out-file "$STATE_CLUSTER/nodes/node-pool$i/stake-reward.reg.cert"
+      --out-file "${STATE_CLUSTER}/nodes/node-pool${i}/stake-reward.reg.cert"
 
     # owner stake address stake and vote delegation cert
     cardano_cli_log conway stake-address stake-and-vote-delegation-certificate \
-      --stake-verification-key-file "$STATE_CLUSTER/nodes/node-pool$i/owner-stake.vkey" \
-      --cold-verification-key-file  "$STATE_CLUSTER/nodes/node-pool$i/cold.vkey" \
+      --stake-verification-key-file "${STATE_CLUSTER}/nodes/node-pool${i}/owner-stake.vkey" \
+      --cold-verification-key-file  "${STATE_CLUSTER}/nodes/node-pool${i}/cold.vkey" \
       --always-abstain \
-      --out-file "$STATE_CLUSTER/nodes/node-pool$i/owner-stake.deleg.cert"
+      --out-file "${STATE_CLUSTER}/nodes/node-pool${i}/owner-stake.deleg.cert"
   else
     # stake reward address registration cert
     cardano_cli_log conway stake-address registration-certificate \
-      --stake-verification-key-file "$STATE_CLUSTER/nodes/node-pool$i/reward.vkey" \
+      --stake-verification-key-file "${STATE_CLUSTER}/nodes/node-pool${i}/reward.vkey" \
       --key-reg-deposit-amt "$KEY_DEPOSIT" \
-      --out-file "$STATE_CLUSTER/nodes/node-pool$i/stake-reward.reg.cert"
+      --out-file "${STATE_CLUSTER}/nodes/node-pool${i}/stake-reward.reg.cert"
 
     # owner stake address stake delegation cert
     cardano_cli_log conway stake-address stake-delegation-certificate \
-      --stake-verification-key-file "$STATE_CLUSTER/nodes/node-pool$i/owner-stake.vkey" \
-      --cold-verification-key-file  "$STATE_CLUSTER/nodes/node-pool$i/cold.vkey" \
-      --out-file "$STATE_CLUSTER/nodes/node-pool$i/owner-stake.deleg.cert"
+      --stake-verification-key-file "${STATE_CLUSTER}/nodes/node-pool${i}/owner-stake.vkey" \
+      --cold-verification-key-file  "${STATE_CLUSTER}/nodes/node-pool${i}/cold.vkey" \
+      --out-file "${STATE_CLUSTER}/nodes/node-pool${i}/owner-stake.deleg.cert"
   fi
 
-  POOL_NAME="TestPool$i"
+  POOL_NAME="TestPool${i}"
   POOL_DESC="Test Pool $i"
-  POOL_TICKER="TP$i"
+  POOL_TICKER="TP${i}"
 
-  cat > "$STATE_CLUSTER/webserver/pool$i.html" <<EoF
+  cat > "${STATE_CLUSTER}/webserver/pool${i}.html" <<EoF
 <!DOCTYPE html>
 <html>
 <head>
-<title>$POOL_NAME</title>
+<title>${POOL_NAME}</title>
 </head>
 <body>
-name: <strong>$POOL_NAME</strong><br>
-description: <strong>$POOL_DESC</strong><br>
-ticker: <strong>$POOL_TICKER</strong><br>
+name: <strong>${POOL_NAME}</strong><br>
+description: <strong>${POOL_DESC}</strong><br>
+ticker: <strong>${POOL_TICKER}</strong><br>
 </body>
 </html>
 EoF
@@ -443,107 +443,107 @@ EoF
     --arg name "$POOL_NAME" \
     --arg description "$POOL_DESC" \
     --arg ticker "$POOL_TICKER" \
-    --arg homepage "http://localhost:%%WEBSERVER_PORT%%/pool$i.html" \
+    --arg homepage "http://localhost:%%WEBSERVER_PORT%%/pool${i}.html" \
     '{"name": $name, "description": $description, "ticker": $ticker, "homepage": $homepage}' \
-    > "$STATE_CLUSTER/webserver/pool$i.json"
+    > "${STATE_CLUSTER}/webserver/pool${i}.json"
 
-  METADATA_URL="http://localhost:%%WEBSERVER_PORT%%/pool$i.json"
-  METADATA_HASH=$(cardano_cli_log conway stake-pool metadata-hash --pool-metadata-file \
-    "$STATE_CLUSTER/webserver/pool$i.json")
-  POOL_PORT=$(("%%NODE_PORT_BASE%%" + ("$NUM_BFT_NODES" + i - 1) * "%%PORTS_PER_NODE%%"))
-  echo "$POOL_PORT" > "$STATE_CLUSTER/nodes/node-pool$i/port"
-  echo $POOL_PLEDGE > "$STATE_CLUSTER/nodes/node-pool$i/pledge"
+  METADATA_URL="http://localhost:%%WEBSERVER_PORT%%/pool${i}.json"
+  METADATA_HASH="$(cardano_cli_log conway stake-pool metadata-hash --pool-metadata-file \
+    "${STATE_CLUSTER}/webserver/pool${i}.json")"
+  POOL_PORT="$(("%%NODE_PORT_BASE%%" + (NUM_BFT_NODES + i - 1) * "%%PORTS_PER_NODE%%"))"
+  echo "$POOL_PORT" > "${STATE_CLUSTER}/nodes/node-pool${i}/port"
+  echo "$POOL_PLEDGE" > "${STATE_CLUSTER}/nodes/node-pool${i}/pledge"
 
   cardano_cli_log conway stake-pool registration-certificate \
-    --cold-verification-key-file "$STATE_CLUSTER/nodes/node-pool$i/cold.vkey" \
-    --vrf-verification-key-file "$STATE_CLUSTER/nodes/node-pool$i/vrf.vkey" \
+    --cold-verification-key-file "${STATE_CLUSTER}/nodes/node-pool${i}/cold.vkey" \
+    --vrf-verification-key-file "${STATE_CLUSTER}/nodes/node-pool${i}/vrf.vkey" \
     --pool-pledge "$POOL_PLEDGE" \
     --pool-margin 0.35 \
     --pool-cost "$POOL_COST" \
-    --pool-reward-account-verification-key-file "$STATE_CLUSTER/nodes/node-pool$i/reward.vkey" \
-    --pool-owner-stake-verification-key-file "$STATE_CLUSTER/nodes/node-pool$i/owner-stake.vkey" \
+    --pool-reward-account-verification-key-file "${STATE_CLUSTER}/nodes/node-pool${i}/reward.vkey" \
+    --pool-owner-stake-verification-key-file "${STATE_CLUSTER}/nodes/node-pool${i}/owner-stake.vkey" \
     --metadata-url "$METADATA_URL" \
     --metadata-hash "$METADATA_HASH" \
     --pool-relay-port "$POOL_PORT" \
     --pool-relay-ipv4 "127.0.0.1" \
     --testnet-magic "$NETWORK_MAGIC" \
-    --out-file "$STATE_CLUSTER/nodes/node-pool$i/register.cert"
+    --out-file "${STATE_CLUSTER}/nodes/node-pool${i}/register.cert"
 done
 
-rm -rf "$STATE_CLUSTER/shelley/create_staked"
+rm -rf "${STATE_CLUSTER}/shelley/create_staked"
 
 for i in $(seq 1 "$NUM_DREPS"); do
   # DRep keys
   cardano_cli_log conway governance drep key-gen \
-    --signing-key-file "$STATE_CLUSTER/governance_data/default_drep_${i}_drep.skey" \
-    --verification-key-file "$STATE_CLUSTER/governance_data/default_drep_${i}_drep.vkey"
+    --signing-key-file "${STATE_CLUSTER}/governance_data/default_drep_${i}_drep.skey" \
+    --verification-key-file "${STATE_CLUSTER}/governance_data/default_drep_${i}_drep.vkey"
 
   # DRep registration
   cardano_cli_log conway governance drep registration-certificate \
-    --drep-verification-key-file "$STATE_CLUSTER/governance_data/default_drep_${i}_drep.vkey" \
+    --drep-verification-key-file "${STATE_CLUSTER}/governance_data/default_drep_${i}_drep.vkey" \
     --key-reg-deposit-amt "$DREP_DEPOSIT" \
-    --out-file "$STATE_CLUSTER/governance_data/default_drep_${i}_drep_reg.cert"
+    --out-file "${STATE_CLUSTER}/governance_data/default_drep_${i}_drep_reg.cert"
 
   # delegatee payment keys
   cardano_cli_log conway address key-gen \
-    --signing-key-file "$STATE_CLUSTER/governance_data/vote_stake_addr${i}.skey" \
-    --verification-key-file "$STATE_CLUSTER/governance_data/vote_stake_addr${i}.vkey"
+    --signing-key-file "${STATE_CLUSTER}/governance_data/vote_stake_addr${i}.skey" \
+    --verification-key-file "${STATE_CLUSTER}/governance_data/vote_stake_addr${i}.vkey"
 
   # delegatee stake keys
   cardano_cli_log conway stake-address key-gen \
-    --signing-key-file "$STATE_CLUSTER/governance_data/vote_stake_addr${i}_stake.skey" \
-    --verification-key-file "$STATE_CLUSTER/governance_data/vote_stake_addr${i}_stake.vkey"
+    --signing-key-file "${STATE_CLUSTER}/governance_data/vote_stake_addr${i}_stake.skey" \
+    --verification-key-file "${STATE_CLUSTER}/governance_data/vote_stake_addr${i}_stake.vkey"
 
   # delegatee payment address
   cardano_cli_log conway address build \
-    --payment-verification-key-file "$STATE_CLUSTER/governance_data/vote_stake_addr${i}.vkey" \
-    --stake-verification-key-file "$STATE_CLUSTER/governance_data/vote_stake_addr${i}_stake.vkey" \
+    --payment-verification-key-file "${STATE_CLUSTER}/governance_data/vote_stake_addr${i}.vkey" \
+    --stake-verification-key-file "${STATE_CLUSTER}/governance_data/vote_stake_addr${i}_stake.vkey" \
     --testnet-magic "$NETWORK_MAGIC" \
-    --out-file "$STATE_CLUSTER/governance_data/vote_stake_addr${i}.addr"
+    --out-file "${STATE_CLUSTER}/governance_data/vote_stake_addr${i}.addr"
 
   # delegatee stake address
   cardano_cli_log conway stake-address build \
-    --stake-verification-key-file "$STATE_CLUSTER/governance_data/vote_stake_addr${i}_stake.vkey" \
+    --stake-verification-key-file "${STATE_CLUSTER}/governance_data/vote_stake_addr${i}_stake.vkey" \
     --testnet-magic "$NETWORK_MAGIC" \
-    --out-file "$STATE_CLUSTER/governance_data/vote_stake_addr${i}_stake.addr"
+    --out-file "${STATE_CLUSTER}/governance_data/vote_stake_addr${i}_stake.addr"
 
   # delegatee stake address registration cert
   cardano_cli_log conway stake-address registration-certificate \
-    --stake-verification-key-file "$STATE_CLUSTER/governance_data/vote_stake_addr${i}_stake.vkey" \
+    --stake-verification-key-file "${STATE_CLUSTER}/governance_data/vote_stake_addr${i}_stake.vkey" \
     --key-reg-deposit-amt "$KEY_DEPOSIT" \
-    --out-file "$STATE_CLUSTER/governance_data/vote_stake_addr${i}_stake.reg.cert"
+    --out-file "${STATE_CLUSTER}/governance_data/vote_stake_addr${i}_stake.reg.cert"
 
   # delegatee vote delegation cert
   cardano_cli_log conway stake-address vote-delegation-certificate \
-    --stake-verification-key-file "$STATE_CLUSTER/governance_data/vote_stake_addr${i}_stake.vkey" \
-    --drep-verification-key-file "$STATE_CLUSTER/governance_data/default_drep_${i}_drep.vkey" \
-    --out-file "$STATE_CLUSTER/governance_data/vote_stake_addr${i}_stake.vote_deleg.cert"
+    --stake-verification-key-file "${STATE_CLUSTER}/governance_data/vote_stake_addr${i}_stake.vkey" \
+    --drep-verification-key-file "${STATE_CLUSTER}/governance_data/default_drep_${i}_drep.vkey" \
+    --out-file "${STATE_CLUSTER}/governance_data/vote_stake_addr${i}_stake.vote_deleg.cert"
 done
 
 # create scripts for cluster starting / stopping
-printf "#!/bin/sh\n\nsupervisorctl -s http://127.0.0.1:%%SUPERVISOR_PORT%% start all" > "$STATE_CLUSTER/supervisorctl_start"
-printf "#!/bin/sh\n\nsupervisorctl -s http://127.0.0.1:%%SUPERVISOR_PORT%% restart nodes:" > "$STATE_CLUSTER/supervisorctl_restart_nodes"
-printf "#!/bin/sh\n\nsupervisorctl -s http://127.0.0.1:%%SUPERVISOR_PORT%% \"\$@\"" > "$STATE_CLUSTER/supervisorctl"
+printf "#!/bin/sh\n\nsupervisorctl -s http://127.0.0.1:%%SUPERVISOR_PORT%% start all" > "${STATE_CLUSTER}/supervisorctl_start"
+printf "#!/bin/sh\n\nsupervisorctl -s http://127.0.0.1:%%SUPERVISOR_PORT%% restart nodes:" > "${STATE_CLUSTER}/supervisorctl_restart_nodes"
+printf "#!/bin/sh\n\nsupervisorctl -s http://127.0.0.1:%%SUPERVISOR_PORT%% \"\$@\"" > "${STATE_CLUSTER}/supervisorctl"
 
-cat > "$STATE_CLUSTER/supervisord_start" <<EoF
+cat > "${STATE_CLUSTER}/supervisord_start" <<EoF
 #!/usr/bin/env bash
 
 set -uo pipefail
 
 SCRIPT_DIR="\$(readlink -m "\${0%/*}")"
 
-cd "\$SCRIPT_DIR/.."
+cd "\${SCRIPT_DIR}/.."
 
-supervisord --config "\$SCRIPT_DIR/supervisor.conf"
+supervisord --config "\${SCRIPT_DIR}/supervisor.conf"
 EoF
 
-cat > "$STATE_CLUSTER/supervisord_stop" <<EoF
+cat > "${STATE_CLUSTER}/supervisord_stop" <<EoF
 #!/usr/bin/env bash
 
 set -uo pipefail
 
 SCRIPT_DIR="\$(readlink -m "\${0%/*}")"
-PID_FILE="\$SCRIPT_DIR/supervisord.pid"
+PID_FILE="\${SCRIPT_DIR}/supervisord.pid"
 
 supervisorctl -s http://127.0.0.1:%%SUPERVISOR_PORT%% stop all
 
@@ -574,7 +574,7 @@ if [ -n "${DRY_RUN:-""}" ]; then
   exit 0
 fi
 
-supervisord --config "$STATE_CLUSTER/supervisor.conf"
+supervisord --config "${STATE_CLUSTER}/supervisor.conf"
 
 for _ in {1..5}; do
   if [ -S "$CARDANO_NODE_SOCKET_PATH" ]; then
@@ -630,16 +630,16 @@ POOL_ARGS=()
 POOL_SIGNING=()
 for i in $(seq 1 "$NUM_POOLS"); do
   POOL_ARGS+=( \
-    "--tx-out" "$(<"$STATE_CLUSTER/nodes/node-pool$i/owner.addr")+$POOL_PLEDGE" \
-    "--certificate-file" "$STATE_CLUSTER/nodes/node-pool$i/stake.reg.cert" \
-    "--certificate-file" "$STATE_CLUSTER/nodes/node-pool$i/stake-reward.reg.cert" \
-    "--certificate-file" "$STATE_CLUSTER/nodes/node-pool$i/register.cert" \
-    "--certificate-file" "$STATE_CLUSTER/nodes/node-pool$i/owner-stake.deleg.cert" \
+    "--tx-out" "$(<"${STATE_CLUSTER}/nodes/node-pool${i}/owner.addr")+${POOL_PLEDGE}" \
+    "--certificate-file" "${STATE_CLUSTER}/nodes/node-pool${i}/stake.reg.cert" \
+    "--certificate-file" "${STATE_CLUSTER}/nodes/node-pool${i}/stake-reward.reg.cert" \
+    "--certificate-file" "${STATE_CLUSTER}/nodes/node-pool${i}/register.cert" \
+    "--certificate-file" "${STATE_CLUSTER}/nodes/node-pool${i}/owner-stake.deleg.cert" \
   )
   POOL_SIGNING+=( \
-    "--signing-key-file" "$STATE_CLUSTER/nodes/node-pool$i/owner-stake.skey" \
-    "--signing-key-file" "$STATE_CLUSTER/nodes/node-pool$i/reward.skey" \
-    "--signing-key-file" "$STATE_CLUSTER/nodes/node-pool$i/cold.skey" \
+    "--signing-key-file" "${STATE_CLUSTER}/nodes/node-pool${i}/owner-stake.skey" \
+    "--signing-key-file" "${STATE_CLUSTER}/nodes/node-pool${i}/reward.skey" \
+    "--signing-key-file" "${STATE_CLUSTER}/nodes/node-pool${i}/cold.skey" \
   )
 done
 
@@ -659,15 +659,15 @@ DREPS_ARGS=()
 DREPS_SIGNING=()
 for i in $(seq 1 "$NUM_DREPS"); do
   DREPS_ARGS+=( \
-    "--tx-out" "$(<"$STATE_CLUSTER/governance_data/vote_stake_addr${i}.addr")+$DREP_DELEGATED" \
-    "--certificate-file" "$STATE_CLUSTER/governance_data/default_drep_${i}_drep_reg.cert" \
-    "--certificate-file" "$STATE_CLUSTER/governance_data/vote_stake_addr${i}_stake.reg.cert" \
-    "--certificate-file" "$STATE_CLUSTER/governance_data/vote_stake_addr${i}_stake.vote_deleg.cert" \
+    "--tx-out" "$(<"${STATE_CLUSTER}/governance_data/vote_stake_addr${i}.addr")+${DREP_DELEGATED}" \
+    "--certificate-file" "${STATE_CLUSTER}/governance_data/default_drep_${i}_drep_reg.cert" \
+    "--certificate-file" "${STATE_CLUSTER}/governance_data/vote_stake_addr${i}_stake.reg.cert" \
+    "--certificate-file" "${STATE_CLUSTER}/governance_data/vote_stake_addr${i}_stake.vote_deleg.cert" \
   )
   DREPS_SIGNING+=( \
-    "--signing-key-file" "$STATE_CLUSTER/governance_data/default_drep_${i}_drep.skey" \
-    "--signing-key-file" "$STATE_CLUSTER/governance_data/vote_stake_addr${i}.skey" \
-    "--signing-key-file" "$STATE_CLUSTER/governance_data/vote_stake_addr${i}_stake.skey" \
+    "--signing-key-file" "${STATE_CLUSTER}/governance_data/default_drep_${i}_drep.skey" \
+    "--signing-key-file" "${STATE_CLUSTER}/governance_data/vote_stake_addr${i}.skey" \
+    "--signing-key-file" "${STATE_CLUSTER}/governance_data/vote_stake_addr${i}_stake.skey" \
   )
 done
 
@@ -681,7 +681,7 @@ cardano_cli_log conway transaction build \
   "${DREPS_ARGS[@]}" \
   --witness-override "$WITNESS_COUNT" \
   --testnet-magic    "$NETWORK_MAGIC" \
-  --out-file         "$STATE_CLUSTER/shelley/transfer-register-delegate-tx.txbody"
+  --out-file         "${STATE_CLUSTER}/shelley/transfer-register-delegate-tx.txbody"
 
 cardano_cli_log conway transaction sign \
   "${POOL_SIGNING[@]}" \
@@ -689,13 +689,13 @@ cardano_cli_log conway transaction sign \
   "${DELEGATE_SIGNING[@]}" \
   "${CC_SIGNING[@]}" \
   "${DREPS_SIGNING[@]}" \
-  --signing-key-file "$STATE_CLUSTER/shelley/genesis-utxo.skey" \
+  --signing-key-file "${STATE_CLUSTER}/shelley/genesis-utxo.skey" \
   --testnet-magic    "$NETWORK_MAGIC" \
-  --tx-body-file     "$STATE_CLUSTER/shelley/transfer-register-delegate-tx.txbody" \
-  --out-file         "$STATE_CLUSTER/shelley/transfer-register-delegate-tx.tx"
+  --tx-body-file     "${STATE_CLUSTER}/shelley/transfer-register-delegate-tx.txbody" \
+  --out-file         "${STATE_CLUSTER}/shelley/transfer-register-delegate-tx.tx"
 
 cardano_cli_log conway transaction submit \
-  --tx-file "$STATE_CLUSTER/shelley/transfer-register-delegate-tx.tx" \
+  --tx-file "${STATE_CLUSTER}/shelley/transfer-register-delegate-tx.tx" \
   --testnet-magic "$NETWORK_MAGIC"
 
 # start cardano-submit-api
@@ -710,4 +710,4 @@ if ! check_spend_success "${TXINS[@]}"; then
   exit 1
 fi
 
-echo "Cluster started. Run \`$SCRIPT_DIR/stop-cluster\` to stop"
+echo "Cluster started. Run \`${SCRIPT_DIR}/stop-cluster\` to stop"

--- a/cardano_node_tests/cluster_scripts/mainnet_fast/start-cluster
+++ b/cardano_node_tests/cluster_scripts/mainnet_fast/start-cluster
@@ -37,10 +37,10 @@ if [ -n "${PV10:-""}" ]; then
   PROTOCOL_VERSION=10
 fi
 
-SECURITY_PARAM="$(jq '.securityParam' < "$SCRIPT_DIR/genesis.spec.json")"
-NETWORK_MAGIC="$(jq '.networkMagic' < "$SCRIPT_DIR/genesis.spec.json")"
-MAX_SUPPLY="$(jq '.maxLovelaceSupply' < "$SCRIPT_DIR/genesis.spec.json")"
-POOL_COST="$(jq '.protocolParams.minPoolCost' < "$SCRIPT_DIR/genesis.spec.json")"
+SECURITY_PARAM="$(jq '.securityParam' < "${SCRIPT_DIR}/genesis.spec.json")"
+NETWORK_MAGIC="$(jq '.networkMagic' < "${SCRIPT_DIR}/genesis.spec.json")"
+MAX_SUPPLY="$(jq '.maxLovelaceSupply' < "${SCRIPT_DIR}/genesis.spec.json")"
+POOL_COST="$(jq '.protocolParams.minPoolCost' < "${SCRIPT_DIR}/genesis.spec.json")"
 if [ "$POOL_COST" -eq 0 ]; then
   POOL_COST=600
 fi
@@ -51,8 +51,8 @@ DELEG_MAGIC_VALUE=3340000000000000
 DELEG_SUPPLY="$((POOL_PLEDGE * NUM_POOLS + DELEG_MAGIC_VALUE))"
 NONDELEG_SUPPLY="$(( (MAX_SUPPLY - DELEG_SUPPLY) * 8 / 10))"
 
-if [ -f "$STATE_CLUSTER/supervisord.pid" ]; then
-  echo "Cluster already running. Please run \`$SCRIPT_DIR/stop-cluster\` first!" >&2
+if [ -f "${STATE_CLUSTER}/supervisord.pid" ]; then
+  echo "Cluster already running. Please run \`${SCRIPT_DIR}/stop-cluster\` first!" >&2
   exit 1
 fi
 
@@ -62,7 +62,7 @@ if [ "$NUM_POOLS" -lt 3 ]; then
 fi
 
 cardano_cli_log() {
-  echo cardano-cli "$@" >> "$STATE_CLUSTER/start_cluster_cmds.log"
+  echo cardano-cli "$@" >> "${STATE_CLUSTER}/start_cluster_cmds.log"
 
   for _ in {1..3}; do
     set +e
@@ -119,22 +119,22 @@ get_txins() {
 
 ENABLE_SUBMIT_API="$(command -v cardano-submit-api >/dev/null 2>&1 && echo 1 || echo 0)"
 
-if [ -e "$SCRIPT_DIR/shell_env" ]; then
+if [ -e "${SCRIPT_DIR}/shell_env" ]; then
   # shellcheck disable=SC1090,SC1091
-  source "$SCRIPT_DIR/shell_env"
+  source "${SCRIPT_DIR}/shell_env"
 fi
 
 rm -rf "$STATE_CLUSTER"
 mkdir -p "$STATE_CLUSTER"/{shelley,webserver,db-sync,create_staked}
-cd "$STATE_CLUSTER/.."
+cd "${STATE_CLUSTER}/.."
 
 cp "$SCRIPT_DIR"/cardano-node-* "$STATE_CLUSTER"
-cp "$SCRIPT_DIR/run-cardano-submit-api" "$STATE_CLUSTER"
-cp "$SCRIPT_DIR/byron-params.json" "$STATE_CLUSTER"
-cp "$SCRIPT_DIR/dbsync-config.yaml" "$STATE_CLUSTER"
-cp "$SCRIPT_DIR/submit-api-config.json" "$STATE_CLUSTER"
-cp "$SCRIPT_DIR/supervisor.conf" "$STATE_CLUSTER"
-cp "$SCRIPT_DIR"/*genesis*.spec.json "$STATE_CLUSTER/create_staked/"
+cp "${SCRIPT_DIR}/run-cardano-submit-api" "$STATE_CLUSTER"
+cp "${SCRIPT_DIR}/byron-params.json" "$STATE_CLUSTER"
+cp "${SCRIPT_DIR}/dbsync-config.yaml" "$STATE_CLUSTER"
+cp "${SCRIPT_DIR}/submit-api-config.json" "$STATE_CLUSTER"
+cp "${SCRIPT_DIR}/supervisor.conf" "$STATE_CLUSTER"
+cp "$SCRIPT_DIR"/*genesis*.spec.json "${STATE_CLUSTER}/create_staked/"
 
 if [ -z "${ENABLE_LEGACY:-""}" ]; then
   # use P2P topology files
@@ -148,7 +148,7 @@ fi
 
 case "${UTXO_BACKEND:=""}" in
   "" | mem | disk)
-    echo "$UTXO_BACKEND" > "$STATE_CLUSTER/utxo_backend"
+    echo "$UTXO_BACKEND" > "${STATE_CLUSTER}/utxo_backend"
     ;;
   *)
     echo "Unknown \`UTXO_BACKEND\`: '$UTXO_BACKEND', line $LINENO" >&2
@@ -158,20 +158,20 @@ esac
 
 # enable db-sync service
 if [ -n "${DBSYNC_REPO:-""}" ]; then
-  [ -e "$DBSYNC_REPO/db-sync-node/bin/cardano-db-sync" ] || \
-    { echo "The \`$DBSYNC_REPO/db-sync-node/bin/cardano-db-sync\` not found, line $LINENO" >&2; exit 1; }  # assert
+  [ -e "${DBSYNC_REPO}/db-sync-node/bin/cardano-db-sync" ] || \
+    { echo "The \`${DBSYNC_REPO}/db-sync-node/bin/cardano-db-sync\` not found, line $LINENO" >&2; exit 1; }  # assert
 
   # create clean database
   if [ -z "${DRY_RUN:-""}" ]; then
-    "$SCRIPT_DIR/postgres-setup.sh"
+    "${SCRIPT_DIR}/postgres-setup.sh"
   fi
 
-  cat >> "$STATE_CLUSTER/supervisor.conf" <<EoF
+  cat >> "${STATE_CLUSTER}/supervisor.conf" <<EoF
 
 [program:dbsync]
-command=$SCRIPT_DIR/run-cardano-dbsync
-stderr_logfile=./$STATE_CLUSTER_NAME/dbsync.stderr
-stdout_logfile=./$STATE_CLUSTER_NAME/dbsync.stdout
+command=${SCRIPT_DIR}/run-cardano-dbsync
+stderr_logfile=./${STATE_CLUSTER_NAME}/dbsync.stderr
+stdout_logfile=./${STATE_CLUSTER_NAME}/dbsync.stdout
 autostart=false
 autorestart=false
 startsecs=5
@@ -180,21 +180,21 @@ fi
 
 # enable cardano-submit-api service
 if [ "$ENABLE_SUBMIT_API" -eq 1 ]; then
-  cat >> "$STATE_CLUSTER/supervisor.conf" <<EoF
+  cat >> "${STATE_CLUSTER}/supervisor.conf" <<EoF
 
 [program:submit_api]
-command=$SCRIPT_DIR/run-cardano-submit-api
-stderr_logfile=./$STATE_CLUSTER_NAME/submit_api.stderr
-stdout_logfile=./$STATE_CLUSTER_NAME/submit_api.stdout
+command=${SCRIPT_DIR}/run-cardano-submit-api
+stderr_logfile=./${STATE_CLUSTER_NAME}/submit_api.stderr
+stdout_logfile=./${STATE_CLUSTER_NAME}/submit_api.stdout
 autostart=false
 autorestart=false
 startsecs=5
 EoF
 fi
 
-START_TIME_SHELLEY=$(date --utc +"%Y-%m-%dT%H:%M:%SZ" --date="5 seconds")
-START_TIME=$(date +%s --date="$START_TIME_SHELLEY")
-echo "$START_TIME" > "$STATE_CLUSTER/cluster_start_time"
+START_TIME_SHELLEY="$(date --utc +"%Y-%m-%dT%H:%M:%SZ" --date="5 seconds")"
+START_TIME="$(date +%s --date="$START_TIME_SHELLEY")"
+echo "$START_TIME" > "${STATE_CLUSTER}/cluster_start_time"
 
 cardano_cli_log byron genesis genesis \
   --protocol-magic "$NETWORK_MAGIC" \
@@ -205,14 +205,14 @@ cardano_cli_log byron genesis genesis \
   --delegate-share 1 \
   --avvm-entry-count 0 \
   --avvm-entry-balance 0 \
-  --protocol-parameters-file "$STATE_CLUSTER/byron-params.json" \
-  --genesis-output-dir "$STATE_CLUSTER/byron" \
+  --protocol-parameters-file "${STATE_CLUSTER}/byron-params.json" \
+  --genesis-output-dir "${STATE_CLUSTER}/byron" \
   --start-time "$START_TIME"
 
-mv "$STATE_CLUSTER/byron-params.json" "$STATE_CLUSTER/byron/params.json"
+mv "${STATE_CLUSTER}/byron-params.json" "${STATE_CLUSTER}/byron/params.json"
 
 cardano_cli_log legacy genesis create-staked \
-  --genesis-dir "$STATE_CLUSTER/create_staked" \
+  --genesis-dir "${STATE_CLUSTER}/create_staked" \
   --testnet-magic "$NETWORK_MAGIC" \
   --gen-pools "$NUM_POOLS" \
   --gen-utxo-keys 1 \
@@ -221,72 +221,72 @@ cardano_cli_log legacy genesis create-staked \
   --supply-delegated "$DELEG_SUPPLY" \
   --start-time "$START_TIME_SHELLEY"
 
-mkdir -p "$STATE_CLUSTER/governance_data"
+mkdir -p "${STATE_CLUSTER}/governance_data"
 
 # Create committee keys
 if [ -z "${NO_CC:-""}" ]; then
   for i in $(seq 1 "$NUM_CC"); do
     cardano_cli_log conway governance committee key-gen-cold \
-      --cold-verification-key-file "$STATE_CLUSTER/governance_data/cc_member${i}_committee_cold.vkey" \
-      --cold-signing-key-file "$STATE_CLUSTER/governance_data/cc_member${i}_committee_cold.skey"
+      --cold-verification-key-file "${STATE_CLUSTER}/governance_data/cc_member${i}_committee_cold.vkey" \
+      --cold-signing-key-file "${STATE_CLUSTER}/governance_data/cc_member${i}_committee_cold.skey"
     cardano_cli_log conway governance committee key-gen-hot \
-      --verification-key-file "$STATE_CLUSTER/governance_data/cc_member${i}_committee_hot.vkey" \
-      --signing-key-file "$STATE_CLUSTER/governance_data/cc_member${i}_committee_hot.skey"
+      --verification-key-file "${STATE_CLUSTER}/governance_data/cc_member${i}_committee_hot.vkey" \
+      --signing-key-file "${STATE_CLUSTER}/governance_data/cc_member${i}_committee_hot.skey"
     cardano_cli_log conway governance committee create-hot-key-authorization-certificate \
-      --cold-verification-key-file "$STATE_CLUSTER/governance_data/cc_member${i}_committee_cold.vkey" \
-      --hot-verification-key-file "$STATE_CLUSTER/governance_data/cc_member${i}_committee_hot.vkey" \
-      --out-file "$STATE_CLUSTER/governance_data/cc_member${i}_committee_hot_auth.cert"
+      --cold-verification-key-file "${STATE_CLUSTER}/governance_data/cc_member${i}_committee_cold.vkey" \
+      --hot-verification-key-file "${STATE_CLUSTER}/governance_data/cc_member${i}_committee_hot.vkey" \
+      --out-file "${STATE_CLUSTER}/governance_data/cc_member${i}_committee_hot_auth.cert"
     cardano_cli_log conway governance committee key-hash \
-      --verification-key-file "$STATE_CLUSTER/governance_data/cc_member${i}_committee_cold.vkey" \
-      > "$STATE_CLUSTER/governance_data/cc_member${i}_committee_cold.hash"
+      --verification-key-file "${STATE_CLUSTER}/governance_data/cc_member${i}_committee_cold.vkey" \
+      > "${STATE_CLUSTER}/governance_data/cc_member${i}_committee_cold.hash"
   done
 
   # Pre-register committee in genesis
-  KEY_HASH_JSON=$(jq -nR '[inputs | {("keyHash-" + .): 10000}] | add' \
-    "$STATE_CLUSTER"/governance_data/cc_member*_committee_cold.hash)
+  KEY_HASH_JSON="$(jq -nR '[inputs | {("keyHash-" + .): 10000}] | add' \
+    "$STATE_CLUSTER"/governance_data/cc_member*_committee_cold.hash)"
   jq \
     --argjson keyHashJson "$KEY_HASH_JSON" \
     '.committee.members = $keyHashJson
     | .committee.threshold = 0.6
     | .committeeMinSize = 2' \
-    "$STATE_CLUSTER/create_staked/genesis.conway.json" > "$STATE_CLUSTER/create_staked/genesis.conway.json_jq"
-  cat "$STATE_CLUSTER/create_staked/genesis.conway.json_jq" > "$STATE_CLUSTER/create_staked/genesis.conway.json"
-  rm -f "$STATE_CLUSTER/create_staked/genesis.conway.json_jq"
+    "${STATE_CLUSTER}/create_staked/genesis.conway.json" > "${STATE_CLUSTER}/create_staked/genesis.conway.json_jq"
+  cat "${STATE_CLUSTER}/create_staked/genesis.conway.json_jq" > "${STATE_CLUSTER}/create_staked/genesis.conway.json"
+  rm -f "${STATE_CLUSTER}/create_staked/genesis.conway.json_jq"
 fi
 
-mv "$STATE_CLUSTER/create_staked/delegate-keys" "$STATE_CLUSTER/shelley/delegate-keys"
-mv "$STATE_CLUSTER/create_staked/genesis-keys" "$STATE_CLUSTER/shelley/genesis-keys"
+mv "${STATE_CLUSTER}/create_staked/delegate-keys" "${STATE_CLUSTER}/shelley/delegate-keys"
+mv "${STATE_CLUSTER}/create_staked/genesis-keys" "${STATE_CLUSTER}/shelley/genesis-keys"
 jq \
   --argjson max_supply "$MAX_SUPPLY" \
   --argjson prot_ver "$PROTOCOL_VERSION" \
   '.protocolParams.protocolVersion.major = $prot_ver
   | .maxLovelaceSupply = $max_supply' \
-  "$STATE_CLUSTER/create_staked/genesis.json" > "$STATE_CLUSTER/shelley/genesis.json"
-rm -f "$STATE_CLUSTER/create_staked/genesis.json"
-mv "$STATE_CLUSTER"/create_staked/genesis*.json "$STATE_CLUSTER/shelley/"
+  "${STATE_CLUSTER}/create_staked/genesis.json" > "${STATE_CLUSTER}/shelley/genesis.json"
+rm -f "${STATE_CLUSTER}/create_staked/genesis.json"
+mv "$STATE_CLUSTER"/create_staked/genesis*.json "${STATE_CLUSTER}/shelley/"
 
-mv "$STATE_CLUSTER/create_staked/utxo-keys/utxo1.skey" "$STATE_CLUSTER/shelley/genesis-utxo.skey"
-mv "$STATE_CLUSTER/create_staked/utxo-keys/utxo1.vkey" "$STATE_CLUSTER/shelley/genesis-utxo.vkey"
+mv "${STATE_CLUSTER}/create_staked/utxo-keys/utxo1.skey" "${STATE_CLUSTER}/shelley/genesis-utxo.skey"
+mv "${STATE_CLUSTER}/create_staked/utxo-keys/utxo1.vkey" "${STATE_CLUSTER}/shelley/genesis-utxo.vkey"
 cardano_cli_log conway address build --payment-verification-key-file \
-  "$STATE_CLUSTER/shelley/genesis-utxo.vkey" \
-  --out-file "$STATE_CLUSTER/shelley/genesis-utxo.addr" \
+  "${STATE_CLUSTER}/shelley/genesis-utxo.vkey" \
+  --out-file "${STATE_CLUSTER}/shelley/genesis-utxo.addr" \
   --testnet-magic "$NETWORK_MAGIC"
 
-mv "$STATE_CLUSTER/create_staked/stake-delegator-keys" "$STATE_CLUSTER/shelley/stake-delegator-keys"
+mv "${STATE_CLUSTER}/create_staked/stake-delegator-keys" "${STATE_CLUSTER}/shelley/stake-delegator-keys"
 
 KEY_DEPOSIT="$(jq '.protocolParams.keyDeposit' \
-  < "$STATE_CLUSTER/shelley/genesis.json")"
+  < "${STATE_CLUSTER}/shelley/genesis.json")"
 DREP_DEPOSIT="$(jq '.dRepDeposit' \
-  < "$STATE_CLUSTER/shelley/genesis.conway.json")"
+  < "${STATE_CLUSTER}/shelley/genesis.conway.json")"
 
 BYRON_GENESIS_HASH="$(cardano_cli_log byron genesis print-genesis-hash --genesis-json \
-  "$STATE_CLUSTER/byron/genesis.json")"
+  "${STATE_CLUSTER}/byron/genesis.json")"
 SHELLEY_GENESIS_HASH="$(cardano_cli_log legacy genesis hash --genesis \
-  "$STATE_CLUSTER/shelley/genesis.json")"
+  "${STATE_CLUSTER}/shelley/genesis.json")"
 ALONZO_GENESIS_HASH="$(cardano_cli_log legacy genesis hash --genesis \
-  "$STATE_CLUSTER/shelley/genesis.alonzo.json")"
+  "${STATE_CLUSTER}/shelley/genesis.alonzo.json")"
 CONWAY_GENESIS_HASH="$(cardano_cli_log legacy genesis hash --genesis \
-  "$STATE_CLUSTER/shelley/genesis.conway.json")"
+  "${STATE_CLUSTER}/shelley/genesis.conway.json")"
 
 for conf in "$SCRIPT_DIR"/config-*.json; do
   fname="${conf##*/}"
@@ -301,7 +301,7 @@ for conf in "$SCRIPT_DIR"/config-*.json; do
     | .AlonzoGenesisHash = $alonzo_hash
     | .ConwayGenesisHash = $conway_hash
     | ."LastKnownBlockVersion-Major" = $prot_ver' \
-    "$conf" > "$STATE_CLUSTER/$fname"
+    "$conf" > "${STATE_CLUSTER}/${fname}"
 
   # enable P2P
   if [ -z "${ENABLE_LEGACY:-""}" ]; then
@@ -318,7 +318,7 @@ for conf in "$SCRIPT_DIR"/config-*.json; do
       pool_num="${fname##*-pool}"
       pool_num="${pool_num%.json}"
       if [ "$((pool_num % 2))" != 0 ]; then
-        cp -f "$SCRIPT_DIR/topology-pool${pool_num}.json" "$STATE_CLUSTER"
+        cp -f "${SCRIPT_DIR}/topology-pool${pool_num}.json" "$STATE_CLUSTER"
         continue
       fi
     fi
@@ -333,107 +333,107 @@ for conf in "$SCRIPT_DIR"/config-*.json; do
       | .TargetNumberOfActivePeers = 20
       | .TraceBlockFetchClient = true
       | .TraceChainSyncClient = true' \
-      "$STATE_CLUSTER/$fname" > "$STATE_CLUSTER/${fname}_jq"
-    cat "$STATE_CLUSTER/${fname}_jq" > "$STATE_CLUSTER/$fname"
-    rm -f "$STATE_CLUSTER/${fname}_jq"
+      "${STATE_CLUSTER}/${fname}" > "${STATE_CLUSTER}/${fname}_jq"
+    cat "${STATE_CLUSTER}/${fname}_jq" > "${STATE_CLUSTER}/${fname}"
+    rm -f "${STATE_CLUSTER}/${fname}_jq"
   fi
 done
 
-for i in $(seq 1 $NUM_BFT_NODES); do
-  mkdir -p "$STATE_CLUSTER/nodes/node-bft$i"
-  BFT_PORT=$(("%%NODE_PORT_BASE%%" + (i - 1) * "%%PORTS_PER_NODE%%" ))
-  echo "$BFT_PORT" > "$STATE_CLUSTER/nodes/node-bft$i/port"
+for i in $(seq 1 "$NUM_BFT_NODES"); do
+  mkdir -p "${STATE_CLUSTER}/nodes/node-bft$i"
+  BFT_PORT="$(("%%NODE_PORT_BASE%%" + (i - 1) * "%%PORTS_PER_NODE%%" ))"
+  echo "$BFT_PORT" > "${STATE_CLUSTER}/nodes/node-bft${i}/port"
 done
 
 for i in $(seq 1 "$NUM_POOLS"); do
-  mkdir -p "$STATE_CLUSTER/nodes/node-pool$i"
-  mv "$STATE_CLUSTER/create_staked/pools/cold$i.skey" "$STATE_CLUSTER/nodes/node-pool$i/cold.skey"
-  mv "$STATE_CLUSTER/create_staked/pools/cold$i.vkey" "$STATE_CLUSTER/nodes/node-pool$i/cold.vkey"
+  mkdir -p "${STATE_CLUSTER}/nodes/node-pool$i"
+  mv "${STATE_CLUSTER}/create_staked/pools/cold${i}.skey" "${STATE_CLUSTER}/nodes/node-pool${i}/cold.skey"
+  mv "${STATE_CLUSTER}/create_staked/pools/cold${i}.vkey" "${STATE_CLUSTER}/nodes/node-pool${i}/cold.vkey"
 
-  mv "$STATE_CLUSTER/create_staked/pools/kes$i.skey" "$STATE_CLUSTER/nodes/node-pool$i/kes.skey"
-  mv "$STATE_CLUSTER/create_staked/pools/kes$i.vkey" "$STATE_CLUSTER/nodes/node-pool$i/kes.vkey"
+  mv "${STATE_CLUSTER}/create_staked/pools/kes${i}.skey" "${STATE_CLUSTER}/nodes/node-pool${i}/kes.skey"
+  mv "${STATE_CLUSTER}/create_staked/pools/kes${i}.vkey" "${STATE_CLUSTER}/nodes/node-pool${i}/kes.vkey"
 
-  mv "$STATE_CLUSTER/create_staked/pools/opcert$i.cert" "$STATE_CLUSTER/nodes/node-pool$i/op.cert"
-  mv "$STATE_CLUSTER/create_staked/pools/opcert$i.counter" "$STATE_CLUSTER/nodes/node-pool$i/cold.counter"
+  mv "${STATE_CLUSTER}/create_staked/pools/opcert${i}.cert" "${STATE_CLUSTER}/nodes/node-pool${i}/op.cert"
+  mv "${STATE_CLUSTER}/create_staked/pools/opcert${i}.counter" "${STATE_CLUSTER}/nodes/node-pool${i}/cold.counter"
 
   # stake reward keys
-  mv "$STATE_CLUSTER/create_staked/pools/staking-reward$i.skey" "$STATE_CLUSTER/nodes/node-pool$i/reward.skey"
-  mv "$STATE_CLUSTER/create_staked/pools/staking-reward$i.vkey" "$STATE_CLUSTER/nodes/node-pool$i/reward.vkey"
+  mv "${STATE_CLUSTER}/create_staked/pools/staking-reward${i}.skey" "${STATE_CLUSTER}/nodes/node-pool${i}/reward.skey"
+  mv "${STATE_CLUSTER}/create_staked/pools/staking-reward${i}.vkey" "${STATE_CLUSTER}/nodes/node-pool${i}/reward.vkey"
 
-  mv "$STATE_CLUSTER/create_staked/pools/vrf$i.skey" "$STATE_CLUSTER/nodes/node-pool$i/vrf.skey"
-  mv "$STATE_CLUSTER/create_staked/pools/vrf$i.vkey" "$STATE_CLUSTER/nodes/node-pool$i/vrf.vkey"
+  mv "${STATE_CLUSTER}/create_staked/pools/vrf${i}.skey" "${STATE_CLUSTER}/nodes/node-pool${i}/vrf.skey"
+  mv "${STATE_CLUSTER}/create_staked/pools/vrf${i}.vkey" "${STATE_CLUSTER}/nodes/node-pool${i}/vrf.vkey"
 
   echo "Generating Pool $i Secrets"
 
   # pool owner addresses and keys
   cardano_cli_log conway address key-gen \
-    --signing-key-file "$STATE_CLUSTER/nodes/node-pool$i/owner-utxo.skey" \
-    --verification-key-file "$STATE_CLUSTER/nodes/node-pool$i/owner-utxo.vkey"
+    --signing-key-file "${STATE_CLUSTER}/nodes/node-pool${i}/owner-utxo.skey" \
+    --verification-key-file "${STATE_CLUSTER}/nodes/node-pool${i}/owner-utxo.vkey"
   cardano_cli_log conway stake-address key-gen \
-    --signing-key-file "$STATE_CLUSTER/nodes/node-pool$i/owner-stake.skey" \
-    --verification-key-file "$STATE_CLUSTER/nodes/node-pool$i/owner-stake.vkey"
+    --signing-key-file "${STATE_CLUSTER}/nodes/node-pool${i}/owner-stake.skey" \
+    --verification-key-file "${STATE_CLUSTER}/nodes/node-pool${i}/owner-stake.vkey"
 
   #   payment address
   cardano_cli_log conway address build \
-    --payment-verification-key-file "$STATE_CLUSTER/nodes/node-pool$i/owner-utxo.vkey" \
-    --stake-verification-key-file "$STATE_CLUSTER/nodes/node-pool$i/owner-stake.vkey" \
+    --payment-verification-key-file "${STATE_CLUSTER}/nodes/node-pool${i}/owner-utxo.vkey" \
+    --stake-verification-key-file "${STATE_CLUSTER}/nodes/node-pool${i}/owner-stake.vkey" \
     --testnet-magic "$NETWORK_MAGIC" \
-    --out-file "$STATE_CLUSTER/nodes/node-pool$i/owner.addr"
+    --out-file "${STATE_CLUSTER}/nodes/node-pool${i}/owner.addr"
 
   #   stake address
   cardano_cli_log conway stake-address build \
-    --stake-verification-key-file "$STATE_CLUSTER/nodes/node-pool$i/owner-stake.vkey" \
+    --stake-verification-key-file "${STATE_CLUSTER}/nodes/node-pool${i}/owner-stake.vkey" \
     --testnet-magic "$NETWORK_MAGIC" \
-    --out-file "$STATE_CLUSTER/nodes/node-pool$i/owner-stake.addr"
+    --out-file "${STATE_CLUSTER}/nodes/node-pool${i}/owner-stake.addr"
 
   #   stake address registration cert
   cardano_cli_log conway stake-address registration-certificate \
-    --stake-verification-key-file "$STATE_CLUSTER/nodes/node-pool$i/owner-stake.vkey" \
+    --stake-verification-key-file "${STATE_CLUSTER}/nodes/node-pool${i}/owner-stake.vkey" \
     --key-reg-deposit-amt "$KEY_DEPOSIT" \
-    --out-file "$STATE_CLUSTER/nodes/node-pool$i/stake.reg.cert"
+    --out-file "${STATE_CLUSTER}/nodes/node-pool${i}/stake.reg.cert"
 
   if [ -n "${PV10:-""}" ]; then
     # stake reward address registration and vote delegation cert
     cardano_cli_log conway stake-address registration-and-vote-delegation-certificate \
-      --stake-verification-key-file "$STATE_CLUSTER/nodes/node-pool$i/reward.vkey" \
+      --stake-verification-key-file "${STATE_CLUSTER}/nodes/node-pool${i}/reward.vkey" \
       --always-abstain \
       --key-reg-deposit-amt "$KEY_DEPOSIT" \
-      --out-file "$STATE_CLUSTER/nodes/node-pool$i/stake-reward.reg.cert"
+      --out-file "${STATE_CLUSTER}/nodes/node-pool${i}/stake-reward.reg.cert"
 
     # owner stake address stake and vote delegation cert
     cardano_cli_log conway stake-address stake-and-vote-delegation-certificate \
-      --stake-verification-key-file "$STATE_CLUSTER/nodes/node-pool$i/owner-stake.vkey" \
-      --cold-verification-key-file  "$STATE_CLUSTER/nodes/node-pool$i/cold.vkey" \
+      --stake-verification-key-file "${STATE_CLUSTER}/nodes/node-pool${i}/owner-stake.vkey" \
+      --cold-verification-key-file  "${STATE_CLUSTER}/nodes/node-pool${i}/cold.vkey" \
       --always-abstain \
-      --out-file "$STATE_CLUSTER/nodes/node-pool$i/owner-stake.deleg.cert"
+      --out-file "${STATE_CLUSTER}/nodes/node-pool${i}/owner-stake.deleg.cert"
   else
     # stake reward address registration cert
     cardano_cli_log conway stake-address registration-certificate \
-      --stake-verification-key-file "$STATE_CLUSTER/nodes/node-pool$i/reward.vkey" \
+      --stake-verification-key-file "${STATE_CLUSTER}/nodes/node-pool${i}/reward.vkey" \
       --key-reg-deposit-amt "$KEY_DEPOSIT" \
-      --out-file "$STATE_CLUSTER/nodes/node-pool$i/stake-reward.reg.cert"
+      --out-file "${STATE_CLUSTER}/nodes/node-pool${i}/stake-reward.reg.cert"
 
     # owner stake address stake delegation cert
     cardano_cli_log conway stake-address stake-delegation-certificate \
-      --stake-verification-key-file "$STATE_CLUSTER/nodes/node-pool$i/owner-stake.vkey" \
-      --cold-verification-key-file  "$STATE_CLUSTER/nodes/node-pool$i/cold.vkey" \
-      --out-file "$STATE_CLUSTER/nodes/node-pool$i/owner-stake.deleg.cert"
+      --stake-verification-key-file "${STATE_CLUSTER}/nodes/node-pool${i}/owner-stake.vkey" \
+      --cold-verification-key-file  "${STATE_CLUSTER}/nodes/node-pool${i}/cold.vkey" \
+      --out-file "${STATE_CLUSTER}/nodes/node-pool${i}/owner-stake.deleg.cert"
   fi
 
-  POOL_NAME="TestPool$i"
+  POOL_NAME="TestPool${i}"
   POOL_DESC="Test Pool $i"
-  POOL_TICKER="TP$i"
+  POOL_TICKER="TP${i}"
 
-  cat > "$STATE_CLUSTER/webserver/pool$i.html" <<EoF
+  cat > "${STATE_CLUSTER}/webserver/pool${i}.html" <<EoF
 <!DOCTYPE html>
 <html>
 <head>
-<title>$POOL_NAME</title>
+<title>${POOL_NAME}</title>
 </head>
 <body>
-name: <strong>$POOL_NAME</strong><br>
-description: <strong>$POOL_DESC</strong><br>
-ticker: <strong>$POOL_TICKER</strong><br>
+name: <strong>${POOL_NAME}</strong><br>
+description: <strong>${POOL_DESC}</strong><br>
+ticker: <strong>${POOL_TICKER}</strong><br>
 </body>
 </html>
 EoF
@@ -443,107 +443,107 @@ EoF
     --arg name "$POOL_NAME" \
     --arg description "$POOL_DESC" \
     --arg ticker "$POOL_TICKER" \
-    --arg homepage "http://localhost:%%WEBSERVER_PORT%%/pool$i.html" \
+    --arg homepage "http://localhost:%%WEBSERVER_PORT%%/pool${i}.html" \
     '{"name": $name, "description": $description, "ticker": $ticker, "homepage": $homepage}' \
-    > "$STATE_CLUSTER/webserver/pool$i.json"
+    > "${STATE_CLUSTER}/webserver/pool${i}.json"
 
-  METADATA_URL="http://localhost:%%WEBSERVER_PORT%%/pool$i.json"
-  METADATA_HASH=$(cardano_cli_log conway stake-pool metadata-hash --pool-metadata-file \
-    "$STATE_CLUSTER/webserver/pool$i.json")
-  POOL_PORT=$(("%%NODE_PORT_BASE%%" + ("$NUM_BFT_NODES" + i - 1) * "%%PORTS_PER_NODE%%"))
-  echo "$POOL_PORT" > "$STATE_CLUSTER/nodes/node-pool$i/port"
-  echo $POOL_PLEDGE > "$STATE_CLUSTER/nodes/node-pool$i/pledge"
+  METADATA_URL="http://localhost:%%WEBSERVER_PORT%%/pool${i}.json"
+  METADATA_HASH="$(cardano_cli_log conway stake-pool metadata-hash --pool-metadata-file \
+    "${STATE_CLUSTER}/webserver/pool${i}.json")"
+  POOL_PORT="$(("%%NODE_PORT_BASE%%" + (NUM_BFT_NODES + i - 1) * "%%PORTS_PER_NODE%%"))"
+  echo "$POOL_PORT" > "${STATE_CLUSTER}/nodes/node-pool${i}/port"
+  echo "$POOL_PLEDGE" > "${STATE_CLUSTER}/nodes/node-pool${i}/pledge"
 
   cardano_cli_log conway stake-pool registration-certificate \
-    --cold-verification-key-file "$STATE_CLUSTER/nodes/node-pool$i/cold.vkey" \
-    --vrf-verification-key-file "$STATE_CLUSTER/nodes/node-pool$i/vrf.vkey" \
+    --cold-verification-key-file "${STATE_CLUSTER}/nodes/node-pool${i}/cold.vkey" \
+    --vrf-verification-key-file "${STATE_CLUSTER}/nodes/node-pool${i}/vrf.vkey" \
     --pool-pledge "$POOL_PLEDGE" \
     --pool-margin 0.35 \
     --pool-cost "$POOL_COST" \
-    --pool-reward-account-verification-key-file "$STATE_CLUSTER/nodes/node-pool$i/reward.vkey" \
-    --pool-owner-stake-verification-key-file "$STATE_CLUSTER/nodes/node-pool$i/owner-stake.vkey" \
+    --pool-reward-account-verification-key-file "${STATE_CLUSTER}/nodes/node-pool${i}/reward.vkey" \
+    --pool-owner-stake-verification-key-file "${STATE_CLUSTER}/nodes/node-pool${i}/owner-stake.vkey" \
     --metadata-url "$METADATA_URL" \
     --metadata-hash "$METADATA_HASH" \
     --pool-relay-port "$POOL_PORT" \
     --pool-relay-ipv4 "127.0.0.1" \
     --testnet-magic "$NETWORK_MAGIC" \
-    --out-file "$STATE_CLUSTER/nodes/node-pool$i/register.cert"
+    --out-file "${STATE_CLUSTER}/nodes/node-pool${i}/register.cert"
 done
 
-rm -rf "$STATE_CLUSTER/shelley/create_staked"
+rm -rf "${STATE_CLUSTER}/shelley/create_staked"
 
 for i in $(seq 1 "$NUM_DREPS"); do
   # DRep keys
   cardano_cli_log conway governance drep key-gen \
-    --signing-key-file "$STATE_CLUSTER/governance_data/default_drep_${i}_drep.skey" \
-    --verification-key-file "$STATE_CLUSTER/governance_data/default_drep_${i}_drep.vkey"
+    --signing-key-file "${STATE_CLUSTER}/governance_data/default_drep_${i}_drep.skey" \
+    --verification-key-file "${STATE_CLUSTER}/governance_data/default_drep_${i}_drep.vkey"
 
   # DRep registration
   cardano_cli_log conway governance drep registration-certificate \
-    --drep-verification-key-file "$STATE_CLUSTER/governance_data/default_drep_${i}_drep.vkey" \
+    --drep-verification-key-file "${STATE_CLUSTER}/governance_data/default_drep_${i}_drep.vkey" \
     --key-reg-deposit-amt "$DREP_DEPOSIT" \
-    --out-file "$STATE_CLUSTER/governance_data/default_drep_${i}_drep_reg.cert"
+    --out-file "${STATE_CLUSTER}/governance_data/default_drep_${i}_drep_reg.cert"
 
   # delegatee payment keys
   cardano_cli_log conway address key-gen \
-    --signing-key-file "$STATE_CLUSTER/governance_data/vote_stake_addr${i}.skey" \
-    --verification-key-file "$STATE_CLUSTER/governance_data/vote_stake_addr${i}.vkey"
+    --signing-key-file "${STATE_CLUSTER}/governance_data/vote_stake_addr${i}.skey" \
+    --verification-key-file "${STATE_CLUSTER}/governance_data/vote_stake_addr${i}.vkey"
 
   # delegatee stake keys
   cardano_cli_log conway stake-address key-gen \
-    --signing-key-file "$STATE_CLUSTER/governance_data/vote_stake_addr${i}_stake.skey" \
-    --verification-key-file "$STATE_CLUSTER/governance_data/vote_stake_addr${i}_stake.vkey"
+    --signing-key-file "${STATE_CLUSTER}/governance_data/vote_stake_addr${i}_stake.skey" \
+    --verification-key-file "${STATE_CLUSTER}/governance_data/vote_stake_addr${i}_stake.vkey"
 
   # delegatee payment address
   cardano_cli_log conway address build \
-    --payment-verification-key-file "$STATE_CLUSTER/governance_data/vote_stake_addr${i}.vkey" \
-    --stake-verification-key-file "$STATE_CLUSTER/governance_data/vote_stake_addr${i}_stake.vkey" \
+    --payment-verification-key-file "${STATE_CLUSTER}/governance_data/vote_stake_addr${i}.vkey" \
+    --stake-verification-key-file "${STATE_CLUSTER}/governance_data/vote_stake_addr${i}_stake.vkey" \
     --testnet-magic "$NETWORK_MAGIC" \
-    --out-file "$STATE_CLUSTER/governance_data/vote_stake_addr${i}.addr"
+    --out-file "${STATE_CLUSTER}/governance_data/vote_stake_addr${i}.addr"
 
   # delegatee stake address
   cardano_cli_log conway stake-address build \
-    --stake-verification-key-file "$STATE_CLUSTER/governance_data/vote_stake_addr${i}_stake.vkey" \
+    --stake-verification-key-file "${STATE_CLUSTER}/governance_data/vote_stake_addr${i}_stake.vkey" \
     --testnet-magic "$NETWORK_MAGIC" \
-    --out-file "$STATE_CLUSTER/governance_data/vote_stake_addr${i}_stake.addr"
+    --out-file "${STATE_CLUSTER}/governance_data/vote_stake_addr${i}_stake.addr"
 
   # delegatee stake address registration cert
   cardano_cli_log conway stake-address registration-certificate \
-    --stake-verification-key-file "$STATE_CLUSTER/governance_data/vote_stake_addr${i}_stake.vkey" \
+    --stake-verification-key-file "${STATE_CLUSTER}/governance_data/vote_stake_addr${i}_stake.vkey" \
     --key-reg-deposit-amt "$KEY_DEPOSIT" \
-    --out-file "$STATE_CLUSTER/governance_data/vote_stake_addr${i}_stake.reg.cert"
+    --out-file "${STATE_CLUSTER}/governance_data/vote_stake_addr${i}_stake.reg.cert"
 
   # delegatee vote delegation cert
   cardano_cli_log conway stake-address vote-delegation-certificate \
-    --stake-verification-key-file "$STATE_CLUSTER/governance_data/vote_stake_addr${i}_stake.vkey" \
-    --drep-verification-key-file "$STATE_CLUSTER/governance_data/default_drep_${i}_drep.vkey" \
-    --out-file "$STATE_CLUSTER/governance_data/vote_stake_addr${i}_stake.vote_deleg.cert"
+    --stake-verification-key-file "${STATE_CLUSTER}/governance_data/vote_stake_addr${i}_stake.vkey" \
+    --drep-verification-key-file "${STATE_CLUSTER}/governance_data/default_drep_${i}_drep.vkey" \
+    --out-file "${STATE_CLUSTER}/governance_data/vote_stake_addr${i}_stake.vote_deleg.cert"
 done
 
 # create scripts for cluster starting / stopping
-printf "#!/bin/sh\n\nsupervisorctl -s http://127.0.0.1:%%SUPERVISOR_PORT%% start all" > "$STATE_CLUSTER/supervisorctl_start"
-printf "#!/bin/sh\n\nsupervisorctl -s http://127.0.0.1:%%SUPERVISOR_PORT%% restart nodes:" > "$STATE_CLUSTER/supervisorctl_restart_nodes"
-printf "#!/bin/sh\n\nsupervisorctl -s http://127.0.0.1:%%SUPERVISOR_PORT%% \"\$@\"" > "$STATE_CLUSTER/supervisorctl"
+printf "#!/bin/sh\n\nsupervisorctl -s http://127.0.0.1:%%SUPERVISOR_PORT%% start all" > "${STATE_CLUSTER}/supervisorctl_start"
+printf "#!/bin/sh\n\nsupervisorctl -s http://127.0.0.1:%%SUPERVISOR_PORT%% restart nodes:" > "${STATE_CLUSTER}/supervisorctl_restart_nodes"
+printf "#!/bin/sh\n\nsupervisorctl -s http://127.0.0.1:%%SUPERVISOR_PORT%% \"\$@\"" > "${STATE_CLUSTER}/supervisorctl"
 
-cat > "$STATE_CLUSTER/supervisord_start" <<EoF
+cat > "${STATE_CLUSTER}/supervisord_start" <<EoF
 #!/usr/bin/env bash
 
 set -uo pipefail
 
 SCRIPT_DIR="\$(readlink -m "\${0%/*}")"
 
-cd "\$SCRIPT_DIR/.."
+cd "\${SCRIPT_DIR}/.."
 
-supervisord --config "\$SCRIPT_DIR/supervisor.conf"
+supervisord --config "\${SCRIPT_DIR}/supervisor.conf"
 EoF
 
-cat > "$STATE_CLUSTER/supervisord_stop" <<EoF
+cat > "${STATE_CLUSTER}/supervisord_stop" <<EoF
 #!/usr/bin/env bash
 
 set -uo pipefail
 
 SCRIPT_DIR="\$(readlink -m "\${0%/*}")"
-PID_FILE="\$SCRIPT_DIR/supervisord.pid"
+PID_FILE="\${SCRIPT_DIR}/supervisord.pid"
 
 supervisorctl -s http://127.0.0.1:%%SUPERVISOR_PORT%% stop all
 
@@ -574,7 +574,7 @@ if [ -n "${DRY_RUN:-""}" ]; then
   exit 0
 fi
 
-supervisord --config "$STATE_CLUSTER/supervisor.conf"
+supervisord --config "${STATE_CLUSTER}/supervisor.conf"
 
 for _ in {1..5}; do
   if [ -S "$CARDANO_NODE_SOCKET_PATH" ]; then
@@ -630,16 +630,16 @@ POOL_ARGS=()
 POOL_SIGNING=()
 for i in $(seq 1 "$NUM_POOLS"); do
   POOL_ARGS+=( \
-    "--tx-out" "$(<"$STATE_CLUSTER/nodes/node-pool$i/owner.addr")+$POOL_PLEDGE" \
-    "--certificate-file" "$STATE_CLUSTER/nodes/node-pool$i/stake.reg.cert" \
-    "--certificate-file" "$STATE_CLUSTER/nodes/node-pool$i/stake-reward.reg.cert" \
-    "--certificate-file" "$STATE_CLUSTER/nodes/node-pool$i/register.cert" \
-    "--certificate-file" "$STATE_CLUSTER/nodes/node-pool$i/owner-stake.deleg.cert" \
+    "--tx-out" "$(<"${STATE_CLUSTER}/nodes/node-pool${i}/owner.addr")+${POOL_PLEDGE}" \
+    "--certificate-file" "${STATE_CLUSTER}/nodes/node-pool${i}/stake.reg.cert" \
+    "--certificate-file" "${STATE_CLUSTER}/nodes/node-pool${i}/stake-reward.reg.cert" \
+    "--certificate-file" "${STATE_CLUSTER}/nodes/node-pool${i}/register.cert" \
+    "--certificate-file" "${STATE_CLUSTER}/nodes/node-pool${i}/owner-stake.deleg.cert" \
   )
   POOL_SIGNING+=( \
-    "--signing-key-file" "$STATE_CLUSTER/nodes/node-pool$i/owner-stake.skey" \
-    "--signing-key-file" "$STATE_CLUSTER/nodes/node-pool$i/reward.skey" \
-    "--signing-key-file" "$STATE_CLUSTER/nodes/node-pool$i/cold.skey" \
+    "--signing-key-file" "${STATE_CLUSTER}/nodes/node-pool${i}/owner-stake.skey" \
+    "--signing-key-file" "${STATE_CLUSTER}/nodes/node-pool${i}/reward.skey" \
+    "--signing-key-file" "${STATE_CLUSTER}/nodes/node-pool${i}/cold.skey" \
   )
 done
 
@@ -659,15 +659,15 @@ DREPS_ARGS=()
 DREPS_SIGNING=()
 for i in $(seq 1 "$NUM_DREPS"); do
   DREPS_ARGS+=( \
-    "--tx-out" "$(<"$STATE_CLUSTER/governance_data/vote_stake_addr${i}.addr")+$DREP_DELEGATED" \
-    "--certificate-file" "$STATE_CLUSTER/governance_data/default_drep_${i}_drep_reg.cert" \
-    "--certificate-file" "$STATE_CLUSTER/governance_data/vote_stake_addr${i}_stake.reg.cert" \
-    "--certificate-file" "$STATE_CLUSTER/governance_data/vote_stake_addr${i}_stake.vote_deleg.cert" \
+    "--tx-out" "$(<"${STATE_CLUSTER}/governance_data/vote_stake_addr${i}.addr")+${DREP_DELEGATED}" \
+    "--certificate-file" "${STATE_CLUSTER}/governance_data/default_drep_${i}_drep_reg.cert" \
+    "--certificate-file" "${STATE_CLUSTER}/governance_data/vote_stake_addr${i}_stake.reg.cert" \
+    "--certificate-file" "${STATE_CLUSTER}/governance_data/vote_stake_addr${i}_stake.vote_deleg.cert" \
   )
   DREPS_SIGNING+=( \
-    "--signing-key-file" "$STATE_CLUSTER/governance_data/default_drep_${i}_drep.skey" \
-    "--signing-key-file" "$STATE_CLUSTER/governance_data/vote_stake_addr${i}.skey" \
-    "--signing-key-file" "$STATE_CLUSTER/governance_data/vote_stake_addr${i}_stake.skey" \
+    "--signing-key-file" "${STATE_CLUSTER}/governance_data/default_drep_${i}_drep.skey" \
+    "--signing-key-file" "${STATE_CLUSTER}/governance_data/vote_stake_addr${i}.skey" \
+    "--signing-key-file" "${STATE_CLUSTER}/governance_data/vote_stake_addr${i}_stake.skey" \
   )
 done
 
@@ -681,7 +681,7 @@ cardano_cli_log conway transaction build \
   "${DREPS_ARGS[@]}" \
   --witness-override "$WITNESS_COUNT" \
   --testnet-magic    "$NETWORK_MAGIC" \
-  --out-file         "$STATE_CLUSTER/shelley/transfer-register-delegate-tx.txbody"
+  --out-file         "${STATE_CLUSTER}/shelley/transfer-register-delegate-tx.txbody"
 
 cardano_cli_log conway transaction sign \
   "${POOL_SIGNING[@]}" \
@@ -689,13 +689,13 @@ cardano_cli_log conway transaction sign \
   "${DELEGATE_SIGNING[@]}" \
   "${CC_SIGNING[@]}" \
   "${DREPS_SIGNING[@]}" \
-  --signing-key-file "$STATE_CLUSTER/shelley/genesis-utxo.skey" \
+  --signing-key-file "${STATE_CLUSTER}/shelley/genesis-utxo.skey" \
   --testnet-magic    "$NETWORK_MAGIC" \
-  --tx-body-file     "$STATE_CLUSTER/shelley/transfer-register-delegate-tx.txbody" \
-  --out-file         "$STATE_CLUSTER/shelley/transfer-register-delegate-tx.tx"
+  --tx-body-file     "${STATE_CLUSTER}/shelley/transfer-register-delegate-tx.txbody" \
+  --out-file         "${STATE_CLUSTER}/shelley/transfer-register-delegate-tx.tx"
 
 cardano_cli_log conway transaction submit \
-  --tx-file "$STATE_CLUSTER/shelley/transfer-register-delegate-tx.tx" \
+  --tx-file "${STATE_CLUSTER}/shelley/transfer-register-delegate-tx.tx" \
   --testnet-magic "$NETWORK_MAGIC"
 
 # start cardano-submit-api
@@ -710,4 +710,4 @@ if ! check_spend_success "${TXINS[@]}"; then
   exit 1
 fi
 
-echo "Cluster started. Run \`$SCRIPT_DIR/stop-cluster\` to stop"
+echo "Cluster started. Run \`${SCRIPT_DIR}/stop-cluster\` to stop"


### PR DESCRIPTION
Updated the start-cluster scripts to use braces for variable expansion in cases where the variable is part of a string.