### PR TITLE
refactor: replace `poetry shell` with `source` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ When running tests, the testing framework starts and stops cluster instances as 
 1. activate virtual env
 
     ```sh
-    poetry shell
+    source "$(poetry env info --path)"/bin/activate
     ```
 
 1. add virtual env to `PYTHONPATH`
@@ -278,7 +278,7 @@ It is sufficient to activate the Python virtual environment before running linte
 1. activate virtual env
 
     ```sh
-    poetry shell
+    source "$(poetry env info --path)"/bin/activate
     ```
 
 1. run linters
@@ -295,7 +295,7 @@ To install cardano-clusterlib in development mode:
 1. activate virtual env
 
     ```sh
-    poetry shell
+    source "$(poetry env info --path)"/bin/activate
     ```
 
 1. update virtual env (answer 'y' to question "Install into the current virtual env? [y/N]")

--- a/setup_dev_venv.sh
+++ b/setup_dev_venv.sh
@@ -50,4 +50,5 @@ fi
 poetry env use "python$PYTHON_VERSION"
 poetry install --with docs --with dev
 
-echo "Run \`poetry shell\` to activate the virtual env."
+# shellcheck disable=SC2016
+echo 'Run \`source "$(poetry env info --path)"/bin/activate\` to activate the virtual env.'


### PR DESCRIPTION
Updated README.md and setup_dev_venv.sh to replace `poetry shell` with `source "$(poetry env info --path)"/bin/activate` for activating the virtual environment.