### PR TITLE
feat: add supervisord unix socket support

### DIFF
--- a/cardano_node_tests/cluster_scripts/conway/start-cluster
+++ b/cardano_node_tests/cluster_scripts/conway/start-cluster
@@ -16,6 +16,7 @@ SCRIPT_DIR="$(readlink -m "${0%/*}")"
 SOCKET_PATH="$(readlink -m "$CARDANO_NODE_SOCKET_PATH")"
 STATE_CLUSTER="${SOCKET_PATH%/*}"
 STATE_CLUSTER_NAME="${STATE_CLUSTER##*/}"
+SUPERVISORD_SOCKET_PATH="${STATE_CLUSTER}/supervisord.sock"
 
 INSTANCE_NUM="%%INSTANCE_NUM%%"
 if [[ "$SOCKET_PATH" != *"/state-cluster${INSTANCE_NUM}/"* ]]; then
@@ -234,6 +235,15 @@ case "${UTXO_BACKEND:=""}" in
     exit 1
     ;;
 esac
+
+cat >> "${STATE_CLUSTER}/supervisor.conf" <<EoF
+
+[unix_http_server]
+file = ${SUPERVISORD_SOCKET_PATH}
+
+[supervisorctl]
+serverurl = unix:///${SUPERVISORD_SOCKET_PATH}
+EoF
 
 # enable db-sync service
 if [ -n "${DBSYNC_REPO:-""}" ]; then
@@ -656,9 +666,9 @@ for i in $(seq 1 "$NUM_DREPS"); do
 done
 
 # create scripts for cluster starting / stopping
-printf "#!/bin/sh\n\nsupervisorctl -s http://127.0.0.1:%%SUPERVISOR_PORT%% start all" > "${STATE_CLUSTER}/supervisorctl_start"
-printf "#!/bin/sh\n\nsupervisorctl -s http://127.0.0.1:%%SUPERVISOR_PORT%% restart nodes:" > "${STATE_CLUSTER}/supervisorctl_restart_nodes"
-printf "#!/bin/sh\n\nsupervisorctl -s http://127.0.0.1:%%SUPERVISOR_PORT%% \"\$@\"" > "${STATE_CLUSTER}/supervisorctl"
+printf "#!/bin/sh\n\nsupervisorctl -s unix:///%s start all" "$SUPERVISORD_SOCKET_PATH" > "${STATE_CLUSTER}/supervisorctl_start"
+printf "#!/bin/sh\n\nsupervisorctl -s unix:///%s restart nodes:" "$SUPERVISORD_SOCKET_PATH" > "${STATE_CLUSTER}/supervisorctl_restart_nodes"
+printf "#!/bin/sh\n\nsupervisorctl -s unix:///%s \"\$@\"" "$SUPERVISORD_SOCKET_PATH" > "${STATE_CLUSTER}/supervisorctl"
 
 cat > "${STATE_CLUSTER}/supervisord_start" <<EoF
 #!/usr/bin/env bash
