### PR TITLE
fix(env): correct BASE_TAR_URL in env_nightly_upgrade

### DIFF
--- a/.github/env_nightly_upgrade
+++ b/.github/env_nightly_upgrade
@@ -1,2 +1,2 @@
-BASE_TAR_URL=BASE_TAR_URL=https://github.com/IntersectMBO/cardano-node/releases/download/10.1.2/cardano-node-10.1.2-linux.tar.gz
+BASE_TAR_URL=https://github.com/IntersectMBO/cardano-node/releases/download/10.1.2/cardano-node-10.1.2-linux.tar.gz
 CI_BYRON_CLUSTER=true


### PR DESCRIPTION
The BASE_TAR_URL was incorrectly duplicated in the env_nightly_upgrade file. This commit removes the duplicate and ensures the URL is correctly formatted.