### PR TITLE
fix(github-actions): hide special keywords in debug output

### DIFF
--- a/.github/node_upgrade.sh
+++ b/.github/node_upgrade.sh
@@ -58,9 +58,9 @@ export SCHEDULING_LOG=scheduling.log
 export DEV_CLUSTER_RUNNING=1 CLUSTERS_COUNT=1 FORBID_RESTART=1 TEST_THREADS=10 NUM_POOLS="${NUM_POOLS:-4}"
 unset ENABLE_LEGACY MIXED_P2P
 
-echo "::endgroup::"  # end group for "Script setup"
+echo -e "\x3A:endgroup::"  # end group for "Script setup"
 
-echo "::group::Nix env setup step1"
+echo -e "\x3A:group::Nix env setup step1"
 printf "start: %(%H:%M:%S)T\n" -1
 
 # shellcheck disable=SC1090,SC1091
@@ -85,13 +85,13 @@ nix flake update --accept-flake-config $NODE_OVERRIDE
 nix develop --accept-flake-config .#venv --command bash -c '
   : > "$WORKDIR/.nix_step1"
   printf "finish: %(%H:%M:%S)T\n" -1
-  echo "::endgroup::"  # end group for "Nix env setup step1"
+  echo -e "\x3A:endgroup::"  # end group for "Nix env setup step1"
 
-  echo "::group::Python venv setup step1"
+  echo -e "\x3A:group::Python venv setup step1"
   . .github/setup_venv.sh clean
-  echo "::endgroup::"  # end group for "Python venv setup step1"
+  echo -e "\x3A:endgroup::"  # end group for "Python venv setup step1"
 
-  echo "::group::-> PYTEST STEP1 <-"
+  echo -e "\x3A:group::-> PYTEST STEP1 <-"
   df -h .
   # prepare scripts for stating cluster instance, start cluster instance, run smoke tests
   ./.github/node_upgrade_pytest.sh step1
@@ -106,9 +106,9 @@ fi
 # retval 0 == all tests passed; 1 == some tests failed; > 1 == some runtime error and we don't want to continue
 [ "$retval" -le 1 ] || exit "$retval"
 
-echo "::endgroup::"  # end group for "-> PYTEST STEP1 <-"
+echo -e "\x3A:endgroup::"  # end group for "-> PYTEST STEP1 <-"
 
-echo "::group::Nix env setup steps 2 & 3"
+echo -e "\x3A:group::Nix env setup steps 2 & 3"
 printf "start: %(%H:%M:%S)T\n" -1
 
 # update cardano-node to specified branch and/or revision, or to the latest available revision
@@ -124,29 +124,29 @@ nix flake update --accept-flake-config $NODE_OVERRIDE
 nix develop --accept-flake-config .#venv --command bash -c '
   : > "$WORKDIR/.nix_step2"
   printf "finish: %(%H:%M:%S)T\n" -1
-  echo "::endgroup::"  # end group for "Nix env setup steps 2 & 3"
+  echo -e "\x3A:endgroup::"  # end group for "Nix env setup steps 2 & 3"
 
-  echo "::group::Python venv setup steps 2 & 3"
+  echo -e "\x3A:group::Python venv setup steps 2 & 3"
   . .github/setup_venv.sh clean
-  echo "::endgroup::"  # end group for "Python venv setup steps 2 & 3"
+  echo -e "\x3A:endgroup::"  # end group for "Python venv setup steps 2 & 3"
 
-  echo "::group::-> PYTEST STEP2 <-"
+  echo -e "\x3A:group::-> PYTEST STEP2 <-"
   df -h .
   # update cluster nodes, run smoke tests
   ./.github/node_upgrade_pytest.sh step2
   retval="$?"
   # retval 0 == all tests passed; 1 == some tests failed; > 1 == some runtime error and we dont want to continue
   [ "$retval" -le 1 ] || exit "$retval"
-  echo "::endgroup::"  # end group for "-> PYTEST STEP2 <-"
+  echo -e "\x3A:endgroup::"  # end group for "-> PYTEST STEP2 <-"
 
-  echo "::group::-> PYTEST STEP3 <-"
+  echo -e "\x3A:group::-> PYTEST STEP3 <-"
   df -h .
   # update to Conway, run smoke tests
   ./.github/node_upgrade_pytest.sh step3
   retval="$?"
