### PR TITLE
refactor: use max function for comparisons

### DIFF
--- a/cardano_node_tests/tests/plutus_common.py
+++ b/cardano_node_tests/tests/plutus_common.py
@@ -551,7 +551,7 @@ def compute_cost(
 
     collateral_fraction = protocol_params["collateralPercentage"] / 100
     min_collateral = int(fee_redeem * collateral_fraction * collateral_fraction_offset)
-    collateral_amount = min_collateral if min_collateral >= 2_000_000 else 2_000_000
+    collateral_amount = max(min_collateral, 2000000)
 
     return ScriptCost(fee=fee_redeem, collateral=collateral_amount, min_collateral=min_collateral)
 

--- a/cardano_node_tests/tests/test_dbsync.py
+++ b/cardano_node_tests/tests/test_dbsync.py
@@ -129,7 +129,7 @@ class TestDBSync:
 
         # Check records for last 50 epochs
         epoch_from = epoch - 50
-        epoch_from = epoch_from if epoch_from >= 0 else 0
+        epoch_from = max(epoch_from, 0)
 
         rec = None
         prev_rec = None

--- a/cardano_node_tests/tests/test_tx_basic.py
+++ b/cardano_node_tests/tests/test_tx_basic.py
@@ -1202,7 +1202,7 @@ class TestMultiInOut:
         # The "from" addresses has zero balance after each test.
         fund_amount = int(amount * len(dst_addresses) / len(from_addr_recs))
         # Min UTxO on testnets is 1.x ADA
-        fund_amount = fund_amount if fund_amount >= 1_500_000 else 1_500_000
+        fund_amount = max(fund_amount, 1500000)
         fund_dst = [
             clusterlib.TxOut(address=d.address, amount=fund_amount) for d in from_addr_recs[:-1]
         ]

--- a/cardano_node_tests/utils/clusterlib_utils.py
+++ b/cardano_node_tests/utils/clusterlib_utils.py
@@ -1071,7 +1071,7 @@ def wait_for_epoch_interval(
         to_sleep = start_abs - s_from_epoch_start
         if to_sleep > 0:
             # `to_sleep` is float, wait for at least 1 second
-            time.sleep(to_sleep if to_sleep > 1 else 1)
+            time.sleep(max(1, to_sleep))
 
         # We can finish if slot number of last minted block doesn't need
         # to match the time interval

--- a/cardano_node_tests/utils/configuration.py
+++ b/cardano_node_tests/utils/configuration.py
@@ -76,7 +76,7 @@ if COMMAND_ERA not in ("", "shelley", "allegra", "mary", "alonzo", "babbage", "c
 
 CLUSTERS_COUNT = int(os.environ.get("CLUSTERS_COUNT") or 0)
 WORKERS_COUNT = int(os.environ.get("PYTEST_XDIST_WORKER_COUNT") or 1)
-CLUSTERS_COUNT = int(CLUSTERS_COUNT or (WORKERS_COUNT if WORKERS_COUNT <= 9 else 9))
+CLUSTERS_COUNT = int(CLUSTERS_COUNT or (min(WORKERS_COUNT, 9)))
 
 DEV_CLUSTER_RUNNING = bool(os.environ.get("DEV_CLUSTER_RUNNING"))
 FORBID_RESTART = bool(os.environ.get("FORBID_RESTART"))

--- a/cardano_node_tests/utils/dbsync_utils.py
+++ b/cardano_node_tests/utils/dbsync_utils.py
@@ -503,7 +503,7 @@ def get_tx_record_retry(txhash: str, retry_num: int = 3) -> dbsync_types.TxRecor
 
     Under load it might be necessary to wait a bit and retry the query.
     """
-    retry_num = retry_num if retry_num >= 0 else 0
+    retry_num = max(retry_num, 0)
     response = None
 
     # First try + number of retries

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,7 +84,7 @@ line-length = 100
 line-length = 100
 
 [tool.ruff.lint]
-select = ["ARG", "B", "C4", "C90", "D", "DTZ", "E", "EM", "F", "I001", "ISC", "N", "PIE", "PL", "PLE", "PLR", "PLW", "PT", "PTH", "Q", "RET", "RSE", "RUF", "SIM", "TRY", "UP", "W", "YTT"]
+select = ["ARG", "B", "C4", "C90", "D", "DTZ", "E", "EM", "F", "FURB", "I001", "ISC", "N", "PIE", "PL", "PLE", "PLR", "PLW", "PT", "PTH", "Q", "RET", "RSE", "RUF", "SIM", "TRY", "UP", "W", "YTT"]
 ignore = ["B905", "D10", "D203", "D212", "D213", "D214", "D215", "D404", "D405", "D406", "D407", "D408", "D409", "D410", "D411", "D413", "ISC001", "PLR0912", "PLR0913", "PLR0915", "PLR2004", "PT001", "PT007", "PT012", "PT018", "PT023", "PTH123", "RET504", "TRY002", "TRY301", "UP006", "UP007", "UP035"]
 
 [tool.ruff.lint.per-file-ignores]


### PR DESCRIPTION
Refactor code to use the max function for comparisons instead of conditional expressions. This change improves readability and maintainability of the code.

Added "FURB" to ruff lint select in pyproject.toml that checks for such code.