### PR TITLE
refactor: update address creation and funding methods

### DIFF
--- a/cardano_node_tests/tests/test_tx_basic.py
+++ b/cardano_node_tests/tests/test_tx_basic.py
@@ -739,13 +739,10 @@ class TestBasicTransactions:
         """
         temp_template = common.get_test_id(cluster)
 
-        src_record = clusterlib_utils.create_payment_addr_records(
-            f"{temp_template}_0", cluster_obj=cluster
-        )[0]
-        clusterlib_utils.fund_from_faucet(
-            src_record,
+        src_record = common.get_payment_addr(
+            name_template=temp_template,
+            cluster_manager=cluster_manager,
             cluster_obj=cluster,
-            all_faucets=cluster_manager.cache.addrs_data,
             amount=2_000_000,
         )
 

--- a/cardano_node_tests/tests/test_tx_metadata.py
+++ b/cardano_node_tests/tests/test_tx_metadata.py
@@ -590,13 +590,10 @@ class TestMetadata:
         """
         temp_template = common.get_test_id(cluster)
 
-        src_record = clusterlib_utils.create_payment_addr_records(
-            f"{temp_template}_0", cluster_obj=cluster
-        )[0]
-        clusterlib_utils.fund_from_faucet(
-            src_record,
+        src_record = common.get_payment_addr(
+            name_template=temp_template,
+            cluster_manager=cluster_manager,
             cluster_obj=cluster,
-            all_faucets=cluster_manager.cache.addrs_data,
             amount=2_000_000,
         )
 

--- a/cardano_node_tests/tests/tests_conway/test_committee.py
+++ b/cardano_node_tests/tests/tests_conway/test_committee.py
@@ -42,23 +42,12 @@ def payment_addr_comm(
 ) -> clusterlib.AddressRecord:
     """Create new payment address."""
     cluster, __ = cluster_use_committee
-    with cluster_manager.cache_fixture() as fixture_cache:
-        if fixture_cache.value:
-            return fixture_cache.value  # type: ignore
-
-        addr = clusterlib_utils.create_payment_addr_records(
-            f"committee_addr_ci{cluster_manager.cluster_instance_num}",
-            cluster_obj=cluster,
-        )[0]
-        fixture_cache.value = addr
-
-    # Fund source address
-    clusterlib_utils.fund_from_faucet(
-        addr,
+    addr = common.get_payment_addr(
+        name_template=common.get_test_id(cluster),
+        cluster_manager=cluster_manager,
         cluster_obj=cluster,
-        all_faucets=cluster_manager.cache.addrs_data,
+        caching_key=helpers.get_current_line_str(),
     )
-
     return addr
 
 

--- a/cardano_node_tests/tests/tests_plutus/test_spend_negative_raw.py
+++ b/cardano_node_tests/tests/tests_plutus/test_spend_negative_raw.py
@@ -702,16 +702,12 @@ class TestNegativeRedeemer:
         plutus_version: str,
     ) -> FundTupleT:
         """Fund a Plutus script and create the locked UTxO and collateral UTxO."""
-        payment_addrs = clusterlib_utils.create_payment_addr_records(
-            *[f"{temp_template}_payment_addr_{i}" for i in range(2)],
+        payment_addrs = common.get_payment_addrs(
+            name_template=temp_template,
+            cluster_manager=cluster_manager,
             cluster_obj=cluster_obj,
-        )
-
-        # Fund source address
-        clusterlib_utils.fund_from_faucet(
-            payment_addrs[0],
-            cluster_obj=cluster_obj,
-            all_faucets=cluster_manager.cache.addrs_data,
+            num=2,
+            fund_idx=[0],
             amount=3_000_000_000,
         )
 


### PR DESCRIPTION
- Replace `create_payment_addr_records` with `get_payment_addr` in `test_tx_basic.py` and `test_tx_metadata.py`
- Update `test_committee.py` to use `get_payment_addr` with caching key
- Modify `test_spend_negative_raw.py` to use `get_payment_addrs` for funding Plutus scripts