### PR TITLE
feat(tests): add CIP027 and failed withdrawal test case

### DIFF
--- a/cardano_node_tests/tests/reqs_conway.py
+++ b/cardano_node_tests/tests/reqs_conway.py
@@ -49,6 +49,7 @@ cip026_01 = __r("intCIP026-01")  # Committee disallowed
 cip026_02 = __r("intCIP026-02")  # Constitution disallowed
 cip026_03 = __r("intCIP026-03")  # Withdrawal disallowed
 cip026_04 = __r("intCIP026-04")  # DRep voting disallowed
+cip027 = __r("CIP027")
 cip028 = __r("CIP028")
 cip029 = __r("CIP029")
 cip030en = __r("intCIP030en")  # enacted


### PR DESCRIPTION
- Added CIP027 to the list of requirements in reqs_conway.py.
- Updated TestConstitution to include a test case for failing to withdraw the deposit from a stake address that is not delegated to a DRep.