### PR TITLE
feat(cluster): add ports property to ClusterGetter

### DIFF
--- a/cardano_node_tests/cluster_management/manager.py
+++ b/cardano_node_tests/cluster_management/manager.py
@@ -90,13 +90,6 @@ class ClusterManager:
         )
         return instance_dir
 
-    @property
-    def ports(self) -> cluster_scripts.InstancePorts:
-        """Return port mappings for current cluster instance."""
-        return cluster_nodes.get_cluster_type().cluster_scripts.get_instance_ports(
-            self.cluster_instance_num
-        )
-
     def log(self, msg: str) -> None:
         """Log a message."""
         if not configuration.SCHEDULING_LOG:


### PR DESCRIPTION
- Added `ports` property to `ClusterGetter` to return port mappings for the current cluster instance.
- Removed `ports` property from `ClusterManager` as it is now handled by `ClusterGetter`.
- Updated logging to include port mappings when cluster fails to start.