### PR TITLE
fix(cluster_management): correct logger string arguments

### DIFF
--- a/cardano_node_tests/cluster_management/cluster_getter.py
+++ b/cardano_node_tests/cluster_management/cluster_getter.py
@@ -227,7 +227,7 @@ class ClusterGetter:
         else:
             self.log(f"c{self.cluster_instance_num}: cluster dead")
             framework_log.framework_logger().error(
-                "Failed to start cluster instance 'c%s':\n%s\nports:\n{ports}\nnetstat:\n%s",
+                "Failed to start cluster instance 'c%s':\n%s\nports:\n%s\nnetstat:\n%s",
                 self.cluster_instance_num,
                 excp,
                 ports,


### PR DESCRIPTION
Corrected the logger string arguments in cluster_getter.py to ensure proper formatting of the error message when a cluster instance fails to start.