### PR TITLE
fix(Makefile): silence check_dev_env output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ lint:
 # generate and deploy sphinx documentation
 .PHONY: check_dev_env
 check_dev_env:
-	./scripts/check_dev_env.sh
+	@./scripts/check_dev_env.sh
 
 
 # build sphinx documentation

--- a/README.md
+++ b/README.md
@@ -232,7 +232,6 @@ To check that the development environment was correctly setup, run the `make che
 
 ```text
 $ make check_dev_env
-./scripts/check_dev_env.sh
 'cardano-node' available: ✔
 'cardano-cli' available: ✔
 'python' available: ✔


### PR DESCRIPTION
Added '@' to the check_dev_env target in the Makefile to silence its output. Updated README.md to reflect this change by removing the script call from the example output.