### PR TITLE
feat: Mark use of Plutus and lock Plutus when changing pparams

### DIFF
--- a/cardano_node_tests/cluster_management/resources.py
+++ b/cardano_node_tests/cluster_management/resources.py
@@ -18,6 +18,7 @@ class Resources:
     )
     # Reserve one pool for all tests where the pool will stop producing blocks
     POOL_FOR_OFFLINE: tp.Final[str] = POOL2
+    PLUTUS: tp.Final[str] = "plutus"
     RESERVES: tp.Final[str] = "reserves"
     TREASURY: tp.Final[str] = "treasury"
     REWARDS: tp.Final[str] = "rewards"

--- a/cardano_node_tests/tests/tests_conway/conftest.py
+++ b/cardano_node_tests/tests/tests_conway/conftest.py
@@ -13,7 +13,7 @@ LOGGER = logging.getLogger(__name__)
 def cluster_use_committee(
     cluster_manager: cluster_management.ClusterManager,
 ) -> governance_utils.GovClusterT:
-    """Mark governance committee as "in use" and return instance of `clusterlib.ClusterLib`."""
+    """Mark governance committee as "in use"."""
     cluster_obj = cluster_manager.get(
         use_resources=[
             cluster_management.Resources.COMMITTEE,
@@ -29,7 +29,7 @@ def cluster_use_committee(
 def cluster_use_dreps(
     cluster_manager: cluster_management.ClusterManager,
 ) -> governance_utils.GovClusterT:
-    """Mark governance DReps as "in use" and return instance of `clusterlib.ClusterLib`."""
+    """Mark governance DReps as "in use"."""
     cluster_obj = cluster_manager.get(
         use_resources=[
             cluster_management.Resources.DREPS,
@@ -45,7 +45,7 @@ def cluster_use_dreps(
 def cluster_use_governance(
     cluster_manager: cluster_management.ClusterManager,
 ) -> governance_utils.GovClusterT:
-    """Mark governance as "in use" and return instance of `clusterlib.ClusterLib`."""
+    """Mark whole governance as "in use"."""
     cluster_obj = cluster_manager.get(
         use_resources=[
             cluster_management.Resources.COMMITTEE,
@@ -64,10 +64,30 @@ def cluster_use_governance(
 def cluster_lock_governance(
     cluster_manager: cluster_management.ClusterManager,
 ) -> governance_utils.GovClusterT:
-    """Mark governance as "locked" and return instance of `clusterlib.ClusterLib`."""
+    """Mark whole governance as "locked"."""
     cluster_obj = cluster_manager.get(
         use_resources=cluster_management.Resources.ALL_POOLS,
         lock_resources=[cluster_management.Resources.COMMITTEE, cluster_management.Resources.DREPS],
+    )
+    governance_data = governance_setup.get_default_governance(
+        cluster_manager=cluster_manager, cluster_obj=cluster_obj
+    )
+    governance_utils.wait_delayed_ratification(cluster_obj=cluster_obj)
+    return cluster_obj, governance_data
+
+
+@pytest.fixture
+def cluster_lock_governance_plutus(
+    cluster_manager: cluster_management.ClusterManager,
+) -> governance_utils.GovClusterT:
+    """Mark whole governance and Plutus as "locked"."""
+    cluster_obj = cluster_manager.get(
+        use_resources=cluster_management.Resources.ALL_POOLS,
+        lock_resources=[
+            cluster_management.Resources.COMMITTEE,
+            cluster_management.Resources.DREPS,
+            cluster_management.Resources.PLUTUS,
+        ],
     )
     governance_data = governance_setup.get_default_governance(
         cluster_manager=cluster_manager, cluster_obj=cluster_obj

--- a/cardano_node_tests/tests/tests_conway/test_constitution.py
+++ b/cardano_node_tests/tests/tests_conway/test_constitution.py
@@ -44,6 +44,7 @@ def cluster_lock_gov_script(
         use_resources=[
             *cluster_management.Resources.ALL_POOLS,
             cluster_management.Resources.REWARDS,
+            cluster_management.Resources.PLUTUS,
         ],
         lock_resources=[
             cluster_management.Resources.COMMITTEE,

--- a/cardano_node_tests/tests/tests_conway/test_guardrails.py
+++ b/cardano_node_tests/tests/tests_conway/test_guardrails.py
@@ -49,7 +49,10 @@ def cluster_guardrails(
     Cleanup (== respin the cluster instance) after the tests are finished.
     """
     cluster_obj = cluster_manager.get(
-        use_resources=cluster_management.Resources.ALL_POOLS,
+        use_resources=[
+            *cluster_management.Resources.ALL_POOLS,
+            cluster_management.Resources.PLUTUS,
+        ],
         lock_resources=[cluster_management.Resources.COMMITTEE, cluster_management.Resources.DREPS],
         cleanup=True,
     )

--- a/cardano_node_tests/tests/tests_conway/test_pparam_update.py
+++ b/cardano_node_tests/tests/tests_conway/test_pparam_update.py
@@ -200,13 +200,13 @@ class TestPParamUpdate:
     """Tests for protocol parameters update."""
 
     @pytest.fixture
-    def pool_user_lg(
+    def pool_user_lgp(
         self,
         cluster_manager: cluster_management.ClusterManager,
-        cluster_lock_governance: governance_utils.GovClusterT,
+        cluster_lock_governance_plutus: governance_utils.GovClusterT,
     ) -> clusterlib.PoolUser:
         """Create a pool user for "lock governance"."""
-        cluster, __ = cluster_lock_governance
+        cluster, __ = cluster_lock_governance_plutus
         key = helpers.get_current_line_str()
         name_template = common.get_test_id(cluster)
         return conway_common.get_registered_pool_user(
@@ -222,8 +222,10 @@ class TestPParamUpdate:
     @pytest.mark.dbsync
     def test_pparam_update(  # noqa: C901
         self,
-        cluster_lock_governance: governance_utils.GovClusterT,
-        pool_user_lg: clusterlib.PoolUser,
+        # The test is changing protocol parameters, so it is not safe to run Plutus tests at that
+        # time. It could e.g. lead to `PPViewHashesDontMatch` errors on transaction submits.
+        cluster_lock_governance_plutus: governance_utils.GovClusterT,
+        pool_user_lgp: clusterlib.PoolUser,
     ):
         """Test enactment of protocol parameter update.
 
@@ -246,7 +248,7 @@ class TestPParamUpdate:
           and enacted actions
         """
         # pylint: disable=too-many-locals,too-many-statements
-        cluster, governance_data = cluster_lock_governance
+        cluster, governance_data = cluster_lock_governance_plutus
         temp_template = common.get_test_id(cluster)
         cost_proposal_file = DATA_DIR / "cost_models_list_185_v2_v3.json"
         db_errors_final = []
@@ -256,7 +258,7 @@ class TestPParamUpdate:
             pytest.skip("The test doesn't work in bootstrap period without CC.")
 
         init_return_account_balance = cluster.g_query.get_stake_addr_info(
-            pool_user_lg.stake.address
+            pool_user_lgp.stake.address
         ).reward_account_balance
 
         # Check if total delegated stake is below the threshold. This can be used to check that
@@ -660,7 +662,7 @@ class TestPParamUpdate:
                 name_template=name_template,
                 anchor_url=anchor_url,
                 anchor_data_hash=anchor_data_hash,
-                pool_user=pool_user_lg,
+                pool_user=pool_user_lgp,
                 proposals=proposals,
                 prev_action_rec=prev_action_rec,
             )
@@ -707,7 +709,7 @@ class TestPParamUpdate:
                     cluster_obj=cluster,
                     governance_data=governance_data,
                     name_template=f"{temp_template}_net_nodrep_bootstrap",
-                    payment_addr=pool_user_lg.payment,
+                    payment_addr=pool_user_lgp.payment,
                     action_txid=net_nodrep_prop_rec.action_txid,
                     action_ix=net_nodrep_prop_rec.action_ix,
                     approve_cc=True,
@@ -723,7 +725,7 @@ class TestPParamUpdate:
                 cluster_obj=cluster,
                 governance_data=governance_data,
                 name_template=f"{temp_template}_net_nodrep",
-                payment_addr=pool_user_lg.payment,
+                payment_addr=pool_user_lgp.payment,
                 action_txid=net_nodrep_prop_rec.action_txid,
                 action_ix=net_nodrep_prop_rec.action_ix,
                 approve_cc=True,
@@ -755,7 +757,7 @@ class TestPParamUpdate:
                 cluster_obj=cluster,
                 governance_data=governance_data,
                 name_template=f"{temp_template}_net_nocc",
-                payment_addr=pool_user_lg.payment,
+                payment_addr=pool_user_lgp.payment,
                 action_txid=net_nocc_prop_rec.action_txid,
                 action_ix=net_nocc_prop_rec.action_ix,
                 approve_cc=False,
@@ -779,7 +781,7 @@ class TestPParamUpdate:
                 cluster_obj=cluster,
                 governance_data=governance_data,
                 name_template=f"{temp_template}_eco_nodrep",
-                payment_addr=pool_user_lg.payment,
+                payment_addr=pool_user_lgp.payment,
                 action_txid=eco_nodrep_prop_rec.action_txid,
                 action_ix=eco_nodrep_prop_rec.action_ix,
                 approve_cc=True,
@@ -809,7 +811,7 @@ class TestPParamUpdate:
                 cluster_obj=cluster,
                 governance_data=governance_data,
                 name_template=f"{temp_template}_eco_nocc",
-                payment_addr=pool_user_lg.payment,
+                payment_addr=pool_user_lgp.payment,
                 action_txid=eco_nocc_prop_rec.action_txid,
                 action_ix=eco_nocc_prop_rec.action_ix,
                 approve_cc=False,
@@ -839,7 +841,7 @@ class TestPParamUpdate:
                 cluster_obj=cluster,
                 governance_data=governance_data,
                 name_template=f"{temp_template}_fin_with_spos",
-                payment_addr=pool_user_lg.payment,
+                payment_addr=pool_user_lgp.payment,
                 action_txid=tech_nodrep_prop_rec.action_txid,
                 action_ix=tech_nodrep_prop_rec.action_ix,
                 approve_cc=False,
@@ -859,7 +861,7 @@ class TestPParamUpdate:
                 cluster_obj=cluster,
                 governance_data=governance_data,
                 name_template=f"{temp_template}_tech_nodrep",
-                payment_addr=pool_user_lg.payment,
+                payment_addr=pool_user_lgp.payment,
                 action_txid=tech_nodrep_prop_rec.action_txid,
                 action_ix=tech_nodrep_prop_rec.action_ix,
                 approve_cc=True,
@@ -885,7 +887,7 @@ class TestPParamUpdate:
                 cluster_obj=cluster,
                 governance_data=governance_data,
                 name_template=f"{temp_template}_tech_nocc",
-                payment_addr=pool_user_lg.payment,
+                payment_addr=pool_user_lgp.payment,
                 action_txid=tech_nocc_prop_rec.action_txid,
                 action_ix=tech_nocc_prop_rec.action_ix,
                 approve_cc=None,
@@ -911,7 +913,7 @@ class TestPParamUpdate:
             cluster_obj=cluster,
             governance_data=governance_data,
             name_template=f"{temp_template}_sec_nonespo",
-            payment_addr=pool_user_lg.payment,
+            payment_addr=pool_user_lgp.payment,
             action_txid=sec_nonespo_prop_rec.action_txid,
             action_ix=sec_nonespo_prop_rec.action_ix,
             approve_cc=True,
@@ -928,7 +930,7 @@ class TestPParamUpdate:
             cluster_obj=cluster,
             governance_data=governance_data,
             name_template=f"{temp_template}_sec_nospo",
-            payment_addr=pool_user_lg.payment,
+            payment_addr=pool_user_lgp.payment,
             action_txid=sec_nospo_prop_rec.action_txid,
             action_ix=sec_nospo_prop_rec.action_ix,
             approve_cc=True,
@@ -951,7 +953,7 @@ class TestPParamUpdate:
                 cluster_obj=cluster,
                 governance_data=governance_data,
                 name_template=f"{temp_template}_gov_nodrep",
-                payment_addr=pool_user_lg.payment,
+                payment_addr=pool_user_lgp.payment,
                 action_txid=gov_nodrep_prop_rec.action_txid,
                 action_ix=gov_nodrep_prop_rec.action_ix,
                 approve_cc=True,
@@ -981,7 +983,7 @@ class TestPParamUpdate:
                 cluster_obj=cluster,
                 governance_data=governance_data,
                 name_template=f"{temp_template}_gov_nocc",
-                payment_addr=pool_user_lg.payment,
+                payment_addr=pool_user_lgp.payment,
                 action_txid=gov_nocc_prop_rec.action_txid,
                 action_ix=gov_nocc_prop_rec.action_ix,
                 approve_cc=False,
@@ -1014,7 +1016,7 @@ class TestPParamUpdate:
                 cluster_obj=cluster,
                 governance_data=governance_data,
                 name_template=f"{temp_template}_mix_nodrep",
-                payment_addr=pool_user_lg.payment,
+                payment_addr=pool_user_lgp.payment,
                 action_txid=mix_nodrep_prop_rec.action_txid,
                 action_ix=mix_nodrep_prop_rec.action_ix,
                 approve_cc=True,
@@ -1057,7 +1059,7 @@ class TestPParamUpdate:
                 cluster_obj=cluster,
                 governance_data=governance_data,
                 name_template=f"{temp_template}_mix_nocc",
-                payment_addr=pool_user_lg.payment,
+                payment_addr=pool_user_lgp.payment,
                 action_txid=mix_nocc_prop_rec.action_txid,
                 action_ix=mix_nocc_prop_rec.action_ix,
                 approve_cc=False,
@@ -1082,7 +1084,7 @@ class TestPParamUpdate:
             cluster_obj=cluster,
             governance_data=governance_data,
             name_template=f"{temp_template}_fin_no",
-            payment_addr=pool_user_lg.payment,
+            payment_addr=pool_user_lgp.payment,
             action_txid=fin_prop_rec.action_txid,
             action_ix=fin_prop_rec.action_ix,
             approve_cc=False,
@@ -1097,7 +1099,7 @@ class TestPParamUpdate:
             cluster_obj=cluster,
             governance_data=governance_data,
             name_template=f"{temp_template}_fin_yes",
-            payment_addr=pool_user_lg.payment,
+            payment_addr=pool_user_lgp.payment,
             action_txid=fin_prop_rec.action_txid,
             action_ix=fin_prop_rec.action_ix,
             approve_cc=True,
@@ -1142,7 +1144,7 @@ class TestPParamUpdate:
             cluster_obj=cluster,
             governance_data=governance_data,
             name_template=f"{temp_template}_mix_approved",
-            payment_addr=pool_user_lg.payment,
+            payment_addr=pool_user_lgp.payment,
             action_txid=mix_approved_prop_rec.action_txid,
             action_ix=mix_approved_prop_rec.action_ix,
             approve_cc=True,
@@ -1178,7 +1180,7 @@ class TestPParamUpdate:
                 cluster_obj=cluster,
                 governance_data=governance_data,
                 name_template=f"{temp_template}_after_ratification",
-                payment_addr=pool_user_lg.payment,
+                payment_addr=pool_user_lgp.payment,
                 action_txid=fin_prop_rec.action_txid,
                 action_ix=fin_prop_rec.action_ix,
                 approve_cc=False,
@@ -1261,7 +1263,7 @@ class TestPParamUpdate:
                 cluster_obj=cluster,
                 governance_data=governance_data,
                 name_template=f"{temp_template}_enacted",
-                payment_addr=pool_user_lg.payment,
+                payment_addr=pool_user_lgp.payment,
                 action_txid=fin_prop_rec.action_txid,
                 action_ix=fin_prop_rec.action_ix,
                 approve_cc=False,
@@ -1275,7 +1277,7 @@ class TestPParamUpdate:
         # (all the remaining pparam proposals in our case).
         deposit_amt = cluster.conway_genesis["govActionDeposit"]
         total_deposit_return = cluster.g_query.get_stake_addr_info(
-            pool_user_lg.stake.address
+            pool_user_lgp.stake.address
         ).reward_account_balance
         # Check total deposit return accounting for both expired and enacted actions
         assert (
@@ -1291,7 +1293,7 @@ class TestPParamUpdate:
 
         try:
             dbsync_utils.check_proposal_refunds(
-                stake_address=pool_user_lg.stake.address, refunds_num=submitted_proposal_count
+                stake_address=pool_user_lgp.stake.address, refunds_num=submitted_proposal_count
             )
         except AssertionError as exc:
             db_errors_final.append(f"db-sync proposal refunds error: {exc}")

--- a/cardano_node_tests/tests/tests_plutus/conftest.py
+++ b/cardano_node_tests/tests/tests_plutus/conftest.py
@@ -1,0 +1,16 @@
+import logging
+
+import pytest
+from cardano_clusterlib import clusterlib
+
+from cardano_node_tests.cluster_management import cluster_management
+
+LOGGER = logging.getLogger(__name__)
+
+
+@pytest.fixture
+def cluster(
+    cluster_manager: cluster_management.ClusterManager,
+) -> clusterlib.ClusterLib:
+    """Return instance of `clusterlib.ClusterLib`."""
+    return cluster_manager.get(use_resources=[cluster_management.Resources.PLUTUS])

--- a/cardano_node_tests/tests/tests_plutus/test_delegation.py
+++ b/cardano_node_tests/tests/tests_plutus/test_delegation.py
@@ -58,6 +58,7 @@ def cluster_lock_42stake(
         use_resources=[
             resources_management.OneOf(resources=cluster_management.Resources.ALL_POOLS),
             cluster_management.Resources.REWARDS,
+            cluster_management.Resources.PLUTUS,
         ],
     )
     pool_name = cluster_manager.get_used_resources(from_set=cluster_management.Resources.ALL_POOLS)[

--- a/cardano_node_tests/tests/tests_plutus_v2/conftest.py
+++ b/cardano_node_tests/tests/tests_plutus_v2/conftest.py
@@ -1,0 +1,16 @@
+import logging
+
+import pytest
+from cardano_clusterlib import clusterlib
+
+from cardano_node_tests.cluster_management import cluster_management
+
+LOGGER = logging.getLogger(__name__)
+
+
+@pytest.fixture
+def cluster(
+    cluster_manager: cluster_management.ClusterManager,
+) -> clusterlib.ClusterLib:
+    """Return instance of `clusterlib.ClusterLib`."""
+    return cluster_manager.get(use_resources=[cluster_management.Resources.PLUTUS])


### PR DESCRIPTION
The hash of current protocol parameters is passed to Plutus scripts, and pparams change after the transaction was built will lead to `PPViewHashesDontMatch` error on tx submit. Therefore we need to mark usage of Plutus scripts, and "lock" Plutus whenewer we are changing pparams.