### PR TITLE
fix(cluster-scripts): add force flag to cp command

### DIFF
--- a/cardano_node_tests/cluster_scripts/conway/start-cluster
+++ b/cardano_node_tests/cluster_scripts/conway/start-cluster
@@ -199,7 +199,7 @@ cp "${SCRIPT_DIR}/supervisor.conf" "$STATE_CLUSTER"
 cp "$SCRIPT_DIR"/*genesis*.spec.json "${STATE_CLUSTER}/shelley/"
 
 if [ -n "${PV10:-""}" ]; then
-  cp \
+  cp -f \
     "${SCRIPT_DIR}/genesis.conway.spec.pv10.json" \
     "${STATE_CLUSTER}/shelley/genesis.conway.spec.json"
 fi

--- a/cardano_node_tests/cluster_scripts/conway_fast/start-cluster
+++ b/cardano_node_tests/cluster_scripts/conway_fast/start-cluster
@@ -137,7 +137,7 @@ cp "${SCRIPT_DIR}/supervisor.conf" "$STATE_CLUSTER"
 cp "$SCRIPT_DIR"/*genesis*.spec.json "${STATE_CLUSTER}/create_staked/"
 
 if [ -n "${PV10:-""}" ]; then
-  cp \
+  cp -f \
     "${SCRIPT_DIR}/genesis.conway.spec.pv10.json" \
     "${STATE_CLUSTER}/create_staked/genesis.conway.spec.json"
 fi

--- a/cardano_node_tests/cluster_scripts/mainnet_fast/start-cluster
+++ b/cardano_node_tests/cluster_scripts/mainnet_fast/start-cluster
@@ -137,7 +137,7 @@ cp "${SCRIPT_DIR}/supervisor.conf" "$STATE_CLUSTER"
 cp "$SCRIPT_DIR"/*genesis*.spec.json "${STATE_CLUSTER}/create_staked/"
 
 if [ -n "${PV10:-""}" ]; then
-  cp \
+  cp -f \
     "${SCRIPT_DIR}/genesis.conway.spec.pv10.json" \
     "${STATE_CLUSTER}/create_staked/genesis.conway.spec.json"
 fi


### PR DESCRIPTION
Added the -f (force) flag to the cp command in the start-cluster scripts for conway, conway_fast, and mainnet_fast. This ensures that the genesis.conway.spec.pv10.json file is copied even if it already exists in the destination directory.