### PR TITLE
feat: replace requests with global HTTP client

### DIFF
--- a/cardano_node_tests/tests/kes.py
+++ b/cardano_node_tests/tests/kes.py
@@ -5,12 +5,12 @@ import logging
 import typing as tp
 
 import pytest
-import requests
 from cardano_clusterlib import clusterlib
 
 from cardano_node_tests.tests import issues
 from cardano_node_tests.utils import blockers
 from cardano_node_tests.utils import cluster_nodes
+from cardano_node_tests.utils import http_client
 
 LOGGER = logging.getLogger(__name__)
 
@@ -85,7 +85,9 @@ def check_kes_period_info_result(  # noqa: C901
             cluster_nodes.get_instance_num()
         )
         prometheus_port = instance_ports.node_ports[pool_num].prometheus
-        response = requests.get(f"http://localhost:{prometheus_port}/metrics", timeout=10)
+        response = http_client.get_session().get(
+            f"http://localhost:{prometheus_port}/metrics", timeout=10
+        )
 
         _prometheus_metrics_raw = [m.split() for m in response.text.strip().split("\n")]
         prometheus_metrics_raw = {m[0]: m[-1] for m in _prometheus_metrics_raw}

--- a/cardano_node_tests/tests/test_kes.py
+++ b/cardano_node_tests/tests/test_kes.py
@@ -10,7 +10,6 @@ import typing as tp
 
 import allure
 import pytest
-import requests
 from cardano_clusterlib import clusterlib
 
 from cardano_node_tests.cluster_management import cluster_management
@@ -21,6 +20,7 @@ from cardano_node_tests.utils import cluster_nodes
 from cardano_node_tests.utils import clusterlib_utils
 from cardano_node_tests.utils import configuration
 from cardano_node_tests.utils import helpers
+from cardano_node_tests.utils import http_client
 from cardano_node_tests.utils import locking
 from cardano_node_tests.utils import logfiles
 from cardano_node_tests.utils import temptools
@@ -86,7 +86,7 @@ def _save_metrics(pool_num: int, temp_template: str) -> None:
     )
     port = instance_ports.node_ports[pool_num].prometheus
 
-    response = requests.get(f"http://localhost:{port}/metrics", timeout=10)
+    response = http_client.get_session().get(f"http://localhost:{port}/metrics", timeout=10)
     assert response, f"Request failed, status code {response.status_code}"
 
     with open(f"{temp_template}_pool{pool_num}_metrics.txt", "w", encoding="utf-8") as fp_out:

--- a/cardano_node_tests/tests/test_metrics.py
+++ b/cardano_node_tests/tests/test_metrics.py
@@ -11,6 +11,7 @@ from cardano_clusterlib import clusterlib
 from cardano_node_tests.tests import common
 from cardano_node_tests.utils import cluster_nodes
 from cardano_node_tests.utils import helpers
+from cardano_node_tests.utils import http_client
 from cardano_node_tests.utils import model_ekg
 
 LOGGER = logging.getLogger(__name__)
@@ -27,13 +28,13 @@ def wait_epochs(cluster: clusterlib.ClusterLib):
 
 
 def get_prometheus_metrics(port: int) -> requests.Response:
-    response = requests.get(f"http://localhost:{port}/metrics", timeout=10)
+    response = http_client.get_session().get(f"http://localhost:{port}/metrics", timeout=10)
     assert response, f"Request failed, status code {response.status_code}"
     return response
 
 
 def get_ekg_metrics(port: int) -> requests.Response:
-    response = requests.get(
+    response = http_client.get_session().get(
         f"http://localhost:{port}/", headers={"Accept": "application/json"}, timeout=10
     )
     assert response, f"Request failed, status code {response.status_code}"

--- a/cardano_node_tests/tests/test_reconnect.py
+++ b/cardano_node_tests/tests/test_reconnect.py
@@ -16,6 +16,7 @@ from cardano_node_tests.tests import common
 from cardano_node_tests.utils import cluster_nodes
 from cardano_node_tests.utils import configuration
 from cardano_node_tests.utils import helpers
+from cardano_node_tests.utils import http_client
 from cardano_node_tests.utils.versions import VERSIONS
 
 LOGGER = logging.getLogger(__name__)
@@ -119,7 +120,7 @@ class TestNodeReconnect:
             os.environ["CARDANO_NODE_SOCKET_PATH"] = orig_socket
 
     def get_prometheus_metrics(self, port: int) -> requests.Response:
-        response = requests.get(f"http://localhost:{port}/metrics", timeout=10)
+        response = http_client.get_session().get(f"http://localhost:{port}/metrics", timeout=10)
         assert response, f"Request failed, status code {response.status_code}"
         return response
 

--- a/cardano_node_tests/utils/http_client.py
+++ b/cardano_node_tests/utils/http_client.py
@@ -1,0 +1,14 @@
+"""Global HTTP client."""
+
+import requests
+
+_session = None
+
+
+def get_session() -> requests.Session:
+    """Get a session object."""
+    global _session  # noqa: PLW0603
+
+    if _session is None:
+        _session = requests.Session()
+    return _session

--- a/cardano_node_tests/utils/submit_api.py
+++ b/cardano_node_tests/utils/submit_api.py
@@ -13,6 +13,7 @@ import requests
 from cardano_clusterlib import clusterlib
 
 from cardano_node_tests.utils import cluster_nodes
+from cardano_node_tests.utils import http_client
 
 LOGGER = logging.getLogger(__name__)
 
@@ -64,7 +65,9 @@ def post_cbor(cbor_file: clusterlib.FileType, url: str) -> requests.Response:
         if i > 0:
             LOGGER.warning("Resubmitting transaction to submit-api.")
         try:
-            response = requests.post(url, headers=headers, data=cbor_binary, timeout=20)
+            response = http_client.get_session().post(
+                url, headers=headers, data=cbor_binary, timeout=20
+            )
         except requests.exceptions.ReadTimeout:
             delay = True
         else:


### PR DESCRIPTION
Reuse HTTP connections to avoid number of connections in TIME_WAIT status.

- Removed direct imports of `requests` in test files.
- Added `http_client` module to provide a global HTTP client session.
- Updated test files to use the global HTTP client session.
- Modified `submit_api.py` to use the global HTTP client session.