### PR TITLE
refactor(tests): remove unneeded fixtures in test files

### DIFF
--- a/cardano_node_tests/tests/test_blocks.py
+++ b/cardano_node_tests/tests/test_blocks.py
@@ -34,17 +34,11 @@ LOGGER = logging.getLogger(__name__)
 class TestLeadershipSchedule:
     """Tests for cardano-cli leadership-schedule."""
 
-    @pytest.fixture(scope="class")
-    def skip_leadership_schedule(self):
-        if not clusterlib_utils.cli_has("query leadership-schedule"):
-            pytest.skip("The `cardano-cli query leadership-schedule` command is not available.")
-
     @allure.link(helpers.get_vcs_link())
     @pytest.mark.needs_dbsync
     @pytest.mark.parametrize("for_epoch", ("current", "next"))
     def test_pool_blocks(
         self,
-        skip_leadership_schedule: None,  # noqa: ARG002
         cluster_manager: cluster_management.ClusterManager,
         cluster_use_pool: tp.Tuple[clusterlib.ClusterLib, str],
         for_epoch: str,
@@ -143,7 +137,6 @@ class TestLeadershipSchedule:
     @allure.link(helpers.get_vcs_link())
     def test_unstable_stake_distribution(
         self,
-        skip_leadership_schedule: None,  # noqa: ARG002
         cluster_manager: cluster_management.ClusterManager,
         cluster: clusterlib.ClusterLib,
     ):

--- a/cardano_node_tests/tests/tests_conway/test_hardfork.py
+++ b/cardano_node_tests/tests/tests_conway/test_hardfork.py
@@ -43,19 +43,10 @@ def pool_user_lg(
 class TestHardfork:
     """Tests for hard-fork."""
 
-    @pytest.fixture(scope="class")
-    def skip_hf_command(self):
-        if not clusterlib_utils.cli_has("conway governance action create-hardfork"):
-            pytest.skip(
-                "The `cardano-cli conway governance action create-hardfork` command "
-                "is not available."
-            )
-
     @allure.link(helpers.get_vcs_link())
     @pytest.mark.long
     def test_hardfork(
         self,
-        skip_hf_command: None,  # noqa: ARG002
         cluster_manager: cluster_management.ClusterManager,
         cluster_lock_governance: governance_utils.GovClusterT,
         pool_user_lg: clusterlib.PoolUser,


### PR DESCRIPTION
Removed unneeded fixtures `skip_leadership_schedule` and `skip_hf_command` from `test_blocks.py` and `test_hardfork.py` respectively. These fixtures were checking for the availability of certain CLI commands, which are available in all recent node versions.

This change simplifies the test code and removes unnecessary checks.