### PR TITLE
chore: update pre-commit hooks to latest versions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 exclude: ^sync_tests/
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.6.0
+  rev: v5.0.0
   hooks:
   - id: trailing-whitespace
     language_version: python3
@@ -14,7 +14,7 @@ repos:
   - id: debug-statements
     language_version: python3
 - repo: https://github.com/charliermarsh/ruff-pre-commit
-  rev: v0.6.3
+  rev: v0.7.3
   hooks:
     - id: ruff
       args: [ --fix ]
@@ -24,7 +24,7 @@ repos:
   hooks:
   - id: shellcheck
 - repo: https://github.com/igorshubovych/markdownlint-cli
-  rev: v0.41.0
+  rev: v0.42.0
   hooks:
   - id: markdownlint
 - repo: https://github.com/rstcheck/rstcheck


### PR DESCRIPTION
Updated the following pre-commit hooks to their latest versions:
- pre-commit-hooks from v4.6.0 to v5.0.0
- ruff-pre-commit from v0.6.3 to v0.7.3
- markdownlint-cli from v0.41.0 to v0.42.0

This ensures we are using the latest features and fixes.