### PR TITLE
refactor: update group names in shell scripts

### DIFF
--- a/.github/node_upgrade.sh
+++ b/.github/node_upgrade.sh
@@ -60,7 +60,7 @@ unset ENABLE_LEGACY MIXED_P2P
 
 echo "::endgroup::"  # end group for "Script setup"
 
-echo "::group::Nix env setup"
+echo "::group::Nix env setup step1"
 printf "start: %(%H:%M:%S)T\n" -1
 
 # shellcheck disable=SC1090,SC1091
@@ -85,11 +85,11 @@ nix flake update --accept-flake-config $NODE_OVERRIDE
 nix develop --accept-flake-config .#venv --command bash -c '
   : > "$WORKDIR/.nix_step1"
   printf "finish: %(%H:%M:%S)T\n" -1
-  echo "::endgroup::"  # end group for "Nix env setup"
+  echo "::endgroup::"  # end group for "Nix env setup step1"
 
-  echo "::group::Python venv setup"
+  echo "::group::Python venv setup step1"
   . .github/setup_venv.sh clean
-  echo "::endgroup::"  # end group for "Python venv setup"
+  echo "::endgroup::"  # end group for "Python venv setup step1"
 
   echo "::group::-> PYTEST STEP1 <-"
   df -h .
@@ -107,7 +107,8 @@ fi
 [ "$retval" -le 1 ] || exit "$retval"
 
 echo "::endgroup::"  # end group for "-> PYTEST STEP1 <-"
-echo "::group::-> PYTEST STEP2 <-"
+echo "::group::Nix env setup steps 2 & 3"
+printf "start: %(%H:%M:%S)T\n" -1
 
 # update cardano-node to specified branch and/or revision, or to the latest available revision
 if [ -n "${UPGRADE_REVISION:-""}" ]; then
@@ -121,12 +122,15 @@ nix flake update --accept-flake-config $NODE_OVERRIDE
 # shellcheck disable=SC2016
 nix develop --accept-flake-config .#venv --command bash -c '
   : > "$WORKDIR/.nix_step2"
-  df -h .
+  printf "finish: %(%H:%M:%S)T\n" -1
+  echo "::endgroup::"  # end group for "Nix env setup steps 2 & 3"
 
-  echo "::group::Python venv setup"
+  echo "::group::Python venv setup steps 2 & 3"
   . .github/setup_venv.sh clean
-  echo "::endgroup::"  # end group for "Python venv setup"
+  echo "::endgroup::"  # end group for "Python venv setup steps 2 & 3"
 
+  echo "::group::-> PYTEST STEP2 <-"
+  df -h .
   # update cluster nodes, run smoke tests
   ./.github/node_upgrade_pytest.sh step2
   retval="$?"

--- a/.github/regression.sh
+++ b/.github/regression.sh
@@ -95,9 +95,11 @@ case "${DBSYNC_REV:-""}" in
     unset DBSYNC_REV
     ;;
   * )
+    echo "::group::db-sync setup"
     # shellcheck disable=SC1090,SC1091
     . .github/source_dbsync.sh
     df -h .
+    echo "::endgroup::"
     ;;
 esac
 
@@ -111,8 +113,10 @@ case "${PLUTUS_APPS_REV:="none"}" in
     unset PLUTUS_APPS_REV
     ;;
   * )
+    echo "::group::plutus-apps setup"
     # shellcheck disable=SC1090,SC1091
     . .github/source_plutus_apps.sh
+    echo "::endgroup::"
     ;;
 esac
 
@@ -124,8 +128,10 @@ case "${CARDANO_CLI_REV:-""}" in
     unset CARDANO_CLI_REV
     ;;
   * )
+    echo "::group::cardano-cli setup"
     # shellcheck disable=SC1090,SC1091
     . .github/source_cardano_cli.sh
+    echo "::endgroup::"
     ;;
 esac
 

--- a/.github/source_cardano_cli.sh
+++ b/.github/source_cardano_cli.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-echo "::group::cardano-cli setup"
-
 pushd "$WORKDIR" || exit 1
 
 case "${CARDANO_CLI_REV:-""}" in
@@ -39,5 +37,3 @@ nix build --accept-flake-config .#cardano-cli -o cardano-cli-build || exit 1
 [ -e cardano-cli-build/bin/cardano-cli ] || exit 1
 
 pushd "$REPODIR" || exit 1
-
-echo "::endgroup::"

--- a/.github/source_dbsync.sh
+++ b/.github/source_dbsync.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-echo "::group::db-sync setup"
-
 TEST_THREADS="${TEST_THREADS:-15}"
 CLUSTERS_COUNT="${CLUSTERS_COUNT:-4}"
 export TEST_THREADS CLUSTERS_COUNT
@@ -121,5 +119,3 @@ export PGPORT=5432
 
 # start and setup postgres
 ./scripts/postgres-start.sh "$WORKDIR/postgres" -k
-
-echo "::endgroup::"

--- a/.github/source_plutus_apps.sh
+++ b/.github/source_plutus_apps.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-echo "::group::plutus-apps setup"
-
 pushd "$WORKDIR" || exit 1
 
 case "${PLUTUS_APPS_REV:-""}" in
@@ -43,5 +41,3 @@ PATH="$(readlink -m create-script-context-build/bin)":"$PATH"
 export PATH
 
 pushd "$REPODIR" || exit 1
-
-echo "::endgroup::"


### PR DESCRIPTION
Updated the group names in various shell scripts to provide more clarity and consistency. This includes changes in node_upgrade.sh, regression.sh, source_cardano_cli.sh, source_dbsync.sh, and source_plutus_apps.sh. The new group names better reflect the steps being performed in each section.

Remove groups from sourced scripts and move them to the top level script. Groups cannot be nested, and having them just in the top level script makes them more manageable.