@@ -680,7 +690,7 @@ set -uo pipefail
 SCRIPT_DIR="\$(readlink -m "\${0%/*}")"
 PID_FILE="\${SCRIPT_DIR}/supervisord.pid"
 
-supervisorctl -s http://127.0.0.1:%%SUPERVISOR_PORT%% stop all
+supervisorctl -s unix:///${SUPERVISORD_SOCKET_PATH} stop all
 
 if [ ! -f "\$PID_FILE" ]; then
   echo "Cluster is not running!"
@@ -765,7 +775,7 @@ SHELLEY_EPOCH="$(get_epoch)"
 # start db-sync
 if [ -n "${DBSYNC_REPO:-""}" ]; then
   echo "Starting db-sync"
-  supervisorctl -s http://127.0.0.1:%%SUPERVISOR_PORT%% start dbsync
+  supervisorctl -s "unix:///${SUPERVISORD_SOCKET_PATH}" start dbsync
 fi
 
 sleep "$PROPOSAL_DELAY"
@@ -1009,7 +1019,7 @@ ALONZO_PV6_EPOCH="$(get_epoch)"
 # start cardano-submit-api
 if [ "$ENABLE_SUBMIT_API" -eq 1 ]; then
   echo "Starting cardano-submit-api"
-  supervisorctl -s http://127.0.0.1:%%SUPERVISOR_PORT%% start submit_api
+  supervisorctl -s "unix:///${SUPERVISORD_SOCKET_PATH}" start submit_api
 fi
 
 cardano_cli_log alonzo query protocol-parameters \

--- a/cardano_node_tests/cluster_scripts/conway/stop-cluster
+++ b/cardano_node_tests/cluster_scripts/conway/stop-cluster
@@ -5,6 +5,7 @@ set -uo pipefail
 SOCKET_PATH="$(readlink -m "$CARDANO_NODE_SOCKET_PATH")"
 STATE_CLUSTER="${SOCKET_PATH%/*}"
 PID_FILE="${STATE_CLUSTER}/supervisord.pid"
+SUPERVISORD_SOCKET_PATH="${STATE_CLUSTER}/supervisord.sock"
 
 INSTANCE_NUM="%%INSTANCE_NUM%%"
 if [[ "$SOCKET_PATH" != *"/state-cluster${INSTANCE_NUM}/"* ]]; then
@@ -12,7 +13,9 @@ if [[ "$SOCKET_PATH" != *"/state-cluster${INSTANCE_NUM}/"* ]]; then
   exit 1
 fi
 
-supervisorctl -s http://127.0.0.1:%%SUPERVISOR_PORT%% stop all
+if [ -e "$SUPERVISORD_SOCKET_PATH" ]; then
+  supervisorctl -s "unix:///${SUPERVISORD_SOCKET_PATH}" stop all
+fi
 
 if [ ! -f "$PID_FILE" ]; then
   echo "Cluster is not running!"

--- a/cardano_node_tests/cluster_scripts/conway_fast/start-cluster
+++ b/cardano_node_tests/cluster_scripts/conway_fast/start-cluster
@@ -16,6 +16,7 @@ SCRIPT_DIR="$(readlink -m "${0%/*}")"
 SOCKET_PATH="$(readlink -m "$CARDANO_NODE_SOCKET_PATH")"
 STATE_CLUSTER="${SOCKET_PATH%/*}"
 STATE_CLUSTER_NAME="${STATE_CLUSTER##*/}"
+SUPERVISORD_SOCKET_PATH="${STATE_CLUSTER}/supervisord.sock"
 
 INSTANCE_NUM="%%INSTANCE_NUM%%"
 if [[ "$SOCKET_PATH" != *"/state-cluster${INSTANCE_NUM}/"* ]]; then
@@ -173,6 +174,15 @@ case "${UTXO_BACKEND:=""}" in
     exit 1
     ;;
 esac
+
+cat >> "${STATE_CLUSTER}/supervisor.conf" <<EoF
+
+[unix_http_server]
+file = ${SUPERVISORD_SOCKET_PATH}
+
+[supervisorctl]
+serverurl = unix:///${SUPERVISORD_SOCKET_PATH}
+EoF
 
 # enable db-sync service
 if [ -n "${DBSYNC_REPO:-""}" ]; then
@@ -539,9 +549,9 @@ for i in $(seq 1 "$NUM_DREPS"); do
 done
 
 # create scripts for cluster starting / stopping
