### PR TITLE
fix(netstat_tools): add shell=True to run_command

### DIFF
--- a/cardano_node_tests/cluster_management/netstat_tools.py
+++ b/cardano_node_tests/cluster_management/netstat_tools.py
@@ -15,7 +15,7 @@ def get_netstat_out() -> str:
     """Get output of the `netstat` command."""
     try:
         return helpers.run_command(
-            "netstat -pant | grep -E 'LISTEN|TIME_WAIT|CLOSE_WAIT|FIN_WAIT'"
+            "netstat -pant | grep -E 'LISTEN|TIME_WAIT|CLOSE_WAIT|FIN_WAIT'", shell=True
         ).decode()
     except Exception as excp:
         LOGGER.error(f"Failed to fetch netstat output: {excp}")  # noqa: TRY400


### PR DESCRIPTION
Added shell=True to the run_command function in netstat_tools.py to ensure the netstat command is executed correctly. The command has pipe, so shell is needed.