### PR TITLE
fix(submit_api): handle timeout and resubmit transaction

### DIFF
--- a/cardano_node_tests/utils/submit_api.py
+++ b/cardano_node_tests/utils/submit_api.py
@@ -5,7 +5,9 @@ import dataclasses
 import json
 import logging
 import pathlib as pl
+import random
 import shutil
+import time
 import typing as tp
 
 import requests
@@ -57,7 +59,19 @@ def post_cbor(cbor_file: clusterlib.FileType, url: str) -> requests.Response:
     headers = {"Content-Type": "application/cbor"}
     with open(cbor_file, "rb") as in_fp:
         cbor_binary = in_fp.read()
-        response = requests.post(url, headers=headers, data=cbor_binary, timeout=10)
+
+    for i in range(5):
+        delay = False
+        if i > 0:
+            LOGGER.warning("Resubmitting transaction to submit-api.")
+        try:
+            response = requests.post(url, headers=headers, data=cbor_binary, timeout=20)
+        except requests.exceptions.ReadTimeout:
+            delay = True
+        else:
+            break
+        if delay:
+            time.sleep(random.random())
     return response
 
 


### PR DESCRIPTION
- Added retry logic to handle request timeouts when posting CBOR data to the submit API.
- Introduced a delay with random sleep time between retries to avoid overwhelming the server.