### PR TITLE
refactor: turn xtrace off for CI scripts

### DIFF
--- a/.github/node_upgrade.sh
+++ b/.github/node_upgrade.sh
@@ -6,7 +6,7 @@
 # BASE_REVISION - revision of cardano-node to upgrade from (alternative to BASE_TAR_URL)
 # UPGRADE_REVISION - revision of cardano-node to upgrade to
 
-set -xeuo pipefail
+set -euo pipefail
 
 if [[ -z "${BASE_TAR_URL:-""}" && -z "${BASE_REVISION:-""}" ]]; then
   echo "BASE_TAR_URL or BASE_REVISION must be set"
@@ -58,10 +58,8 @@ export SCHEDULING_LOG=scheduling.log
 export DEV_CLUSTER_RUNNING=1 CLUSTERS_COUNT=1 FORBID_RESTART=1 TEST_THREADS=10 NUM_POOLS="${NUM_POOLS:-4}"
 unset ENABLE_LEGACY MIXED_P2P
 
-sets="$-"; set +x
 echo "::endgroup::"  # end group for "Script setup"
 echo "::group::Nix env setup step1"
-set -"$sets"
 
 printf "start: %(%H:%M:%S)T\n" -1
 
@@ -108,10 +106,8 @@ fi
 # retval 0 == all tests passed; 1 == some tests failed; > 1 == some runtime error and we don't want to continue
 [ "$retval" -le 1 ] || exit "$retval"
 
-sets="$-"; set +x
 echo "::endgroup::"  # end group for "-> PYTEST STEP1 <-"
 echo "::group::Nix env setup steps 2 & 3"
-set -"$sets"
 
 printf "start: %(%H:%M:%S)T\n" -1
 

--- a/.github/regression.sh
+++ b/.github/regression.sh
@@ -1,7 +1,7 @@
 #! /usr/bin/env -S nix develop --accept-flake-config .#base -c bash
 # shellcheck shell=bash disable=SC2317
 
-set -xeuo pipefail
+set -euo pipefail
 
 nix --version
 df -h .
@@ -149,10 +149,8 @@ _cleanup_testnet_on_interrupt() {
   _PYTEST_CURRENT="$(readlink -m "$_PYTEST_CURRENT")"
   export _PYTEST_CURRENT
 
-  sets="$-"; set +x
   echo "::endgroup::" # end group for the group that was interrupted
   echo "::group::Testnet cleanup"
-  set -"$sets"
 
   # shellcheck disable=SC2016
   nix develop --accept-flake-config .#venv --command bash -c '
@@ -165,9 +163,7 @@ _cleanup_testnet_on_interrupt() {
     testnet-cleanup -a "$_PYTEST_CURRENT"
   '
 
-  sets="$-"; set +x
   echo "::endgroup::"
-  set -"$sets"
 }
 
 # cleanup on Ctrl+C
@@ -179,10 +175,8 @@ _interrupted() {
 }
 trap 'set +e; _interrupted; exit 130' SIGINT
 
-sets="$-"; set +x
 echo "::endgroup::"  # end group for "Script setup"
 echo "::group::Nix env setup"
-set -"$sets"
 
 printf "start: %(%H:%M:%S)T\n" -1
 
@@ -230,13 +224,10 @@ mv .reports/testrun-report.* ./
 # Don't stop cluster instances just yet if KEEP_CLUSTERS_RUNNING is set to 1.
 # After any key is pressed, resume this script and stop all running cluster instances.
 if [ "${KEEP_CLUSTERS_RUNNING:-""}" = 1 ]; then
-  sets="$-"
-  set +x
   echo
   echo "KEEP_CLUSTERS_RUNNING is set, leaving clusters running until any key is pressed."
   echo "Press any key to continue..."
   read -r
-  set -"$sets"
 fi
 
 _cleanup


### PR DESCRIPTION
Attempt no. 8 to make GHA grouping work reliably for all workflows. Having debug output seems to confuse the GHA groups parser, and some of the debug output leaks out of the groups. I've tried several different attempts to mitigate this behavior, unsuccessfully. In this commit, I'm turning debug output off alltogether. The script is stable, we don't have much use for the debug output anyway.