### PR TITLE
feat: update tx view golden files

### DIFF
--- a/cardano_node_tests/tests/data/test_tx_metadata_both_tx_body_json.out
+++ b/cardano_node_tests/tests/data/test_tx_metadata_both_tx_body_json.out
@@ -2,6 +2,7 @@
     "auxiliary scripts": null,
     "certificates": null,
     "collateral inputs": [],
+    "datums": [],
     "era": "Babbage",
     "fee": "190279 Lovelace",
     "inputs": [
@@ -32,6 +33,7 @@
     "reference inputs": [],
     "required signers (payment key hashes needed for scripts)": null,
     "return collateral": null,
+    "scripts": [],
     "total collateral": null,
     "update proposal": null,
     "validity range": {

--- a/cardano_node_tests/tests/data/test_tx_metadata_both_tx_json.out
+++ b/cardano_node_tests/tests/data/test_tx_metadata_both_tx_json.out
@@ -2,6 +2,7 @@
     "auxiliary scripts": null,
     "certificates": null,
     "collateral inputs": [],
+    "datums": [],
     "era": "Babbage",
     "fee": "190279 Lovelace",
     "inputs": [
@@ -32,6 +33,7 @@
     "reference inputs": [],
     "required signers (payment key hashes needed for scripts)": null,
     "return collateral": null,
+    "scripts": [],
     "total collateral": null,
     "update proposal": null,
     "validity range": {

--- a/cardano_node_tests/tests/test_cli.py
+++ b/cardano_node_tests/tests/test_cli.py
@@ -180,18 +180,20 @@ class TestCLI:
         common.get_test_id(cluster)
 
         tx_body = cluster.g_transaction.view_tx(tx_body_file=self.TX_BODY_FILE)
-        tx = cluster.g_transaction.view_tx(tx_file=self.TX_FILE)
 
         if '"redeemers":' not in tx_body:
+            pytest.skip("unsupported old output format")
+        if '"datums":' not in tx_body:
             pytest.skip("unsupported old output format")
 
         with open(self.TX_BODY_OUT_JSON, encoding="utf-8") as infile:
             tx_body_golden = infile.read()
+        assert tx_body == tx_body_golden.strip()
+
+        tx = cluster.g_transaction.view_tx(tx_file=self.TX_FILE)
 
         if '"governance actions":' in tx:
             issues.cli_799.finish_test()
-
-        assert tx_body == tx_body_golden.strip()
 
         with open(self.TX_OUT_JSON, encoding="utf-8") as infile:
             tx_golden = infile.read()


### PR DESCRIPTION
- Updated test_tx_metadata_both_tx_body_json.out to include "datums" and "scripts" fields.
- Updated test_tx_metadata_both_tx_json.out to include "datums" and "scripts" fields.
- Modified test_cli.py to handle new "datums" field and ensure compatibility with the updated output format.