### PR TITLE
fix(tests): adjust epoch interval buffer in test_hardfork

### DIFF
--- a/cardano_node_tests/tests/tests_conway/test_hardfork.py
+++ b/cardano_node_tests/tests/tests_conway/test_hardfork.py
@@ -118,7 +118,7 @@ class TestHardfork:
 
         # Make sure we have enough time to submit the proposal and the votes in one epoch
         clusterlib_utils.wait_for_epoch_interval(
-            cluster_obj=cluster, start=1, stop=common.EPOCH_STOP_SEC_BUFFER - 20
+            cluster_obj=cluster, start=1, stop=common.EPOCH_STOP_SEC_BUFFER - 30
         )
         init_epoch = cluster.g_query.get_epoch()
 


### PR DESCRIPTION
Increased the stop buffer in wait_for_epoch_interval to ensure enough time for proposal and votes submission within one epoch.