### PR TITLE
feat: remove .reponotes symlink

### DIFF
--- a/.reponotes
+++ b/.reponotes
@@ -1,1 +1,0 @@
-../reponotes/cardano-node-tests


### PR DESCRIPTION
The symlink was included in a commit by mistake.