### PR TITLE
refactor(ci): cleanup CI scripts output

### DIFF
--- a/.github/grep_errors.sh
+++ b/.github/grep_errors.sh
@@ -4,6 +4,6 @@ ARTIFACTS_DIR="${ARTIFACTS_DIR:-".artifacts"}"
 ERR_LOGFILE="$PWD/errors_all.log"
 
 # shellcheck disable=SC2012
-pushd "$ARTIFACTS_DIR" || { echo "Cannot switch to $ARTIFACTS_DIR"; ls -1a "$ARTIFACTS_DIR"; exit 1; } > "$ERR_LOGFILE"
+pushd "$ARTIFACTS_DIR" > /dev/null || { echo "Cannot switch to $ARTIFACTS_DIR"; ls -1a "$ARTIFACTS_DIR"; exit 1; } > "$ERR_LOGFILE"
 grep -r --include "*.stdout" --include "*.stderr" -Ei ":error:|failed|failure" . > "$ERR_LOGFILE"
-popd || exit 1
+popd > /dev/null || exit 1

--- a/.github/node_upgrade.sh
+++ b/.github/node_upgrade.sh
@@ -59,8 +59,8 @@ export DEV_CLUSTER_RUNNING=1 CLUSTERS_COUNT=1 FORBID_RESTART=1 TEST_THREADS=10 N
 unset ENABLE_LEGACY MIXED_P2P
 
 echo "::endgroup::"  # end group for "Script setup"
-echo "::group::Nix env setup step1"
 
+echo "::group::Nix env setup step1"
 printf "start: %(%H:%M:%S)T\n" -1
 
 # shellcheck disable=SC1090,SC1091
@@ -84,14 +84,15 @@ nix flake update --accept-flake-config $NODE_OVERRIDE
 # shellcheck disable=SC2016
 nix develop --accept-flake-config .#venv --command bash -c '
   : > "$WORKDIR/.nix_step1"
-  printf "finish: %(%H:%M:%S)T\n" -1
   echo "::endgroup::"  # end group for "Nix env setup step1"
 
   echo "::group::Python venv setup step1"
+  printf "start: %(%H:%M:%S)T\n" -1
   . .github/setup_venv.sh clean
   echo "::endgroup::"  # end group for "Python venv setup step1"
 
   echo "::group::-> PYTEST STEP1 <-"
+  printf "start: %(%H:%M:%S)T\n" -1
   df -h .
   # prepare scripts for stating cluster instance, start cluster instance, run smoke tests
   ./.github/node_upgrade_pytest.sh step1
@@ -107,8 +108,8 @@ fi
 [ "$retval" -le 1 ] || exit "$retval"
 
 echo "::endgroup::"  # end group for "-> PYTEST STEP1 <-"
-echo "::group::Nix env setup steps 2 & 3"
 
+echo "::group::Nix env setup steps 2 & 3"
 printf "start: %(%H:%M:%S)T\n" -1
 
 # update cardano-node to specified branch and/or revision, or to the latest available revision
@@ -123,14 +124,15 @@ nix flake update --accept-flake-config $NODE_OVERRIDE
 # shellcheck disable=SC2016
 nix develop --accept-flake-config .#venv --command bash -c '
   : > "$WORKDIR/.nix_step2"
-  printf "finish: %(%H:%M:%S)T\n" -1
   echo "::endgroup::"  # end group for "Nix env setup steps 2 & 3"
 
   echo "::group::Python venv setup steps 2 & 3"
+  printf "start: %(%H:%M:%S)T\n" -1
   . .github/setup_venv.sh clean
   echo "::endgroup::"  # end group for "Python venv setup steps 2 & 3"
 
   echo "::group::-> PYTEST STEP2 <-"
+  printf "start: %(%H:%M:%S)T\n" -1
   df -h .
   # update cluster nodes, run smoke tests
   ./.github/node_upgrade_pytest.sh step2
@@ -140,20 +142,21 @@ nix develop --accept-flake-config .#venv --command bash -c '
   echo "::endgroup::"  # end group for "-> PYTEST STEP2 <-"
 
   echo "::group::-> PYTEST STEP3 <-"
+  printf "start: %(%H:%M:%S)T\n" -1
   df -h .
   # update to Conway, run smoke tests
   ./.github/node_upgrade_pytest.sh step3
   retval="$?"
+  df -h .
   echo "::endgroup::"  # end group for "-> PYTEST STEP3 <-"
 
   echo "::group::Teardown cluster & collect artifacts"
+  printf "start: %(%H:%M:%S)T\n" -1
   # teardown cluster
   ./.github/node_upgrade_pytest.sh finish
   exit $retval
 '
 retval="$?"
-
-df -h .
 
 if [ ! -e "$WORKDIR/.nix_step2" ]; then
   echo "Nix env setup failed, exiting"

--- a/.github/source_dbsync.sh
+++ b/.github/source_dbsync.sh
@@ -7,6 +7,8 @@ export TEST_THREADS CLUSTERS_COUNT
 pushd "$WORKDIR" || exit 1
 
 stop_postgres() {
+  echo "Stopping postgres"
+
   local psql_pid_file="$WORKDIR/postgres/postgres.pid"
   if [ ! -f "$psql_pid_file" ]; then
     return 0


### PR DESCRIPTION
Removed multiple redundant `df -h .` commands from various CI scripts. Added a check for the existence of the `stop_postgres` command before attempting to stop PostgreSQL.