-printf "#!/bin/sh\n\nsupervisorctl -s http://127.0.0.1:%%SUPERVISOR_PORT%% start all" > "${STATE_CLUSTER}/supervisorctl_start"
-printf "#!/bin/sh\n\nsupervisorctl -s http://127.0.0.1:%%SUPERVISOR_PORT%% restart nodes:" > "${STATE_CLUSTER}/supervisorctl_restart_nodes"
-printf "#!/bin/sh\n\nsupervisorctl -s http://127.0.0.1:%%SUPERVISOR_PORT%% \"\$@\"" > "${STATE_CLUSTER}/supervisorctl"
+printf "#!/bin/sh\n\nsupervisorctl -s unix:///%s start all" "$SUPERVISORD_SOCKET_PATH" > "${STATE_CLUSTER}/supervisorctl_start"
+printf "#!/bin/sh\n\nsupervisorctl -s unix:///%s restart nodes:" "$SUPERVISORD_SOCKET_PATH" > "${STATE_CLUSTER}/supervisorctl_restart_nodes"
+printf "#!/bin/sh\n\nsupervisorctl -s unix:///%s \"\$@\"" "$SUPERVISORD_SOCKET_PATH" > "${STATE_CLUSTER}/supervisorctl"
 
 cat > "${STATE_CLUSTER}/supervisord_start" <<EoF
 #!/usr/bin/env bash
@@ -563,7 +573,7 @@ set -uo pipefail
 SCRIPT_DIR="\$(readlink -m "\${0%/*}")"
 PID_FILE="\${SCRIPT_DIR}/supervisord.pid"
 
-supervisorctl -s http://127.0.0.1:%%SUPERVISOR_PORT%% stop all
+supervisorctl -s unix:///${SUPERVISORD_SOCKET_PATH} stop all
 
 if [ ! -f "\$PID_FILE" ]; then
   echo "Cluster is not running!"
@@ -612,7 +622,7 @@ done
 # start db-sync
 if [ -n "${DBSYNC_REPO:-""}" ]; then
   echo "Starting db-sync"
-  supervisorctl -s http://127.0.0.1:%%SUPERVISOR_PORT%% start dbsync
+  supervisorctl -s "unix:///${SUPERVISORD_SOCKET_PATH}" start dbsync
 fi
 
 echo "Sleeping for initial Tx submission delay of $TX_SUBMISSION_DELAY seconds"
@@ -719,7 +729,7 @@ cardano_cli_log conway transaction submit \
 # start cardano-submit-api
 if [ "$ENABLE_SUBMIT_API" -eq 1 ]; then
   echo "Starting cardano-submit-api"
-  supervisorctl -s http://127.0.0.1:%%SUPERVISOR_PORT%% start submit_api
+  supervisorctl -s "unix:///${SUPERVISORD_SOCKET_PATH}" start submit_api
 fi
 
 sleep "$SUBMIT_DELAY"

--- a/cardano_node_tests/cluster_scripts/conway_fast/stop-cluster
+++ b/cardano_node_tests/cluster_scripts/conway_fast/stop-cluster
@@ -5,6 +5,7 @@ set -uo pipefail
 SOCKET_PATH="$(readlink -m "$CARDANO_NODE_SOCKET_PATH")"
 STATE_CLUSTER="${SOCKET_PATH%/*}"
 PID_FILE="${STATE_CLUSTER}/supervisord.pid"
+SUPERVISORD_SOCKET_PATH="${STATE_CLUSTER}/supervisord.sock"
 
 INSTANCE_NUM="%%INSTANCE_NUM%%"
 if [[ "$SOCKET_PATH" != *"/state-cluster${INSTANCE_NUM}/"* ]]; then
@@ -12,7 +13,9 @@ if [[ "$SOCKET_PATH" != *"/state-cluster${INSTANCE_NUM}/"* ]]; then
   exit 1
 fi
 
-supervisorctl -s http://127.0.0.1:%%SUPERVISOR_PORT%% stop all
+if [ -e "$SUPERVISORD_SOCKET_PATH" ]; then
+  supervisorctl -s "unix:///${SUPERVISORD_SOCKET_PATH}" stop all
+fi
 
 if [ ! -f "$PID_FILE" ]; then
   echo "Cluster is not running!"

--- a/cardano_node_tests/cluster_scripts/mainnet_fast/start-cluster
+++ b/cardano_node_tests/cluster_scripts/mainnet_fast/start-cluster
@@ -16,6 +16,7 @@ SCRIPT_DIR="$(readlink -m "${0%/*}")"
 SOCKET_PATH="$(readlink -m "$CARDANO_NODE_SOCKET_PATH")"
 STATE_CLUSTER="${SOCKET_PATH%/*}"
 STATE_CLUSTER_NAME="${STATE_CLUSTER##*/}"
