### PR TITLE
feat(cluster): improve cluster shutdown and logging

### DIFF
--- a/cardano_node_tests/cluster_management/netstat_tools.py
+++ b/cardano_node_tests/cluster_management/netstat_tools.py
@@ -15,7 +15,7 @@ def get_netstat_out() -> str:
     """Get output of the `netstat` command."""
     try:
         return helpers.run_command(
-            "netstat -pant | grep -E 'LISTEN|TIME_WAIT|CLOSE_WAIT|FIN_WAIT'", shell=True
+            "netstat -pant | grep -E 'LISTEN|TIME_WAIT|CLOSE'", ignore_fail=True, shell=True
         ).decode()
     except Exception as excp:
         LOGGER.error(f"Failed to fetch netstat output: {excp}")  # noqa: TRY400


### PR DESCRIPTION
- Add delay to ensure cluster processes are stopped before killing leftover processes.
- Improve logging for cluster start failures and netstat output.
- Modify netstat command to include CLOSE state and handle failures gracefully.