### PR TITLE
refactor(utils): replace custom callonce with functools.cache

### DIFF
--- a/cardano_node_tests/utils/cluster_nodes.py
+++ b/cardano_node_tests/utils/cluster_nodes.py
@@ -2,6 +2,7 @@
 
 # ruff: noqa: ARG002
 import dataclasses
+import functools
 import json
 import logging
 import os
@@ -291,7 +292,7 @@ class TestnetCluster(ClusterType):
         return addrs_data
 
 
-@helpers.callonce
+@functools.cache
 def get_cluster_type() -> ClusterType:
     """Return instance of the cluster type indicated by configuration."""
     if configuration.BOOTSTRAP_DIR:

--- a/cardano_node_tests/utils/framework_log.py
+++ b/cardano_node_tests/utils/framework_log.py
@@ -1,17 +1,17 @@
+import functools
 import logging
 import pathlib as pl
 import time
 
-from cardano_node_tests.utils import helpers
 from cardano_node_tests.utils import temptools
 
 
-@helpers.callonce
+@functools.cache
 def get_framework_log_path() -> pl.Path:
     return temptools.get_pytest_worker_tmp() / "framework.log"
 
 
-@helpers.callonce
+@functools.cache
 def framework_logger() -> logging.Logger:
     """Get logger for the `framework.log` file.
 

--- a/cardano_node_tests/utils/helpers.py
+++ b/cardano_node_tests/utils/helpers.py
@@ -27,28 +27,6 @@ GITHUB_URL = "https://github.com/IntersectMBO/cardano-node-tests"
 TCallable = tp.TypeVar("TCallable", bound=tp.Callable)
 
 
-def callonce(func: TCallable) -> TCallable:
-    """Call a function and cache its return value.
-
-    .. warning::
-       The function arguments are not considered when caching the result.
-       Therefore, this decorator should be used only for functions without arguments
-       or for functions with constant arguments.
-    """
-    result: list = []
-
-    @functools.wraps(func)
-    def wrapper(*args, **kwargs):  # type: ignore
-        if result:
-            return result[0]
-
-        retval = func(*args, **kwargs)
-        result.append(retval)
-        return retval
-
-    return tp.cast(TCallable, wrapper)
-
-
 @contextlib.contextmanager
 def change_cwd(dir_path: ttypes.FileType) -> tp.Iterator[ttypes.FileType]:
     """Change and restore CWD - context manager."""
@@ -136,7 +114,7 @@ def run_in_bash(command: str, workdir: ttypes.FileType = "") -> bytes:
     return run_command(cmd, workdir=workdir)
 
 
-@callonce
+@functools.cache
 def get_current_commit() -> str:
     # TODO: make sure we are in correct repo
     return os.environ.get("GIT_REVISION") or run_command("git rev-parse HEAD").decode().strip()

--- a/cardano_node_tests/utils/temptools.py
+++ b/cardano_node_tests/utils/temptools.py
@@ -1,11 +1,10 @@
+import functools
 import os
 import pathlib as pl
 import tempfile
 import typing as tp
 
 from _pytest.tmpdir import TempPathFactory
-
-from cardano_node_tests.utils import helpers
 
 IS_XDIST = bool(os.environ.get("PYTEST_XDIST_TESTRUNUID"))
 
@@ -65,7 +64,7 @@ def get_pytest_shared_tmp() -> pl.Path:
     return PytestTempDirs.pytest_shared_tmp
 
 
-@helpers.callonce
+@functools.cache
 def get_basetemp() -> pl.Path:
     """Return base temporary directory for tests artifacts."""
     basetemp = pl.Path(tempfile.gettempdir()) / "cardano-node-tests"


### PR DESCRIPTION
Replaced the custom `callonce` decorator with `functools.cache` in multiple utility modules. This simplifies the code and leverages the built-in caching mechanism provided by Python's standard library.