+SUPERVISORD_SOCKET_PATH="${STATE_CLUSTER}/supervisord.sock"
 
 INSTANCE_NUM="%%INSTANCE_NUM%%"
 if [[ "$SOCKET_PATH" != *"/state-cluster${INSTANCE_NUM}/"* ]]; then
@@ -173,6 +174,15 @@ case "${UTXO_BACKEND:=""}" in
     exit 1
     ;;
 esac
+
+cat >> "${STATE_CLUSTER}/supervisor.conf" <<EoF
+
+[unix_http_server]
+file = ${SUPERVISORD_SOCKET_PATH}
+
+[supervisorctl]
+serverurl = unix:///${SUPERVISORD_SOCKET_PATH}
+EoF
 
 # enable db-sync service
 if [ -n "${DBSYNC_REPO:-""}" ]; then
@@ -539,9 +549,9 @@ for i in $(seq 1 "$NUM_DREPS"); do
 done
 
 # create scripts for cluster starting / stopping
-printf "#!/bin/sh\n\nsupervisorctl -s http://127.0.0.1:%%SUPERVISOR_PORT%% start all" > "${STATE_CLUSTER}/supervisorctl_start"
-printf "#!/bin/sh\n\nsupervisorctl -s http://127.0.0.1:%%SUPERVISOR_PORT%% restart nodes:" > "${STATE_CLUSTER}/supervisorctl_restart_nodes"
-printf "#!/bin/sh\n\nsupervisorctl -s http://127.0.0.1:%%SUPERVISOR_PORT%% \"\$@\"" > "${STATE_CLUSTER}/supervisorctl"
+printf "#!/bin/sh\n\nsupervisorctl -s unix:///%s start all" "$SUPERVISORD_SOCKET_PATH" > "${STATE_CLUSTER}/supervisorctl_start"
+printf "#!/bin/sh\n\nsupervisorctl -s unix:///%s restart nodes:" "$SUPERVISORD_SOCKET_PATH" > "${STATE_CLUSTER}/supervisorctl_restart_nodes"
+printf "#!/bin/sh\n\nsupervisorctl -s unix:///%s \"\$@\"" "$SUPERVISORD_SOCKET_PATH" > "${STATE_CLUSTER}/supervisorctl"
 
 cat > "${STATE_CLUSTER}/supervisord_start" <<EoF
 #!/usr/bin/env bash
