### PR TITLE
fix(netstat_tools): remove CLOSE from netstat command

### DIFF
--- a/cardano_node_tests/cluster_management/netstat_tools.py
+++ b/cardano_node_tests/cluster_management/netstat_tools.py
@@ -15,7 +15,7 @@ def get_netstat_out() -> str:
     """Get output of the `netstat` command."""
     try:
         return helpers.run_command(
-            "netstat -pant | grep -E 'LISTEN|TIME_WAIT|CLOSE'", ignore_fail=True, shell=True
+            "netstat -pant | grep -E 'LISTEN|TIME_WAIT'", ignore_fail=True, shell=True
         ).decode()
     except Exception as excp:
         LOGGER.error(f"Failed to fetch netstat output: {excp}")  # noqa: TRY400


### PR DESCRIPTION
The netstat command was modified to exclude the 'CLOSE' state from the output. This change ensures that only 'LISTEN' and 'TIME_WAIT' states are included, and so no client connection can be matched.