### PR TITLE
fix(tests): update KES expiration comment

### DIFF
--- a/cardano_node_tests/tests/test_kes.py
+++ b/cardano_node_tests/tests/test_kes.py
@@ -31,7 +31,7 @@ LOGGER = logging.getLogger(__name__)
 
 pytestmark = common.SKIPIF_WRONG_ERA
 
-# Slot number where KES certificate expires when using `cluster_kes`
+# Slot number where KES expires when using `cluster_kes`
 KES_EXPIRE_SLOT = 2100
 
 


### PR DESCRIPTION
Updated the comment in test_kes.py to clarify the slot number where KES expires when using `cluster_kes`. This improves the readability and understanding of the code.