### PR TITLE
fix(tests): update script file identifiers

### DIFF
--- a/cardano_node_tests/tests/plutus_common.py
+++ b/cardano_node_tests/tests/plutus_common.py
@@ -446,7 +446,7 @@ FAILING_BITWISE_SCRIPT_FILES_V3 = (
 UNDETERMINED_COST = ExecutionCost(per_time=1_000_000, per_space=100_000, fixed_cost=1234)
 
 
-FAILING_MINTING_BITWISE_SCRIPTS_V3 = (
+FAILING_MINTING_BITWISE_SCRIPTS_V3 = tuple(
     PlutusScriptData(
         script_file=SCRIPTS_V3_DIR / n,
         script_type=clusterlib.ScriptTypes.PLUTUS_V3,

--- a/cardano_node_tests/tests/tests_plutus/test_mint_build.py
+++ b/cardano_node_tests/tests/tests_plutus/test_mint_build.py
@@ -1536,7 +1536,7 @@ class TestPlutusBatch5V3Builtins:
     @pytest.mark.parametrize(
         "script",
         success_scripts,
-        ids=(s.script_file.name for s in success_scripts),
+        ids=(s.script_file.stem for s in success_scripts),
     )
     @pytest.mark.smoke
     def test_plutus_success(
@@ -1558,7 +1558,7 @@ class TestPlutusBatch5V3Builtins:
     @pytest.mark.parametrize(
         "script",
         fail_scripts,
-        ids=(s.script_file.name for s in fail_scripts),
+        ids=(s.script_file.stem for s in fail_scripts),
     )
     @pytest.mark.smoke
     def test_plutus_fail(


### PR DESCRIPTION
- Change FAILING_MINTING_BITWISE_SCRIPTS_V3 to tuple instead of generator
- Update pytest parametrize ids to use script_file.stem instead of name

This ensures better readability and consistency in test identifiers.