### PR TITLE
fix(makefile): update check_dev_env description

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ lint:
 	if command -v pytype >/dev/null 2>&1; then pytype -k -j auto cardano_node_tests; fi
 
 
-# generate and deploy sphinx documentation
+# check if development environment is set up correctly
 .PHONY: check_dev_env
 check_dev_env:
 	@./scripts/check_dev_env.sh


### PR DESCRIPTION
Updated the description of the check_dev_env target in the Makefile to better reflect its purpose of checking if the development environment is set up correctly.