### PR TITLE
feat: add group for script setup in CI scripts

### DIFF
--- a/.github/workflows/regression_reusable.yaml
+++ b/.github/workflows/regression_reusable.yaml
@@ -108,7 +108,10 @@ jobs:
           fi
       - name: Run CLI regression tests
         id: testing-step
-        run: .github/regression.sh
+        run: |
+          # Regression Tests
+          echo "::group::Script setup"
+          .github/regression.sh
       - name: Report test results
         if: (success() || failure()) && inputs.testrun_name
         run: |

--- a/.github/workflows/upgrade_reusable.yaml
+++ b/.github/workflows/upgrade_reusable.yaml
@@ -43,9 +43,12 @@ jobs:
           cat .github_ci_env
           cat .github_ci_env >> $GITHUB_ENV
           echo "GITHUB_TOKEN=${{ secrets.GH_TOKEN }}" >> $GITHUB_ENV
-      - name: Run CLI regression tests
+      - name: Run upgrade tests
         id: testing-step
-        run: ./.github/node_upgrade.sh
+        run: |
+          # Upgrade Tests
+          echo "::group::Script setup"
+          ./.github/node_upgrade.sh
       - name: Upload testing artifacts on failure
         uses: actions/upload-artifact@v4
         if: failure()


### PR DESCRIPTION
This commit adds the "Script setup" group in the `node_upgrade.sh` and `regression.sh` scripts. This change improves the readability of the CI logs by clearly delineating the setup phase from the rest of the script execution.