### PR TITLE
refactor(logging): move framework logging to separate module

### DIFF
--- a/cardano_node_tests/cluster_management/cluster_getter.py
+++ b/cardano_node_tests/cluster_management/cluster_getter.py
@@ -20,9 +20,9 @@ from cardano_node_tests.cluster_management import resources_management
 from cardano_node_tests.utils import artifacts
 from cardano_node_tests.utils import cluster_nodes
 from cardano_node_tests.utils import configuration
+from cardano_node_tests.utils import framework_log
 from cardano_node_tests.utils import helpers
 from cardano_node_tests.utils import locking
-from cardano_node_tests.utils import logfiles
 from cardano_node_tests.utils import temptools
 
 LOGGER = logging.getLogger(__name__)
@@ -215,7 +215,7 @@ class ClusterGetter:
             )
         else:
             self.log(f"c{self.cluster_instance_num}: cluster dead")
-            logfiles.framework_logger().error(
+            framework_log.framework_logger().error(
                 "Failed to start cluster instance 'c%s':\n%s\nnetstat:\n%s",
                 self.cluster_instance_num,
                 excp,
@@ -251,7 +251,7 @@ class ClusterGetter:
                 f"c{self.cluster_instance_num}: failed to setup test addresses:\n{err}\n"
                 "cluster dead"
             )
-            logfiles.framework_logger().error(
+            framework_log.framework_logger().error(
                 "Failed to setup test addresses on instance 'c%s':\n%s",
                 self.cluster_instance_num,
                 excp,

--- a/cardano_node_tests/utils/framework_log.py
+++ b/cardano_node_tests/utils/framework_log.py
@@ -1,0 +1,33 @@
+import logging
+import pathlib as pl
+import time
+
+from cardano_node_tests.utils import helpers
+from cardano_node_tests.utils import temptools
+
+
+@helpers.callonce
+def get_framework_log_path() -> pl.Path:
+    return temptools.get_pytest_worker_tmp() / "framework.log"
+
+
+@helpers.callonce
+def framework_logger() -> logging.Logger:
+    """Get logger for the `framework.log` file.
+
+    The logger is configured per worker. It can be used for logging (and later reporting) events
+    like a failure to start a cluster instance.
+    """
+
+    class UTCFormatter(logging.Formatter):
+        converter = time.gmtime
+
+    formatter = UTCFormatter("%(asctime)s %(levelname)s %(message)s")
+    handler = logging.FileHandler(get_framework_log_path())
+    handler.setFormatter(formatter)
+
+    logger = logging.getLogger("framework")
+    logger.setLevel(logging.INFO)
+    logger.addHandler(handler)
+
+    return logger

--- a/cardano_node_tests/utils/temptools.py
+++ b/cardano_node_tests/utils/temptools.py
@@ -1,11 +1,13 @@
+import os
 import pathlib as pl
 import tempfile
 import typing as tp
 
 from _pytest.tmpdir import TempPathFactory
 
-from cardano_node_tests.utils import configuration
 from cardano_node_tests.utils import helpers
+
+IS_XDIST = bool(os.environ.get("PYTEST_XDIST_TESTRUNUID"))
 
 
 class PytestTempDirs:
@@ -26,7 +28,7 @@ class PytestTempDirs:
         worker_tmp = pl.Path(tmp_path_factory.getbasetemp())
         cls.pytest_worker_tmp = worker_tmp
 
-        root_tmp = worker_tmp.parent if configuration.IS_XDIST else worker_tmp
+        root_tmp = worker_tmp.parent if IS_XDIST else worker_tmp
         cls.pytest_root_tmp = root_tmp
 
         shared_tmp = root_tmp / "tmp"


### PR DESCRIPTION
- Moved framework logging functions from `logfiles.py` to new `framework_log.py` module.
- Updated imports and references to use the new `framework_log` module.
- Adjusted `temptools.py` to use `IS_XDIST` directly from `os.environ`.