### PR TITLE
feat: add DB-Sync table names to error ignore list

### DIFF
--- a/cardano_node_tests/utils/logfiles.py
+++ b/cardano_node_tests/utils/logfiles.py
@@ -41,6 +41,10 @@ ERRORS_IGNORED = [
     "db-sync-node.*could not serialize access",
     # Can happen on p2p when node is shutting down
     "AsyncCancelled",
+    # DB-Sync table name
+    "OffChainPoolFetchError",
+    # DB-Sync table name
+    "OffChainVoteFetchError",
     # TODO: p2p failures on testnet
     "PeerStatusChangeFailure",
     # TODO: p2p failures on testnet - PeerMonitoringError


### PR DESCRIPTION
Added OffChainPoolFetchError and OffChainVoteFetchError to the list of ignored errors in logfiles.py. The table names are matching the searched error strings, but are not errors.