### PR TITLE
refactor: rename and refactor resource functions

### DIFF
--- a/cardano_node_tests/cluster_management/cluster_getter.py
+++ b/cardano_node_tests/cluster_management/cluster_getter.py
@@ -440,14 +440,14 @@ class ClusterGetter:
 
     def _resolve_resources_availability(self, cget_status: _ClusterGetStatus) -> bool:
         """Resolve availability of required "use" and "lock" resources."""
-        resources_locked = common._get_resources_from_paths(
+        resources_locked = common.get_resources_from_path(
             paths=cget_status.instance_dir.glob(f"{common.RESOURCE_LOCKED_GLOB}_*")
         )
 
         # This test wants to lock some resources, check if these are not in use
         res_lockable = []
         if cget_status.lock_resources:
-            resources_used = common._get_resources_from_paths(
+            resources_used = common.get_resources_from_path(
                 paths=cget_status.instance_dir.glob(f"{common.RESOURCE_IN_USE_GLOB}_*")
             )
             unlockable_resources = {*resources_locked, *resources_used}

--- a/cardano_node_tests/cluster_management/common.py
+++ b/cardano_node_tests/cluster_management/common.py
@@ -24,8 +24,18 @@ CLUSTER_START_CMDS_LOG = "start_cluster_cmds.log"
 
 ADDRS_DATA_DIRNAME = "addrs_data"
 
+RE_RESNAME = re.compile("_@@(.+)@@_")
 
-def _get_resources_from_paths(paths: tp.Iterator[pl.Path]) -> tp.List[str]:
+
+def _get_res(path: pl.Path) -> str:
+    out = RE_RESNAME.search(str(path))
+    if out is None:
+        err = f"Resource name not found in path: {path}"
+        raise ValueError(err)
+    return out.group(1)
+
+
+def get_resources_from_path(paths: tp.Iterator[pl.Path]) -> tp.List[str]:
     """Get resources names from status files path."""
-    resources = [re.search("_@@(.+)@@_", str(r)).group(1) for r in paths]  # type: ignore
+    resources = [_get_res(p) for p in paths]
     return resources

--- a/cardano_node_tests/cluster_management/manager.py
+++ b/cardano_node_tests/cluster_management/manager.py
@@ -296,7 +296,7 @@ class ClusterManager:
             msg = "`from_set` cannot be a string"
             raise AssertionError(msg)
 
-        resources_locked = set(common._get_resources_from_paths(paths=self.instance_dir.glob(glob)))
+        resources_locked = set(common.get_resources_from_path(paths=self.instance_dir.glob(glob)))
 
         if from_set is not None:
             return list(resources_locked.intersection(from_set))


### PR DESCRIPTION
Renamed `_get_resources_from_paths` to `get_resources_from_path` and refactored the function to use a helper function `_get_res` for better readability and maintainability.