### PR TITLE
fix(dbsync): filter tx collaterals by Lovelace

### DIFF
--- a/cardano_node_tests/utils/dbsync_check_tx.py
+++ b/cardano_node_tests/utils/dbsync_check_tx.py
@@ -351,7 +351,9 @@ def check_tx_collaterals(
             *tx_raw_output.script_withdrawals,
         )
     ]
-    tx_collaterals = set(itertools.chain.from_iterable(tx_collaterals_nested))
+    tx_collaterals_flat = set(itertools.chain.from_iterable(tx_collaterals_nested))
+    # TODO: support multi-assets in collateral inputs
+    tx_collaterals = {r for r in tx_collaterals_flat if r.coin == clusterlib.DEFAULT_COIN}
     db_collaterals = {utxorecord2utxodata(utxorecord=r) for r in response.collaterals}
 
     assert (


### PR DESCRIPTION
Updated the `check_tx_collaterals` function to filter transaction collaterals by Lovelace. This change ensures that only collateral UTxOs with Lovelace are considered, while multi-assets in collateral inputs are not yet supported.

TODO: Add support for multi-assets in collateral inputs.