### PR TITLE
feat(cluster): change mv to cp for genesis spec files

### DIFF
--- a/cardano_node_tests/cluster_scripts/conway/start-cluster
+++ b/cardano_node_tests/cluster_scripts/conway/start-cluster
@@ -199,7 +199,7 @@ cp "${SCRIPT_DIR}/supervisor.conf" "$STATE_CLUSTER"
 cp "$SCRIPT_DIR"/*genesis*.spec.json "${STATE_CLUSTER}/shelley/"
 
 if [ -n "${PV10:-""}" ]; then
-  mv \
+  cp \
     "${SCRIPT_DIR}/genesis.conway.spec.pv10.json" \
     "${STATE_CLUSTER}/shelley/genesis.conway.spec.json"
 fi

--- a/cardano_node_tests/cluster_scripts/conway_fast/start-cluster
+++ b/cardano_node_tests/cluster_scripts/conway_fast/start-cluster
@@ -137,7 +137,7 @@ cp "${SCRIPT_DIR}/supervisor.conf" "$STATE_CLUSTER"
 cp "$SCRIPT_DIR"/*genesis*.spec.json "${STATE_CLUSTER}/create_staked/"
 
 if [ -n "${PV10:-""}" ]; then
-  mv \
+  cp \
     "${SCRIPT_DIR}/genesis.conway.spec.pv10.json" \
     "${STATE_CLUSTER}/create_staked/genesis.conway.spec.json"
 fi

--- a/cardano_node_tests/cluster_scripts/mainnet_fast/start-cluster
+++ b/cardano_node_tests/cluster_scripts/mainnet_fast/start-cluster
@@ -137,7 +137,7 @@ cp "${SCRIPT_DIR}/supervisor.conf" "$STATE_CLUSTER"
 cp "$SCRIPT_DIR"/*genesis*.spec.json "${STATE_CLUSTER}/create_staked/"
 
 if [ -n "${PV10:-""}" ]; then
-  mv \
+  cp \
     "${SCRIPT_DIR}/genesis.conway.spec.pv10.json" \
     "${STATE_CLUSTER}/create_staked/genesis.conway.spec.json"
 fi


### PR DESCRIPTION
Changed the command from mv to cp for genesis.conway.spec.pv10.json in start-cluster scripts. This ensures the original file remains intact while copying it to the target directory. This change affects the conway, conway_fast, and mainnet_fast cluster scripts.