### PR TITLE
chore(ci): remove xtrace from node upgrade script

### DIFF
--- a/.github/node_upgrade_pytest.sh
+++ b/.github/node_upgrade_pytest.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -xuo pipefail
+set -uo pipefail
 
 retval=1
 


### PR DESCRIPTION
Removed the 'set -x' option from the node_upgrade_pytest.sh script to disable xtrace and reduce verbosity in CI output.