### PR TITLE
chore(nix): remove python devshell from flake.nix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -47,9 +47,7 @@
 
   # --- Flake Local Nix Configuration ----------------------------
   nixConfig = {
-    # This sets the flake to use the IOG nix cache.
-    # Nix should ask for permission before using it,
-    # but remove it here if you do not want it to.
+    # Sets the flake to use the IOG nix cache.
     extra-substituters = [ "https://cache.iog.io" ];
     extra-trusted-public-keys = [ "hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ=" ];
     allow-import-from-derivation = "true";

--- a/flake.nix
+++ b/flake.nix
@@ -25,10 +25,6 @@
             base = pkgs.mkShell {
               nativeBuildInputs = with pkgs; [ bash coreutils curl git gnugrep gnumake gnutar jq xz ];
             };
-            # TODO: can be removed once sync tests are fully moved to separate repo
-            python = pkgs.mkShell {
-              nativeBuildInputs = with pkgs; with python39Packages; [ python39Full virtualenv pip matplotlib pandas requests xmltodict psutil GitPython pymysql ];
-            };
             postgres = pkgs.mkShell {
               nativeBuildInputs = with pkgs; [ glibcLocales postgresql lsof procps ];
             };


### PR DESCRIPTION
The python devshell has been removed from flake.nix as the sync tests are being fully moved to a separate repository. This change cleans up the flake configuration by removing the unnecessary python shell.