### PR TITLE
feat: upgrade testing now starts in protocol version 10

### DIFF
--- a/.github/node_upgrade_pytest.sh
+++ b/.github/node_upgrade_pytest.sh
@@ -33,7 +33,6 @@ if [ "$1" = "step1" ]; then
 
   export UPGRADE_TESTS_STEP=1
   export ENABLE_LEGACY=1
-  export PV9=1
 
   if [ -n "${BASE_TAR_URL:-""}" ]; then
     # download and extract base revision binaries
@@ -107,7 +106,6 @@ elif [ "$1" = "step2" ]; then
 
   export UPGRADE_TESTS_STEP=2
   export MIXED_P2P=1
-  export PV9=1
   unset ENABLE_LEGACY
 
   # Setup `cardano-cli` binary
@@ -233,7 +231,7 @@ elif [ "$1" = "step2" ]; then
   pytest cardano_node_tests/tests/test_node_upgrade.py -k test_ignore_log_errors
   err_retval="$?"
 
-  # Update PlutusV3 cost models.
+  # Update Plutus cost models.
   pytest cardano_node_tests/tests/test_node_upgrade.py -k test_update_cost_models || exit 6
 
   # run smoke tests
@@ -269,7 +267,7 @@ elif [ "$1" = "step3" ]; then
   printf "STEP3 start: %(%H:%M:%S)T\n" -1
 
   export UPGRADE_TESTS_STEP=3
-  unset ENABLE_LEGACY MIXED_P2P PV9
+  unset ENABLE_LEGACY MIXED_P2P
 
   # Setup `cardano-cli` binary
   if [ -n "${UPGRADE_CLI_REVISION:-""}" ]; then

--- a/cardano_node_tests/tests/test_node_upgrade.py
+++ b/cardano_node_tests/tests/test_node_upgrade.py
@@ -99,6 +99,7 @@ class TestSetup:
         )
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.disabled(reason="The test is not needed when we are already in PV10 on mainnet")
     @pytest.mark.skipif(UPGRADE_TESTS_STEP != 2, reason="runs only on step 2 of upgrade testing")
     def test_update_cost_models(
         self,
@@ -196,6 +197,7 @@ class TestSetup:
         _check_models(enact_gov_state["currentPParams"]["costModels"])
 
     @allure.link(helpers.get_vcs_link())
+    @pytest.mark.disabled(reason="The test is not needed when we are already in PV10 on mainnet")
     @pytest.mark.skipif(UPGRADE_TESTS_STEP != 3, reason="runs only on step 3 of upgrade testing")
     def test_hardfork(
         self,

--- a/src_docs/source/test_results/nightly_system_tests.rst
+++ b/src_docs/source/test_results/nightly_system_tests.rst
@@ -47,7 +47,7 @@ Nightly upgrade testing
 * `Step 1 <https://cardano-tests-reports-3-74-115-22.nip.io/cardano-node-tests-nightly-upgrade/step1/>`__:  |nightly-upgrade-step1-badge|
    * use the `latest cardano-node release <https://github.com/IntersectMBO/cardano-node-tests/blob/master/.github/env_nightly_upgrade>`__ for Mainnet
    * network in Conway era
-   * protocol version 9 (bootstrap phase)
+   * protocol version 10
    * Constitutional Commitee has 5 members
    * default (legacy) network topology
    * smoke tests
@@ -55,12 +55,10 @@ Nightly upgrade testing
 * `Step 2 <https://cardano-tests-reports-3-74-115-22.nip.io/cardano-node-tests-nightly-upgrade/step2/>`__:  |nightly-upgrade-step2-badge|
    * upgrade all nodes except one to the latest cardano-node master
    * mixed network topology (half nodes P2P, half nodes legacy topology)
-   * update PlutusV3 cost models
    * smoke tests
 * `Step 3 <https://cardano-tests-reports-3-74-115-22.nip.io/cardano-node-tests-nightly-upgrade/step3/>`__:  |nightly-upgrade-step3-badge|
    * upgrade the last remaining node to latest cardano-node master
    * P2P network topology
-   * hard fork to Conway protocol version 10
    * smoke tests
    * governance treasury withdrawal action test
 


### PR DESCRIPTION
- Configured the testnet to start in PV10 in node_upgrade_pytest.sh
- Disabled tests not needed for PV10 in test_node_upgrade.py
- Updated documentation for nightly system tests to reflect PV10