### PR TITLE
feat: update base dev shell to use Python 3.11

### DIFF
--- a/.github/workflows/repo_tests.yaml
+++ b/.github/workflows/repo_tests.yaml
@@ -18,7 +18,7 @@ jobs:
       id: setup-python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.10'
+        python-version: '3.11'
     - name: Install Poetry
       uses: snok/install-poetry@v1
       with:

--- a/flake.nix
+++ b/flake.nix
@@ -21,11 +21,13 @@
       (system:
         let
           pkgs = nixpkgs.legacyPackages.${system};
+          py3pkgs = pkgs.python311Packages;
+          py3Full = pkgs.python311Full;
         in
         {
           devShells = rec {
             base = pkgs.mkShell {
-              nativeBuildInputs = with pkgs; [ bash coreutils curl git gnugrep gnumake gnutar jq python3Packages.supervisor xz ];
+              nativeBuildInputs = with pkgs; [ py3Full bash coreutils curl git gnugrep gnumake gnutar jq py3pkgs.supervisor xz ];
             };
             # TODO: can be removed once sync tests are fully moved to separate repo
             python = pkgs.mkShell {
@@ -39,8 +41,8 @@
             ).overrideAttrs (oldAttrs: rec {
               nativeBuildInputs = base.nativeBuildInputs ++ postgres.nativeBuildInputs ++ oldAttrs.nativeBuildInputs ++ [
                 cardano-node.packages.${system}.cardano-submit-api
-                pkgs.python3Packages.pip
-                pkgs.python3Packages.virtualenv
+                py3pkgs.pip
+                py3pkgs.virtualenv
               ];
             });
             # Use 'venv' directly as 'default' and 'dev'

--- a/setup_dev_venv.sh
+++ b/setup_dev_venv.sh
@@ -2,7 +2,7 @@
 #
 # Install cardano_node_tests and its dependencies into a virtual environment.
 
-PYTHON_VERSION="3.10"
+PYTHON_VERSION="3.11"
 
 abort_install=0
 


### PR DESCRIPTION
Updated the base dev shell in flake.nix to use Python 3.11 instead of the default Python 3.10. This change ensures that all dependencies and tools in the base shell are compatible with Python 3.11.