-  echo "::endgroup::"  # end group for "-> PYTEST STEP3 <-"
+  echo -e "\x3A:endgroup::"  # end group for "-> PYTEST STEP3 <-"
 
-  echo "::group::Cluster teardown & artifacts"
+  echo -e "\x3A:group::Cluster teardown & artifacts"
   # teardown cluster
   ./.github/node_upgrade_pytest.sh finish
   exit $retval
@@ -180,6 +180,6 @@ if [ -n "${GITHUB_ACTIONS:-""}" ]; then
   ls -1a
 fi
 
-echo "::endgroup::" # end group for "Cluster teardown & artifacts"
+echo -e "\x3A:endgroup::" # end group for "Cluster teardown & artifacts"
 
 exit "$retval"

--- a/.github/regression.sh
+++ b/.github/regression.sh
@@ -149,8 +149,8 @@ _cleanup_testnet_on_interrupt() {
   _PYTEST_CURRENT="$(readlink -m "$_PYTEST_CURRENT")"
   export _PYTEST_CURRENT
 
-  echo "::endgroup::" # end group for the group that was interrupted
-  echo "::group::Testnet cleanup"
+  echo -e "\x3A:endgroup::" # end group for the group that was interrupted
+  echo -e "\x3A:group::Testnet cleanup"
 
   # shellcheck disable=SC2016
   nix develop --accept-flake-config .#venv --command bash -c '
@@ -163,7 +163,7 @@ _cleanup_testnet_on_interrupt() {
     testnet-cleanup -a "$_PYTEST_CURRENT"
   '
 
-  echo "::endgroup::"
+  echo -e "\x3A:endgroup::"
 }
 
 # cleanup on Ctrl+C
@@ -175,9 +175,9 @@ _interrupted() {
 }
 trap 'set +e; _interrupted; exit 130' SIGINT
 
-echo "::endgroup::"  # end group for "Script setup"
+echo -e "\x3A:endgroup::"  # end group for "Script setup"
 
-echo "::group::Nix env setup"
+echo -e "\x3A:group::Nix env setup"
 printf "start: %(%H:%M:%S)T\n" -1
 
 # function to update cardano-node to specified branch and/or revision, or to the latest available
@@ -192,20 +192,20 @@ nix flake update --accept-flake-config $(node_override)
 nix develop --accept-flake-config .#venv --command bash -c '
   printf "finish: %(%H:%M:%S)T\n" -1
   df -h .
-  echo "::endgroup::"  # end group for "Nix env setup"
+  echo -e "\x3A:endgroup::"  # end group for "Nix env setup"
 
-  echo "::group::Python venv setup"
+  echo -e "\x3A:group::Python venv setup"
   . .github/setup_venv.sh clean
-  echo "::endgroup::"  # end group for "Python venv setup"
+  echo -e "\x3A:endgroup::"  # end group for "Python venv setup"
 
-  echo "::group::-> PYTEST RUN <-"
+  echo -e "\x3A:group::-> PYTEST RUN <-"
   export PATH="${PWD}/.bin":"$WORKDIR/cardano-cli/cardano-cli-build/bin":"$PATH"
   export CARDANO_NODE_SOCKET_PATH="$CARDANO_NODE_SOCKET_PATH_CI"
   make "${MAKE_TARGET:-"tests"}"
   retval="$?"
-  echo "::endgroup::"
+  echo -e "\x3A:endgroup::"
 
-  echo "::group::Collect artifacts"
+  echo -e "\x3A:group::Collect artifacts"
   ./.github/cli_coverage.sh
   ./.github/reqs_coverage.sh
   exit "$retval"
@@ -252,6 +252,6 @@ if [ -n "${GITHUB_ACTIONS:-""}" ]; then
   ls -1a
 fi
 
-echo "::endgroup::" # end group for "Collect artifacts"
+echo -e "\x3A:endgroup::" # end group for "Collect artifacts"
 
 exit "$retval"


### PR DESCRIPTION
Special keywords like "::endgroup::" in debug output seem to confuse GHA from time to time. Try to hide the keyword using hexadecimal representation.