### PR TITLE
refactor: replace `send_funds` with `send_tx`

### DIFF
--- a/cardano_node_tests/tests/test_native_tokens.py
+++ b/cardano_node_tests/tests/test_native_tokens.py
@@ -1734,24 +1734,24 @@ class TestTransfer:
         src_address = new_token.token_mint_addr.address
         dst_address = payment_addrs[2].address
 
-        ma_destinations = [
+        ma_txouts = [
             clusterlib.TxOut(address=dst_address, amount=amount, coin=new_token.token),
         ]
 
         # Destinations with both native token and Lovelace (it doesn't matter on the amounts) for
         # calculating minimum required Lovelace value for tx output
-        calc_destinations = [
-            *ma_destinations,
+        calc_txouts = [
+            *ma_txouts,
             clusterlib.TxOut(address=dst_address, amount=2_000_000),
         ]
 
-        min_value = cluster.g_transaction.calculate_min_req_utxo(txouts=calc_destinations)
+        min_value = cluster.g_transaction.calculate_min_req_utxo(txouts=calc_txouts)
         assert min_value.coin.lower() in (clusterlib.DEFAULT_COIN, "coin")
         assert min_value.value, "No Lovelace required for `min-ada-value`"
         amount_lovelace = min_value.value
 
-        destinations = [
-            *ma_destinations,
+        txouts = [
+            *ma_txouts,
             clusterlib.TxOut(address=dst_address, amount=amount_lovelace),
         ]
 
@@ -1759,7 +1759,7 @@ class TestTransfer:
 
         if use_build_cmd:
             # TODO: add ADA txout for change address - see node issue #3057
-            destinations.append(clusterlib.TxOut(address=src_address, amount=2_000_000))
+            txouts.append(clusterlib.TxOut(address=src_address, amount=2_000_000))
 
             if VERSIONS.transaction_era == VERSIONS.ALONZO:
                 err_str = ""
@@ -1767,7 +1767,7 @@ class TestTransfer:
                     cluster.g_transaction.build_tx(
                         src_address=src_address,
                         tx_name=temp_template,
-                        txouts=destinations,
+                        txouts=txouts,
                         fee_buffer=2_000_000,
                         tx_files=tx_files,
                     )
@@ -1782,8 +1782,8 @@ class TestTransfer:
                 min_reported_utxo = _min_reported_utxo.group(1)
                 amount_lovelace = int(min_reported_utxo)
 
-                destinations = [
-                    *ma_destinations,
+                txouts = [
+                    *ma_txouts,
                     clusterlib.TxOut(address=dst_address, amount=amount_lovelace),
                     clusterlib.TxOut(address=src_address, amount=2_000_000),
                 ]
@@ -1791,7 +1791,7 @@ class TestTransfer:
             tx_raw_output = cluster.g_transaction.build_tx(
                 src_address=src_address,
                 tx_name=temp_template,
-                txouts=destinations,
+                txouts=txouts,
                 fee_buffer=2_000_000,
                 tx_files=tx_files,
             )
@@ -1802,10 +1802,10 @@ class TestTransfer:
             )
             cluster.g_transaction.submit_tx(tx_file=tx_signed, txins=tx_raw_output.txins)
         else:
-            tx_raw_output = cluster.g_transaction.send_funds(
+            tx_raw_output = cluster.g_transaction.send_tx(
                 src_address=src_address,
-                destinations=destinations,
                 tx_name=temp_template,
+                txouts=txouts,
                 tx_files=tx_files,
             )
 
@@ -1880,44 +1880,44 @@ class TestTransfer:
         dst_address1 = payment_addrs[1].address
         dst_address2 = payment_addrs[2].address
 
-        ma_destinations_address1 = []
-        ma_destinations_address2 = []
+        ma_txouts_address1 = []
+        ma_txouts_address2 = []
         for t in new_tokens:
-            ma_destinations_address1.append(
+            ma_txouts_address1.append(
                 clusterlib.TxOut(address=dst_address1, amount=amount, coin=t.token)
             )
-            ma_destinations_address2.append(
+            ma_txouts_address2.append(
                 clusterlib.TxOut(address=dst_address2, amount=amount, coin=t.token)
             )
 
         # Destinations with both native token and Lovelace (it doesn't matter on the amounts) for
         # calculating minimum required Lovelace value for tx output
-        calc_destinations_address1 = [
-            *ma_destinations_address1,
+        calc_txouts_address1 = [
+            *ma_txouts_address1,
             clusterlib.TxOut(address=dst_address1, amount=2_000_000),
         ]
-        calc_destinations_address2 = [
-            *ma_destinations_address2,
+        calc_txouts_address2 = [
+            *ma_txouts_address2,
             clusterlib.TxOut(address=dst_address2, amount=2_000_000),
         ]
 
         min_value_address1 = cluster.g_transaction.calculate_min_req_utxo(
-            txouts=calc_destinations_address1
+            txouts=calc_txouts_address1
         )
         assert min_value_address1.coin.lower() in (clusterlib.DEFAULT_COIN, "coin")
         assert min_value_address1.value, "No Lovelace required for `min-ada-value`"
         amount_lovelace_address1 = min_value_address1.value
 
         min_value_address2 = cluster.g_transaction.calculate_min_req_utxo(
-            txouts=calc_destinations_address2
+            txouts=calc_txouts_address2
         )
         assert min_value_address2.value, "No Lovelace required for `min-ada-value`"
         amount_lovelace_address2 = min_value_address2.value
 
-        destinations = [
-            *ma_destinations_address1,
+        txouts = [
+            *ma_txouts_address1,
             clusterlib.TxOut(address=dst_address1, amount=amount_lovelace_address1),
-            *ma_destinations_address2,
+            *ma_txouts_address2,
             clusterlib.TxOut(address=dst_address2, amount=amount_lovelace_address2),
         ]
 
@@ -1927,7 +1927,7 @@ class TestTransfer:
 
         if use_build_cmd:
             # TODO: add ADA txout for change address
-            destinations.append(clusterlib.TxOut(address=src_address, amount=4_000_000))
+            txouts.append(clusterlib.TxOut(address=src_address, amount=4_000_000))
 
             # TODO: see node issue #4297
             if VERSIONS.transaction_era == VERSIONS.ALONZO:
@@ -1936,7 +1936,7 @@ class TestTransfer:
                     cluster.g_transaction.build_tx(
                         src_address=src_address,
                         tx_name=temp_template,
-                        txouts=destinations,
+                        txouts=txouts,
                         fee_buffer=2_000_000,
                         tx_files=tx_files,
                     )
@@ -1951,10 +1951,10 @@ class TestTransfer:
                 min_reported_utxo = _min_reported_utxo.group(1)
                 amount_lovelace_address1 = amount_lovelace_address2 = int(min_reported_utxo)
 
-                destinations = [
-                    *ma_destinations_address1,
+                txouts = [
+                    *ma_txouts_address1,
                     clusterlib.TxOut(address=dst_address1, amount=amount_lovelace_address1),
-                    *ma_destinations_address2,
+                    *ma_txouts_address2,
                     clusterlib.TxOut(address=dst_address2, amount=amount_lovelace_address2),
                     clusterlib.TxOut(address=src_address, amount=4_000_000),
                 ]
@@ -1962,7 +1962,7 @@ class TestTransfer:
             tx_raw_output = cluster.g_transaction.build_tx(
                 src_address=src_address,
                 tx_name=temp_template,
-                txouts=destinations,
+                txouts=txouts,
                 fee_buffer=2_000_000,
                 tx_files=tx_files,
             )
@@ -1973,10 +1973,10 @@ class TestTransfer:
             )
             cluster.g_transaction.submit_tx(tx_file=tx_signed, txins=tx_raw_output.txins)
         else:
-            tx_raw_output = cluster.g_transaction.send_funds(
+            tx_raw_output = cluster.g_transaction.send_tx(
                 src_address=src_address,
-                destinations=destinations,
                 tx_name=temp_template,
+                txouts=txouts,
                 tx_files=tx_files,
             )
 
@@ -2043,19 +2043,19 @@ class TestTransfer:
         src_address = new_token.token_mint_addr.address
         dst_address = payment_addrs[2].address
 
-        destinations = [clusterlib.TxOut(address=dst_address, amount=amount, coin=new_token.token)]
+        txouts = [clusterlib.TxOut(address=dst_address, amount=amount, coin=new_token.token)]
         tx_files = clusterlib.TxFiles(signing_key_files=[new_token.token_mint_addr.skey_file])
 
         if use_build_cmd:
             expected_error = "Minimum required UTxO:"
             # TODO: add ADA txout for change address
-            destinations.append(clusterlib.TxOut(address=src_address, amount=3500_000))
+            txouts.append(clusterlib.TxOut(address=src_address, amount=3500_000))
 
             with pytest.raises(clusterlib.CLIError) as excinfo:
                 cluster.g_transaction.build_tx(
                     src_address=src_address,
                     tx_name=temp_template,
-                    txouts=destinations,
+                    txouts=txouts,
                     fee_buffer=2_000_000,
                     tx_files=tx_files,
                 )
@@ -2064,10 +2064,10 @@ class TestTransfer:
             expected_error = "OutputTooSmallUTxO"
 
             try:
-                cluster.g_transaction.send_funds(
+                cluster.g_transaction.send_tx(
                     src_address=src_address,
-                    destinations=destinations,
                     tx_name=temp_template,
+                    txouts=txouts,
                     tx_files=tx_files,
                 )
             except clusterlib.CLIError as err:
@@ -2098,14 +2098,14 @@ class TestTransfer:
         src_address = new_token.token_mint_addr.address
         dst_address = payment_addrs[2].address
 
-        ma_destinations = [
+        ma_txouts = [
             clusterlib.TxOut(address=dst_address, amount=token_amount, coin=new_token.token),
         ]
 
         min_amount_lovelace = 4_000_000
 
-        destinations = [
-            *ma_destinations,
+        txouts = [
+            *ma_txouts,
             clusterlib.TxOut(address=dst_address, amount=min_amount_lovelace),
         ]
 
@@ -2114,16 +2114,14 @@ class TestTransfer:
         if use_build_cmd:
             with pytest.raises(clusterlib.CLIError) as excinfo:
                 # Add ADA txout for change address - see node issue #3057
-                destinations.append(
-                    clusterlib.TxOut(address=src_address, amount=min_amount_lovelace)
-                )
+                txouts.append(clusterlib.TxOut(address=src_address, amount=min_amount_lovelace))
 
                 try:
                     logging.disable(logging.ERROR)
                     cluster.g_transaction.build_tx(
                         src_address=src_address,
                         tx_name=temp_template,
-                        txouts=destinations,
+                        txouts=txouts,
                         fee_buffer=2_000_000,
                         tx_files=tx_files,
                     )
@@ -2140,9 +2138,9 @@ class TestTransfer:
             with pytest.raises(clusterlib.CLIError) as excinfo:
                 try:
                     logging.disable(logging.ERROR)
-                    cluster.g_transaction.send_funds(
+                    cluster.g_transaction.send_tx(
                         src_address=src_address,
-                        destinations=destinations,
+                        txouts=txouts,
                         tx_name=temp_template,
                         tx_files=tx_files,
                         fee=80_000,

--- a/cardano_node_tests/tests/test_staking_no_rewards.py
+++ b/cardano_node_tests/tests/test_staking_no_rewards.py
@@ -266,14 +266,14 @@ class TestNoRewards:
         pledge_amount = loaded_data.pool_pledge // 2
 
         # Withdraw part of the pledge
-        destinations = [
+        txouts = [
             clusterlib.TxOut(address=delegation_out.pool_user.payment.address, amount=pledge_amount)
         ]
         tx_files = clusterlib.TxFiles(signing_key_files=[pool_owner.payment.skey_file])
-        cluster.g_transaction.send_funds(
+        cluster.g_transaction.send_tx(
             src_address=pool_owner.payment.address,
-            destinations=destinations,
             tx_name=f"{temp_template}_withdraw_pledge",
+            txouts=txouts,
             tx_files=tx_files,
         )
 
@@ -325,7 +325,7 @@ class TestNoRewards:
             )
 
             # Return pledge
-            destinations = [
+            txouts = [
                 clusterlib.TxOut(
                     address=pool_owner.payment.address, amount=pledge_amount + 100_000_000
                 )
@@ -333,10 +333,10 @@ class TestNoRewards:
             tx_files = clusterlib.TxFiles(
                 signing_key_files=[delegation_out.pool_user.payment.skey_file]
             )
-            cluster.g_transaction.send_funds(
+            cluster.g_transaction.send_tx(
                 src_address=delegation_out.pool_user.payment.address,
-                destinations=destinations,
                 tx_name=f"{temp_template}_return_pledge",
+                txouts=txouts,
                 tx_files=tx_files,
             )
 

--- a/cardano_node_tests/tests/test_tx_fees.py
+++ b/cardano_node_tests/tests/test_tx_fees.py
@@ -87,14 +87,14 @@ class TestFee:
         src_address = payment_addrs[0].address
         dst_address = payment_addrs[1].address
 
-        destinations = [clusterlib.TxOut(address=dst_address, amount=10)]
+        txouts = [clusterlib.TxOut(address=dst_address, amount=10)]
         tx_files = clusterlib.TxFiles(signing_key_files=[payment_addrs[0].skey_file])
 
         with pytest.raises(clusterlib.CLIError) as excinfo:
-            cluster.g_transaction.send_funds(
+            cluster.g_transaction.send_tx(
                 src_address=src_address,
-                destinations=destinations,
                 tx_name=temp_template,
+                txouts=txouts,
                 tx_files=tx_files,
                 fee=fee,
             )
@@ -119,7 +119,7 @@ class TestFee:
         src_address = payment_addrs[0].address
         dst_address = payment_addrs[1].address
 
-        destinations = [clusterlib.TxOut(address=dst_address, amount=10)]
+        txouts = [clusterlib.TxOut(address=dst_address, amount=10)]
         tx_files = clusterlib.TxFiles(signing_key_files=[payment_addrs[0].skey_file])
 
         fee = 0.0
@@ -128,17 +128,17 @@ class TestFee:
                 cluster.g_transaction.calculate_tx_fee(
                     src_address=src_address,
                     tx_name=temp_template,
-                    txouts=destinations,
+                    txouts=txouts,
                     tx_files=tx_files,
                 )
                 / fee_change
             )
 
         with pytest.raises(clusterlib.CLIError) as excinfo:
-            cluster.g_transaction.send_funds(
+            cluster.g_transaction.send_tx(
                 src_address=src_address,
-                destinations=destinations,
                 tx_name=temp_template,
+                txouts=txouts,
                 tx_files=tx_files,
                 fee=int(fee),
             )
@@ -161,22 +161,22 @@ class TestFee:
         src_address = payment_addrs[0].address
         dst_address = payment_addrs[1].address
 
-        destinations = [clusterlib.TxOut(address=dst_address, amount=amount)]
+        txouts = [clusterlib.TxOut(address=dst_address, amount=amount)]
         tx_files = clusterlib.TxFiles(signing_key_files=[payment_addrs[0].skey_file])
         fee = (
             cluster.g_transaction.calculate_tx_fee(
                 src_address=src_address,
                 tx_name=temp_template,
-                txouts=destinations,
+                txouts=txouts,
                 tx_files=tx_files,
             )
             + fee_add
         )
 
-        tx_raw_output = cluster.g_transaction.send_funds(
+        tx_raw_output = cluster.g_transaction.send_tx(
             src_address=src_address,
-            destinations=destinations,
             tx_name=temp_template,
+            txouts=txouts,
             tx_files=tx_files,
             fee=fee,
         )

--- a/cardano_node_tests/utils/faucet.py
+++ b/cardano_node_tests/utils/faucet.py
@@ -38,12 +38,12 @@ def fund_from_faucet(
     if isinstance(amount, int):
         amount = [amount] * len(dst_addr_records)
 
-    fund_dst = [
+    fund_txouts = [
         clusterlib.TxOut(address=d.address, amount=a)
         for d, a in zip(dst_addr_records, amount)
         if force or cluster_obj.g_query.get_address_balance(d.address) < a
     ]
-    if not fund_dst:
+    if not fund_txouts:
         return None
 
     if not faucet_data and all_faucets:
@@ -59,10 +59,10 @@ def fund_from_faucet(
         tx_name = f"{tx_name}_funding"
         fund_tx_files = clusterlib.TxFiles(signing_key_files=[faucet_data["payment"].skey_file])
 
-        tx_raw_output = cluster_obj.g_transaction.send_funds(
+        tx_raw_output = cluster_obj.g_transaction.send_tx(
             src_address=src_address,
-            destinations=fund_dst,
             tx_name=tx_name,
+            txouts=fund_txouts,
             tx_files=fund_tx_files,
             destination_dir=destination_dir,
         )
@@ -91,14 +91,14 @@ def return_funds_to_faucet(
         try:
             logging.disable(logging.ERROR)
             for addr, amount_rec in zip(src_addrs, amount):
-                fund_dst = [clusterlib.TxOut(address=faucet_addr, amount=amount_rec)]
+                fund_txouts = [clusterlib.TxOut(address=faucet_addr, amount=amount_rec)]
                 fund_tx_files = clusterlib.TxFiles(signing_key_files=[addr.skey_file])
                 # Try to return funds; don't mind if there's not enough funds for fees etc.
                 with contextlib.suppress(Exception):
-                    cluster_obj.g_transaction.send_funds(
+                    cluster_obj.g_transaction.send_tx(
                         src_address=addr.address,
-                        destinations=fund_dst,
                         tx_name=tx_name,
+                        txouts=fund_txouts,
                         tx_files=fund_tx_files,
                         destination_dir=destination_dir,
                     )


### PR DESCRIPTION
Updated method calls from `send_funds` to `send_tx`. The `send_funds` will be deprecated in clusterlib.
Renamed variables in for better clarity and consistency. Replaced 'destinations' with 'txouts' and 'ma_destinations' with 'ma_txouts'.