### PR TITLE
fix(pytype): resolve type errors and update Python version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ init_lint:
 .PHONY: lint
 lint:
 	pre-commit run -a
-	if command -v pytype >/dev/null 2>&1; then pytype cardano_node_tests; fi
+	if command -v pytype >/dev/null 2>&1; then pytype -k -j auto cardano_node_tests; fi
 
 
 # generate sphinx documentation

--- a/cardano_node_tests/tests/tests_conway/conway_common.py
+++ b/cardano_node_tests/tests/tests_conway/conway_common.py
@@ -42,7 +42,7 @@ def get_committee_val(data: dict[str, tp.Any]) -> dict[str, tp.Any]:
     The key can be either correctly "committee", or with typo "commitee".
     TODO: Remove this function when the typo is fixed in the ledger.
     """
-    return data.get("committee") or data.get("commitee") or {}
+    return dict(data.get("committee") or data.get("commitee") or {})
 
 
 def possible_rem_issue(gov_state: dict[str, tp.Any], epoch: int) -> bool:

--- a/cardano_node_tests/tests/tests_conway/test_drep.py
+++ b/cardano_node_tests/tests/tests_conway/test_drep.py
@@ -561,6 +561,7 @@ class TestDReps:
         ), f"Incorrect balance for source address `{payment_addr.address}`"
 
         drep_data = dbsync_utils.get_drep(drep_hash=reg_drep.drep_id, drep_deposit=reg_drep.deposit)
+        assert drep_data and drep_data.voting_anchor_id
 
         def _query_func():
             dbsync_utils.check_off_chain_vote_fetch_error(

--- a/cardano_node_tests/utils/governance_setup.py
+++ b/cardano_node_tests/utils/governance_setup.py
@@ -19,7 +19,7 @@ GOV_DATA_STORE = "governance_data.pickle"
 
 
 def _get_committee_val(data: dict[str, tp.Any]) -> dict[str, tp.Any]:
-    return data.get("committee") or data.get("commitee") or {}
+    return dict(data.get("committee") or data.get("commitee") or {})
 
 
 def _cast_vote(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,11 +94,11 @@ ignore = ["B905", "D10", "D203", "D212", "D213", "D214", "D215", "D404", "D405",
 force-single-line = true
 
 [tool.pytype]
-python_version = "3.10"
+python_version = "3.11"
 disable = ["import-error"]
 
 [tool.mypy]
-python_version = "3.10"
+python_version = "3.11"
 show_error_context = true
 verbosity = 0
 ignore_missing_imports = true


### PR DESCRIPTION
- Update Makefile to use pytype with -k and -j auto options
- Convert committee value to dict in conway_common.py and governance_setup.py
- Add assertion for drep_data in test_drep.py
- Update Python version to 3.11 in pyproject.toml for pytype and mypy