@@ -563,7 +573,7 @@ set -uo pipefail
 SCRIPT_DIR="\$(readlink -m "\${0%/*}")"
 PID_FILE="\${SCRIPT_DIR}/supervisord.pid"
 
-supervisorctl -s http://127.0.0.1:%%SUPERVISOR_PORT%% stop all
+supervisorctl -s unix:///${SUPERVISORD_SOCKET_PATH} stop all
 
 if [ ! -f "\$PID_FILE" ]; then
   echo "Cluster is not running!"
@@ -612,7 +622,7 @@ done
 # start db-sync
 if [ -n "${DBSYNC_REPO:-""}" ]; then
   echo "Starting db-sync"
-  supervisorctl -s http://127.0.0.1:%%SUPERVISOR_PORT%% start dbsync
+  supervisorctl -s "unix:///${SUPERVISORD_SOCKET_PATH}" start dbsync
 fi
 
 echo "Sleeping for initial Tx submission delay of $TX_SUBMISSION_DELAY seconds"
@@ -719,7 +729,7 @@ cardano_cli_log conway transaction submit \
 # start cardano-submit-api
 if [ "$ENABLE_SUBMIT_API" -eq 1 ]; then
   echo "Starting cardano-submit-api"
-  supervisorctl -s http://127.0.0.1:%%SUPERVISOR_PORT%% start submit_api
+  supervisorctl -s "unix:///${SUPERVISORD_SOCKET_PATH}" start submit_api
 fi
 
 sleep "$SUBMIT_DELAY"

--- a/cardano_node_tests/cluster_scripts/mainnet_fast/stop-cluster
+++ b/cardano_node_tests/cluster_scripts/mainnet_fast/stop-cluster
@@ -5,6 +5,7 @@ set -uo pipefail
 SOCKET_PATH="$(readlink -m "$CARDANO_NODE_SOCKET_PATH")"
 STATE_CLUSTER="${SOCKET_PATH%/*}"
 PID_FILE="${STATE_CLUSTER}/supervisord.pid"
+SUPERVISORD_SOCKET_PATH="${STATE_CLUSTER}/supervisord.sock"
 
 INSTANCE_NUM="%%INSTANCE_NUM%%"
 if [[ "$SOCKET_PATH" != *"/state-cluster${INSTANCE_NUM}/"* ]]; then
@@ -12,7 +13,9 @@ if [[ "$SOCKET_PATH" != *"/state-cluster${INSTANCE_NUM}/"* ]]; then
   exit 1
 fi
 
-supervisorctl -s http://127.0.0.1:%%SUPERVISOR_PORT%% stop all
+if [ -e "$SUPERVISORD_SOCKET_PATH" ]; then
+  supervisorctl -s "unix:///${SUPERVISORD_SOCKET_PATH}" stop all
+fi
 
 if [ ! -f "$PID_FILE" ]; then
   echo "Cluster is not running!"

--- a/cardano_node_tests/cluster_scripts/testnets/start-cluster
+++ b/cardano_node_tests/cluster_scripts/testnets/start-cluster
@@ -7,6 +7,7 @@ SCRIPT_DIR="$(readlink -m "${0%/*}")"
 SOCKET_PATH="$(readlink -m "$CARDANO_NODE_SOCKET_PATH")"
 STATE_CLUSTER="${SOCKET_PATH%/*}"
 STATE_CLUSTER_NAME="${STATE_CLUSTER##*/}"
+SUPERVISORD_SOCKET_PATH="${STATE_CLUSTER}/supervisord.sock"
 
 INSTANCE_NUM="%%INSTANCE_NUM%%"
 if [[ "$SOCKET_PATH" != *"/state-cluster${INSTANCE_NUM}/"* ]]; then
@@ -55,6 +56,15 @@ jq --arg ekg "$RELAY1_EKG" --arg prometheus "$RELAY1_PROMETHEUS" \
   "$TESTNET_CONF_DIR/config-relay1.json" > "$STATE_CLUSTER/config-relay1.json"
 chmod u+w "$STATE_CLUSTER"/config-*.json
 
+cat >> "${STATE_CLUSTER}/supervisor.conf" <<EoF
+
+[unix_http_server]
+file = ${SUPERVISORD_SOCKET_PATH}
+
+[supervisorctl]
+serverurl = unix:///${SUPERVISORD_SOCKET_PATH}
+EoF
+
 # enable db-sync service
 if [ -n "${DBSYNC_REPO:-""}" ]; then
   [ -e "$DBSYNC_REPO/db-sync-node/bin/cardano-db-sync" ] || \
@@ -96,8 +106,8 @@ EoF
 fi
 
 # create scripts for cluster starting / stopping
-printf "#!/bin/sh\n\nsupervisorctl -s http://127.0.0.1:%%SUPERVISOR_PORT%% start all" > "$STATE_CLUSTER/supervisorctl_start"
-printf "#!/bin/sh\n\nsupervisorctl -s http://127.0.0.1:%%SUPERVISOR_PORT%% \"\$@\"" > "$STATE_CLUSTER/supervisorctl"
+printf "#!/bin/sh\n\nsupervisorctl -s unix:///%s start all" "$SUPERVISORD_SOCKET_PATH" > "${STATE_CLUSTER}/supervisorctl_start"
+printf "#!/bin/sh\n\nsupervisorctl -s unix:///%s \"\$@\"" "$SUPERVISORD_SOCKET_PATH" > "${STATE_CLUSTER}/supervisorctl"
 
 cat > "$STATE_CLUSTER/supervisord_start" <<EoF
 #!/usr/bin/env bash
