### PR TITLE
feat(tests): increase query timeout to 360 seconds

### DIFF
--- a/cardano_node_tests/tests/test_pools.py
+++ b/cardano_node_tests/tests/test_pools.py
@@ -690,7 +690,7 @@ class TestStakePool:
                     ledger_pool_data=pool_params, pool_id=pool_creation_out.stake_pool_id
                 )
 
-            dbsync_utils.retry_query(query_func=_query_func, timeout=300)
+            dbsync_utils.retry_query(query_func=_query_func, timeout=360)
 
     @allure.link(helpers.get_vcs_link())
     @pytest.mark.testnets
@@ -765,7 +765,7 @@ class TestStakePool:
                     ledger_pool_data=pool_params, pool_id=pool_creation_out.stake_pool_id
                 )
 
-            dbsync_utils.retry_query(query_func=_query_func, timeout=300)
+            dbsync_utils.retry_query(query_func=_query_func, timeout=360)
 
     @allure.link(helpers.get_vcs_link())
     @common.PARAM_USE_BUILD_CMD

--- a/cardano_node_tests/tests/tests_conway/test_drep.py
+++ b/cardano_node_tests/tests/tests_conway/test_drep.py
@@ -419,7 +419,7 @@ class TestDReps:
                     drep_data=drep_data, metadata=drep_metadata_content
                 )
 
-            dbsync_utils.retry_query(query_func=_query_func, timeout=300)
+            dbsync_utils.retry_query(query_func=_query_func, timeout=360)
 
         except AssertionError as exc:
             str_exc = str(exc)


### PR DESCRIPTION
Increased the timeout for dbsync_utils.retry_query from 300 to 360 seconds in test_pools.py and test_drep.py to ensure tests have sufficient time to complete.