### PR TITLE
feat: update doc build and deploy process

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,17 +23,17 @@ check_dev_env:
 	./scripts/check_dev_env.sh
 
 
-# generate sphinx documentation
-.PHONY: doc
-doc:
+# build sphinx documentation
+.PHONY: build_doc
+build_doc:
 	mkdir -p src_docs/build
 	$(MAKE) -C src_docs clean
 	$(MAKE) -C src_docs html
 
 
-# generate and deploy sphinx documentation
-.PHONY: doc_deploy
-doc_deploy:
+# build and deploy sphinx documentation
+.PHONY: doc
+doc:
 	./scripts/deploy_doc.sh
 
 # run tests

--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ Restaring the running development cluster is useful mainly when using the "conwa
 To check that the development environment was correctly setup, run the `make check_dev_env` script.
 
 ```text
-$ make ./check_dev_env
+$ make check_dev_env
 ./scripts/check_dev_env.sh
 'cardano-node' available: ✔
 'cardano-cli' available: ✔
@@ -350,7 +350,7 @@ Edit `pyproject.toml` and run
 Build and deploy documentation:
 
 ```sh
-make deploy_doc
+make doc
 ```
 
 ## Contributing

--- a/scripts/deploy_doc.sh
+++ b/scripts/deploy_doc.sh
@@ -32,9 +32,9 @@ if ! git diff-index --quiet HEAD --; then
 fi
 
 # build documentation
-make doc
+make build_doc
 
-# drop changes made automatically by `make doc`
+# drop changes made automatically by `make build_doc`
 if ! git diff-index --quiet HEAD -- "$DOC_SRC"; then
   git stash -- "$DOC_SRC"
   git stash drop


### PR DESCRIPTION
- Rename Makefile targets for building and deploying documentation
- Update README.md to reflect new Makefile targets
- Modify deploy_doc.sh script to use new Makefile targets