### PR TITLE
chore: update pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@ repos:
   - id: debug-statements
     language_version: python3
 - repo: https://github.com/charliermarsh/ruff-pre-commit
-  rev: v0.7.3
+  rev: v0.8.3
   hooks:
     - id: ruff
       args: [ --fix ]
@@ -24,7 +24,7 @@ repos:
   hooks:
   - id: shellcheck
 - repo: https://github.com/igorshubovych/markdownlint-cli
-  rev: v0.42.0
+  rev: v0.43.0
   hooks:
   - id: markdownlint
 - repo: https://github.com/rstcheck/rstcheck

--- a/cardano_node_tests/cluster_management/manager.py
+++ b/cardano_node_tests/cluster_management/manager.py
@@ -100,9 +100,10 @@ class ClusterManager:
         if not configuration.SCHEDULING_LOG:
             return
 
-        with locking.FileLockIfXdist(self.log_lock), open(
-            configuration.SCHEDULING_LOG, "a", encoding="utf-8"
-        ) as logfile:
+        with (
+            locking.FileLockIfXdist(self.log_lock),
+            open(configuration.SCHEDULING_LOG, "a", encoding="utf-8") as logfile,
+        ):
             logfile.write(
                 f"{datetime.datetime.now(tz=datetime.timezone.utc)} on {self.worker_id}: {msg}\n"
             )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,7 +85,7 @@ line-length = 100
 
 [tool.ruff.lint]
 select = ["ARG", "B", "C4", "C90", "D", "DTZ", "E", "EM", "F", "I001", "ISC", "N", "PIE", "PL", "PLE", "PLR", "PLW", "PT", "PTH", "Q", "RET", "RSE", "RUF", "SIM", "TRY", "UP", "W", "YTT"]
-ignore = ["B905", "D10", "D203", "D212", "D213", "D214", "D215", "D404", "D405", "D406", "D407", "D408", "D409", "D410", "D411", "D413", "ISC001", "PLR0912", "PLR0913", "PLR0915", "PLR2004", "PT001", "PT004", "PT007", "PT012", "PT018", "PT023", "PTH123", "RET504", "TRY002", "TRY301", "UP006", "UP007", "UP035"]
+ignore = ["B905", "D10", "D203", "D212", "D213", "D214", "D215", "D404", "D405", "D406", "D407", "D408", "D409", "D410", "D411", "D413", "ISC001", "PLR0912", "PLR0913", "PLR0915", "PLR2004", "PT001", "PT007", "PT012", "PT018", "PT023", "PTH123", "RET504", "TRY002", "TRY301", "UP006", "UP007", "UP035"]
 
 [tool.ruff.lint.per-file-ignores]
 "cardano_node_tests/utils/model_ekg.py" = ["N815"]


### PR DESCRIPTION
- Update ruff-pre-commit to v0.8.3 and markdownlint-cli to v0.43.0
- Reformat code using the updated ruff
- Update pyproject.toml to remove deprecated ignores