### PR TITLE
fix(clusterlib_utils): handle witness_override condition

### DIFF
--- a/cardano_node_tests/utils/clusterlib_utils.py
+++ b/cardano_node_tests/utils/clusterlib_utils.py
@@ -96,7 +96,7 @@ def build_and_submit_tx(
         skip_asset_balancing = True if cli_asset_balancing is None else cli_asset_balancing
         witness_override = (
             len(tx_files.signing_key_files) + witness_count_add
-            if witness_override is None
+            if witness_override is None and witness_count_add > 0
             else witness_override
         )
         tx_output = cluster_obj.g_transaction.build_tx(


### PR DESCRIPTION
Ensure witness_override is only set when witness_count_add is greater than 0. This prevents unnecessary overrides and maintains expected behavior.