### PR TITLE
feat: add team_plutus marker to tests and workflows

### DIFF
--- a/.github/workflows/regression-dbsync.yaml
+++ b/.github/workflows/regression-dbsync.yaml
@@ -33,6 +33,7 @@ on:
         - smoke
         - plutus
         - plutus and smoke
+        - team_plutus
         - not long
         - conway only
         - dbsync and smoke

--- a/.github/workflows/regression.yaml
+++ b/.github/workflows/regression.yaml
@@ -29,6 +29,7 @@ on:
         - smoke
         - plutus
         - plutus and smoke
+        - team_plutus
         - not long
         - conway only
         default: all

--- a/cardano_node_tests/tests/tests_plutus/test_mint_build.py
+++ b/cardano_node_tests/tests/tests_plutus/test_mint_build.py
@@ -1538,6 +1538,7 @@ class TestPlutusBatch5V3Builtins:
         success_scripts,
         ids=(s.script_file.stem for s in success_scripts),
     )
+    @pytest.mark.team_plutus
     @pytest.mark.smoke
     def test_plutus_success(
         self,
@@ -1560,6 +1561,7 @@ class TestPlutusBatch5V3Builtins:
         fail_scripts,
         ids=(s.script_file.stem for s in fail_scripts),
     )
+    @pytest.mark.team_plutus
     @pytest.mark.smoke
     def test_plutus_fail(
         self,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -135,6 +135,7 @@ markers = [
     "smoke: fast test(s) under 1 minute",
     "upgrade: test(s) for upgrade testing",
     "plutus: test(s) for plutus",
+    "team_plutus: test(s) from Plutus dev team",
     "disabled: temporarily disabled test(s)",
     "noop: placeholder marker",
 ]


### PR DESCRIPTION
- Added `team_plutus` marker to the regression-dbsync and regression workflows.
- Marked relevant tests in `test_mint_build.py` with `@pytest.mark.team_plutus`.
- Updated `pyproject.toml` to include the new `team_plutus` marker.