@@ -119,7 +129,7 @@ set -uo pipefail
 SCRIPT_DIR="\$(readlink -m "\${0%/*}")"
 PID_FILE="\$SCRIPT_DIR/supervisord.pid"
 
-supervisorctl -s http://127.0.0.1:%%SUPERVISOR_PORT%% stop all
+supervisorctl -s unix:///${SUPERVISORD_SOCKET_PATH} stop all
 
 if [ ! -f "\$PID_FILE" ]; then
   echo "Cluster is not running!"
@@ -177,13 +187,13 @@ done
 # start cardano-submit-api
 if command -v cardano-submit-api >/dev/null 2>&1 && [ -e "$STATE_CLUSTER/submit-api-config.json" ]; then
   echo "Starting cardano-submit-api"
-  supervisorctl -s http://127.0.0.1:%%SUPERVISOR_PORT%% start submit_api
+  supervisorctl -s "unix:///${SUPERVISORD_SOCKET_PATH}" start submit_api
 fi
 
 # start db-sync
 if [ -n "${DBSYNC_REPO:-""}" ]; then
   echo "Starting db-sync"
-  supervisorctl -s http://127.0.0.1:%%SUPERVISOR_PORT%% start dbsync
+  supervisorctl -s "unix:///${SUPERVISORD_SOCKET_PATH}" start dbsync
   sleep 10
 
   echo "Waiting to make sure db-sync is synced"

--- a/cardano_node_tests/cluster_scripts/testnets/stop-cluster
+++ b/cardano_node_tests/cluster_scripts/testnets/stop-cluster
@@ -5,6 +5,7 @@ set -uo pipefail
 SOCKET_PATH="$(readlink -m "$CARDANO_NODE_SOCKET_PATH")"
 STATE_CLUSTER="${SOCKET_PATH%/*}"
 PID_FILE="${STATE_CLUSTER}/supervisord.pid"
+SUPERVISORD_SOCKET_PATH="${STATE_CLUSTER}/supervisord.sock"
 
 INSTANCE_NUM="%%INSTANCE_NUM%%"
 if [[ "$SOCKET_PATH" != *"/state-cluster${INSTANCE_NUM}/"* ]]; then
@@ -12,7 +13,9 @@ if [[ "$SOCKET_PATH" != *"/state-cluster${INSTANCE_NUM}/"* ]]; then
   exit 1
 fi
 
-supervisorctl -s http://127.0.0.1:%%SUPERVISOR_PORT%% stop all
+if [ -e "$SUPERVISORD_SOCKET_PATH" ]; then
+  supervisorctl -s "unix:///${SUPERVISORD_SOCKET_PATH}" stop all
+fi
 
 if [ ! -f "$PID_FILE" ]; then
   echo "Cluster is not running!"

--- a/cardano_node_tests/utils/cluster_scripts.py
+++ b/cardano_node_tests/utils/cluster_scripts.py
@@ -302,8 +302,8 @@ class LocalScripts(ScriptsTypes):
     def _gen_supervisor_conf(self, instance_num: int, instance_ports: InstancePorts) -> str:
         """Generate supervisor configuration for given instance."""
         lines = [
-            "[inet_http_server]",
-            f"port=127.0.0.1:{instance_ports.supervisor}",
+            "# [inet_http_server]",
+            f"# port=127.0.0.1:{instance_ports.supervisor}",
         ]
 
         programs = []


### PR DESCRIPTION
Use unix socket to communicate with supervisord instead of HTTP socket. This reduces number of http connections in TIME_WAIT state during cluster shitdown.

- Added `SUPERVISORD_SOCKET_PATH` to cluster scripts.
- Updated supervisor configuration to use unix socket.
- Modified `supervisorctl` commands to use unix socket.
- Updated `cluster_nodes.py` to support unix socket for supervisorctl.
- Commented out inet_http_server configuration in `cluster_scripts.py`.