### PR TITLE
chore: remove missing nix inputs

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -4,15 +4,10 @@
   inputs = {
     cardano-node = {
       url = "github:IntersectMBO/cardano-node";
-      inputs = {
-        node-measured.follows = "cardano-node";
-        membench.follows = "/";
-      };
     };
     nixpkgs.follows = "cardano-node/nixpkgs";
     flake-utils = {
       url = "github:numtide/flake-utils";
-      inputs.nixpkgs.follows = "nixpkgs";
     };
   };
 


### PR DESCRIPTION
Removed old missing inputs from flake.nix to clean up the configuration.