### PR TITLE
chore: update flake.lock to latest nixpkgs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1368,16 +1368,16 @@
     },
     "nixpkgs_7": {
       "locked": {
-        "lastModified": 1731797254,
-        "narHash": "sha256-df3dJApLPhd11AlueuoN0Q4fHo/hagP75LlM5K1sz9g=",
+        "lastModified": 1737885640,
+        "narHash": "sha256-GFzPxJzTd1rPIVD4IW+GwJlyGwBDV1Tj5FLYwDQQ9sM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e8c38b73aeb218e27163376a2d617e61a2ad9b59",
+        "rev": "4e96537f163fad24ed9eb317798a79afc85b51b7",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-24.05",
+        "ref": "nixos-24.11",
         "repo": "nixpkgs",
         "type": "github"
       }


### PR DESCRIPTION
Updated the flake.lock file to point to the latest nixpkgs version. This includes changes to the lastModified, narHash, rev, and ref fields to reflect the new version.