### PR TITLE
fix(issues): update fixed_in version for cli issue 904

### DIFF
--- a/cardano_node_tests/tests/issues.py
+++ b/cardano_node_tests/tests/issues.py
@@ -83,7 +83,7 @@ cli_860 = blockers.GH(
 cli_904 = blockers.GH(
     issue=904,
     repo="IntersectMBO/cardano-cli",
-    fixed_in="9.5.0.0",  # Fixed in some release after 9.4.1.0
+    fixed_in="10.1.2.1",  # Fixed in some release after 10.1.2.0
     message="Negative pparam proposal values overflow to positive.",
 )
 cli_942 = blockers.GH(


### PR DESCRIPTION
Updated the fixed_in version for the cli_904 issue in the cardano-cli repository from 9.5.0.0 to 10.1.2.1. The issue is already fixed in cardano-cli that was not released with cardano-node yet.