### PR TITLE
fix(tests): update error assertions for CLI 10.1.1.0+

### DIFF
--- a/cardano_node_tests/tests/test_tx_unbalanced.py
+++ b/cardano_node_tests/tests/test_tx_unbalanced.py
@@ -57,8 +57,9 @@ class TestUnbalanced:
 
         if amount < 0:
             assert (
-                "Negative quantity" in err_str
-                or "Illegal Value in TxOut" in err_str  # In node version 9.2.0+
+                "Value must be positive in UTxO" in err_str  # In cli 10.1.1.0+
+                or "Illegal Value in TxOut" in err_str  # In node 9.2.0+
+                or "Negative quantity" in err_str
             ), err_str
         else:
             assert "Minimum UTxO threshold not met for tx output" in err_str, err_str
@@ -491,6 +492,7 @@ class TestUnbalanced:
             cluster.cli(build_args)
         err_str_build = str(excinfo_build.value)
         assert (
-            "Negative quantity" in err_str_build
+            "Value must be positive in UTxO" in err_str_build  # In cli 10.1.1.0+
             or "Illegal Value in TxOut" in err_str_build  # In node 9.2.0+
+            or "Negative quantity" in err_str_build
         ), err_str_build

--- a/cardano_node_tests/tests/tests_plutus/test_mint_negative_build.py
+++ b/cardano_node_tests/tests/tests_plutus/test_mint_negative_build.py
@@ -279,8 +279,10 @@ class TestBuildMintingNegative:
 
         err_str = str(excinfo.value)
         assert (
-            "expected a script in the Plutus script language, but it is actually "
-            "using SimpleScriptLanguage" in err_str
+            'Error in $: key "description" not found' in err_str  # In cli 10.1.1.0+
+            or "expected a script in the Plutus script language, but it is actually "
+            "using SimpleScriptLanguage"
+            in err_str
         ), err_str
 
     @allure.link(helpers.get_vcs_link())
@@ -463,7 +465,10 @@ class TestBuildMintingNegative:
                 txins=mint_utxos,
                 txouts=txouts_step2,
                 mint=plutus_mint_data,
-                invalid_hereafter=None,  # required validity interval is missing here
+                invalid_hereafter=None,  # Required validity interval is missing here
             )
         err_str = str(excinfo.value)
-        assert "Plutus script evaluation failed" in err_str, err_str
+        assert (
+            "following scripts have execution failures" in err_str  # In cli 10.1.1.0+
+            or "Plutus script evaluation failed" in err_str
+        ), err_str

--- a/cardano_node_tests/tests/tests_plutus/test_spend_build.py
+++ b/cardano_node_tests/tests/tests_plutus/test_spend_build.py
@@ -691,7 +691,10 @@ class TestBuildLocking:
             amount=2_000_000,
             expect_failure=True,
         )
-        assert "The Plutus script evaluation failed" in err, err
+        assert (
+            "following scripts have execution failures" in err  # In cli 10.1.1.0+
+            or "The Plutus script evaluation failed" in err
+        ), err
 
         # Check expected fees
         expected_fee_fund = 168_845

--- a/cardano_node_tests/tests/tests_plutus/test_spend_negative_build.py
+++ b/cardano_node_tests/tests/tests_plutus/test_spend_negative_build.py
@@ -384,7 +384,10 @@ class TestNegative:
             )
 
         err_str = str(excinfo.value)
-        assert "The Plutus script evaluation failed" in err_str, err_str
+        assert (
+            "following scripts have execution failures" in err_str  # In cli 10.1.1.0+
+            or "Plutus script evaluation failed" in err_str
+        ), err_str
 
     @allure.link(helpers.get_vcs_link())
     @common.PARAM_PLUTUS3_VERSION
@@ -538,7 +541,10 @@ class TestNegative:
             )
 
         err_str = str(excinfo.value)
-        assert "The Plutus script evaluation failed" in err_str, err_str
+        assert (
+            "following scripts have execution failures" in err_str  # In cli 10.1.1.0+
+            or "Plutus script evaluation failed" in err_str
+        ), err_str
 
 
 class TestNegativeRedeemer:
@@ -716,7 +722,10 @@ class TestNegativeRedeemer:
             )
 
         err_str = str(excinfo.value)
-        assert "The Plutus script evaluation failed" in err_str, err_str
+        assert (
+            "following scripts have execution failures" in err_str  # In cli 10.1.1.0+
+            or "Plutus script evaluation failed" in err_str
+        ), err_str
 
     @allure.link(helpers.get_vcs_link())
     @hypothesis.given(redeemer_value=st.integers(min_value=common.MAX_UINT64 + 1))
@@ -846,7 +855,7 @@ class TestNegativeRedeemer:
             )
 
         err_str = str(excinfo.value)
-        assert "Script debugging logs: Incorrect datum. Expected 42." in err_str, err_str
+        assert "logs: Incorrect datum. Expected 42." in err_str, err_str
 
     @allure.link(helpers.get_vcs_link())
     @hypothesis.given(redeemer_value=st.binary(min_size=65))

--- a/cardano_node_tests/tests/tests_plutus_v2/test_spend_ref_scripts_build.py
+++ b/cardano_node_tests/tests/tests_plutus_v2/test_spend_ref_scripts_build.py
@@ -891,7 +891,10 @@ class TestNegativeReferenceScripts:
                 script_txins=plutus_txins,
             )
         err_str = str(excinfo.value)
-        assert "The Plutus script evaluation failed" in err_str, err_str
+        assert (
+            "following scripts have execution failures" in err_str  # In cli 10.1.1.0+
+            or "Plutus script evaluation failed" in err_str
+        ), err_str
 
     @allure.link(helpers.get_vcs_link())
     @pytest.mark.smoke


### PR DESCRIPTION
Updated error assertions in various test files to accommodate new error messages introduced in CLI version 10.1.1.0+. This ensures compatibility with both older and newer versions of the CLI.

- Updated test_tx_unbalanced.py to check for "Value must be positive in UTxO"
- Updated test_mint_negative_build.py to check for new error messages
- Updated test_spend_build.py to handle new execution failure messages
- Updated test_spend_negative_build.py to include new error assertions
- Updated test_spend_ref_scripts_build.py to check for new error messages