### PR TITLE
refactor: rename TokenRecord, move Token

### DIFF
--- a/cardano_node_tests/tests/plutus_common.py
+++ b/cardano_node_tests/tests/plutus_common.py
@@ -478,12 +478,6 @@ class PlutusOp:
 
 
 @dataclasses.dataclass(frozen=True, order=True)
-class Token:
-    coin: str
-    amount: int
-
-
-@dataclasses.dataclass(frozen=True, order=True)
 class ScriptCost:
     fee: int
     collateral: int  # Lovelace amount > minimum UTxO value

--- a/cardano_node_tests/tests/test_native_tokens.py
+++ b/cardano_node_tests/tests/test_native_tokens.py
@@ -194,7 +194,7 @@ class TestMinting:
         policyid = cluster.g_transaction.get_policyid(multisig_script)
         token = f"{policyid}.{asset_name}" if asset_name else policyid
 
-        token_mint = clusterlib_utils.TokenRecord(
+        token_mint = clusterlib_utils.NativeTokenRec(
             token=token,
             amount=amount,
             issuers_addrs=token_issuers,
@@ -293,7 +293,7 @@ class TestMinting:
         policyid = cluster.g_transaction.get_policyid(script)
         token = f"{policyid}.{asset_name}" if asset_name else policyid
 
-        token_mint = clusterlib_utils.TokenRecord(
+        token_mint = clusterlib_utils.NativeTokenRec(
             token=token,
             amount=amount,
             issuers_addrs=[issuer_addr],
@@ -394,14 +394,14 @@ class TestMinting:
             # identified by just policyid
             tokens_mint.extend(
                 [
-                    clusterlib_utils.TokenRecord(
+                    clusterlib_utils.NativeTokenRec(
                         token=aname_token,
                         amount=amount,
                         issuers_addrs=[i_addrs[i]],
                         token_mint_addr=token_mint_addr,
                         script=script,
                     ),
-                    clusterlib_utils.TokenRecord(
+                    clusterlib_utils.NativeTokenRec(
                         token=policyid,
                         amount=amount,
                         issuers_addrs=[i_addrs[i]],
@@ -503,7 +503,7 @@ class TestMinting:
         tokens = [f"{policyid}.{an}" for an in asset_names]
 
         tokens_mint = [
-            clusterlib_utils.TokenRecord(
+            clusterlib_utils.NativeTokenRec(
                 token=t,
                 amount=amount,
                 issuers_addrs=[issuer_addr],
@@ -736,7 +736,7 @@ class TestMinting:
             token = f"{policyid}.{asset_name}"
 
             tokens_to_mint.append(
-                clusterlib_utils.TokenRecord(
+                clusterlib_utils.NativeTokenRec(
                     token=token,
                     amount=amount,
                     issuers_addrs=issuers_addrs,
@@ -886,7 +886,7 @@ class TestMinting:
             token = f"{policyid}.{asset_name}"
 
             tokens_to_mint.append(
-                clusterlib_utils.TokenRecord(
+                clusterlib_utils.NativeTokenRec(
                     token=token,
                     amount=amount,
                     issuers_addrs=[issuer_addr],
@@ -1026,7 +1026,7 @@ class TestMinting:
         policyid = cluster.g_transaction.get_policyid(multisig_script)
         token = f"{policyid}.{asset_name}"
 
-        token_mint = clusterlib_utils.TokenRecord(
+        token_mint = clusterlib_utils.NativeTokenRec(
             token=token,
             amount=amount,
             issuers_addrs=issuers_addrs,
@@ -1127,7 +1127,7 @@ class TestMinting:
         policyid = cluster.g_transaction.get_policyid(script)
         token = f"{policyid}.{asset_name}"
 
-        token_mint = clusterlib_utils.TokenRecord(
+        token_mint = clusterlib_utils.NativeTokenRec(
             token=token,
             amount=amount,
             issuers_addrs=[issuer_addr],
@@ -1215,7 +1215,7 @@ class TestPolicies:
             token = f"{policyid}.{asset_name}"
 
             tokens_to_mint.append(
-                clusterlib_utils.TokenRecord(
+                clusterlib_utils.NativeTokenRec(
                     token=token,
                     amount=amount,
                     issuers_addrs=issuers_addrs,
@@ -1309,7 +1309,7 @@ class TestPolicies:
             token = f"{policyid}.{asset_name}"
 
             tokens_to_mint.append(
-                clusterlib_utils.TokenRecord(
+                clusterlib_utils.NativeTokenRec(
                     token=token,
                     amount=amount,
                     issuers_addrs=issuers_addrs,
@@ -1396,7 +1396,7 @@ class TestPolicies:
             token = f"{policyid}.{asset_name}"
 
             tokens_to_mint.append(
-                clusterlib_utils.TokenRecord(
+                clusterlib_utils.NativeTokenRec(
                     token=token,
                     amount=amount,
                     issuers_addrs=issuers_addrs,
@@ -1470,7 +1470,7 @@ class TestPolicies:
             token = f"{policyid}.{asset_name}"
 
             tokens_to_mint.append(
-                clusterlib_utils.TokenRecord(
+                clusterlib_utils.NativeTokenRec(
                     token=token,
                     amount=amount,
                     issuers_addrs=issuers_addrs,
@@ -1533,7 +1533,7 @@ class TestPolicies:
             token = f"{policyid}.{asset_name}"
 
             tokens_to_mint.append(
-                clusterlib_utils.TokenRecord(
+                clusterlib_utils.NativeTokenRec(
                     token=token,
                     amount=amount,
                     issuers_addrs=issuers_addrs,
@@ -1607,7 +1607,7 @@ class TestPolicies:
             token = f"{policyid}.{asset_name}"
 
             tokens_to_mint.append(
-                clusterlib_utils.TokenRecord(
+                clusterlib_utils.NativeTokenRec(
                     token=token,
                     amount=amount,
                     issuers_addrs=issuers_addrs,
@@ -1664,8 +1664,8 @@ class TestTransfer:
         cluster_manager: cluster_management.ClusterManager,
         cluster: clusterlib.ClusterLib,
         payment_addrs: list[clusterlib.AddressRecord],
-    ) -> clusterlib_utils.TokenRecord:
-        fixture_cache: cluster_management.FixtureCache[clusterlib_utils.TokenRecord | None]
+    ) -> clusterlib_utils.NativeTokenRec:
+        fixture_cache: cluster_management.FixtureCache[clusterlib_utils.NativeTokenRec | None]
         with cluster_manager.cache_fixture() as fixture_cache:
             if fixture_cache.value is not None:
                 return fixture_cache.value
@@ -1698,7 +1698,7 @@ class TestTransfer:
         self,
         cluster: clusterlib.ClusterLib,
         payment_addrs: list[clusterlib.AddressRecord],
-        new_token: clusterlib_utils.TokenRecord,
+        new_token: clusterlib_utils.NativeTokenRec,
         amount: int,
         use_build_cmd: bool,
     ):
@@ -1831,7 +1831,7 @@ class TestTransfer:
         self,
         cluster: clusterlib.ClusterLib,
         payment_addrs: list[clusterlib.AddressRecord],
-        new_token: clusterlib_utils.TokenRecord,
+        new_token: clusterlib_utils.NativeTokenRec,
         use_build_cmd: bool,
     ):
         """Test sending multiple different tokens to payment addresses.
@@ -2013,7 +2013,7 @@ class TestTransfer:
         self,
         cluster: clusterlib.ClusterLib,
         payment_addrs: list[clusterlib.AddressRecord],
-        new_token: clusterlib_utils.TokenRecord,
+        new_token: clusterlib_utils.NativeTokenRec,
         use_build_cmd: bool,
     ):
         """Try to create an UTxO with just native tokens, no ADA. Expect failure."""
@@ -2068,7 +2068,7 @@ class TestTransfer:
         self,
         cluster: clusterlib.ClusterLib,
         payment_addrs: list[clusterlib.AddressRecord],
-        new_token: clusterlib_utils.TokenRecord,
+        new_token: clusterlib_utils.NativeTokenRec,
         use_build_cmd: bool,
         token_amount: int,
     ):
@@ -2139,7 +2139,7 @@ class TestNegative:
     def _mint_tx(
         self,
         cluster_obj: clusterlib.ClusterLib,
-        new_tokens: list[clusterlib_utils.TokenRecord],
+        new_tokens: list[clusterlib_utils.NativeTokenRec],
         temp_template: str,
     ) -> pl.Path:
         """Return signed TX for minting new token. Sign using skeys."""
@@ -2220,7 +2220,7 @@ class TestNegative:
         issuer_addr = issuers_addrs[1]
         amount = 20_000_000
 
-        token_mint = clusterlib_utils.TokenRecord(
+        token_mint = clusterlib_utils.NativeTokenRec(
             token=token,
             amount=amount,
             issuers_addrs=[issuer_addr],
@@ -2264,7 +2264,7 @@ class TestNegative:
         token_mint_addr = issuers_addrs[0]
         issuer_addr = issuers_addrs[1]
 
-        token_mint = clusterlib_utils.TokenRecord(
+        token_mint = clusterlib_utils.NativeTokenRec(
             token=token,
             amount=token_amount,
             issuers_addrs=[issuer_addr],

--- a/cardano_node_tests/tests/test_staking_rewards.py
+++ b/cardano_node_tests/tests/test_staking_rewards.py
@@ -388,7 +388,7 @@ class TestRewards:
             pool_id=pool_id,
         )
 
-        native_tokens: list[clusterlib_utils.TokenRecord] = []
+        native_tokens: list[clusterlib_utils.NativeTokenRec] = []
         if VERSIONS.transaction_era >= VERSIONS.MARY:
             # Create native tokens UTxOs for pool user
             native_tokens = clusterlib_utils.new_tokens(

--- a/cardano_node_tests/tests/tests_plutus/spend_build.py
+++ b/cardano_node_tests/tests/tests_plutus/spend_build.py
@@ -20,8 +20,8 @@ def _build_fund_script(
     payment_addr: clusterlib.AddressRecord,
     dst_addr: clusterlib.AddressRecord,
     plutus_op: plutus_common.PlutusOp,
-    tokens: list[plutus_common.Token] | None = None,  # tokens must already be in `payment_addr`
-    tokens_collateral: list[plutus_common.Token]
+    tokens: list[clusterlib_utils.Token] | None = None,  # tokens must already be in `payment_addr`
+    tokens_collateral: list[clusterlib_utils.Token]
     | None = None,  # tokens must already be in `payment_addr`
     embed_datum: bool = False,
 ) -> tuple[list[clusterlib.UTXOData], list[clusterlib.UTXOData], clusterlib.TxRawOutput]:
@@ -139,7 +139,7 @@ def _build_spend_locked_txin(  # noqa: C901
     tx_files: clusterlib.TxFiles | None = None,
     invalid_hereafter: int | None = None,
     invalid_before: int | None = None,
-    tokens: list[plutus_common.Token] | None = None,
+    tokens: list[clusterlib_utils.Token] | None = None,
     expect_failure: bool = False,
     script_valid: bool = True,
     submit_tx: bool = True,

--- a/cardano_node_tests/tests/tests_plutus/spend_raw.py
+++ b/cardano_node_tests/tests/tests_plutus/spend_raw.py
@@ -6,6 +6,7 @@ from cardano_clusterlib import clusterlib
 
 from cardano_node_tests.tests import issues
 from cardano_node_tests.tests import plutus_common
+from cardano_node_tests.utils import clusterlib_utils
 from cardano_node_tests.utils import dbsync_utils
 from cardano_node_tests.utils import tx_view
 from cardano_node_tests.utils.versions import VERSIONS
@@ -26,8 +27,8 @@ def _fund_script(
     amount: int,
     fee_txsize: int = FEE_REDEEM_TXSIZE,
     deposit_amount: int = 0,
-    tokens: list[plutus_common.Token] | None = None,  # tokens must already be in `payment_addr`
-    tokens_collateral: list[plutus_common.Token]
+    tokens: list[clusterlib_utils.Token] | None = None,  # tokens must already be in `payment_addr`
+    tokens_collateral: list[clusterlib_utils.Token]
     | None = None,  # tokens must already be in `payment_addr`
     collateral_fraction_offset: float = 1.0,
     embed_datum: bool = False,
@@ -135,7 +136,7 @@ def _spend_locked_txin(  # noqa: C901
     tx_files: clusterlib.TxFiles | None = None,
     invalid_hereafter: int | None = None,
     invalid_before: int | None = None,
-    tokens: list[plutus_common.Token] | None = None,
+    tokens: list[clusterlib_utils.Token] | None = None,
     expect_failure: bool = False,
     script_valid: bool = True,
     submit_tx: bool = True,

--- a/cardano_node_tests/tests/tests_plutus/test_spend_build.py
+++ b/cardano_node_tests/tests/tests_plutus/test_spend_build.py
@@ -804,7 +804,7 @@ class TestBuildLocking:
             issuer_addr=payment_addrs[0],
             amount=100,
         )
-        tokens_rec = [plutus_common.Token(coin=t.token, amount=t.amount) for t in tokens]
+        tokens_rec = [clusterlib_utils.Token(coin=t.token, amount=t.amount) for t in tokens]
 
         script_utxos, collateral_utxos, tx_output_fund = spend_build._build_fund_script(
             temp_template=temp_template,
@@ -887,7 +887,7 @@ class TestBuildLocking:
             issuer_addr=payment_addrs[0],
             amount=token_amount_fund,
         )
-        tokens_fund_rec = [plutus_common.Token(coin=t.token, amount=t.amount) for t in tokens]
+        tokens_fund_rec = [clusterlib_utils.Token(coin=t.token, amount=t.amount) for t in tokens]
 
         script_utxos, collateral_utxos, tx_output_fund = spend_build._build_fund_script(
             temp_template=temp_template,
@@ -899,7 +899,7 @@ class TestBuildLocking:
         )
 
         tokens_spend_rec = [
-            plutus_common.Token(coin=t.token, amount=token_amount_spend) for t in tokens
+            clusterlib_utils.Token(coin=t.token, amount=token_amount_spend) for t in tokens
         ]
 
         __, tx_output_spend, plutus_costs = spend_build._build_spend_locked_txin(

--- a/cardano_node_tests/tests/tests_plutus/test_spend_negative_build.py
+++ b/cardano_node_tests/tests/tests_plutus/test_spend_negative_build.py
@@ -197,7 +197,7 @@ class TestNegative:
             issuer_addr=payment_addr,
             amount=100,
         )
-        tokens_rec = [plutus_common.Token(coin=t.token, amount=t.amount) for t in tokens]
+        tokens_rec = [clusterlib_utils.Token(coin=t.token, amount=t.amount) for t in tokens]
 
         script_utxos, collateral_utxos, tx_output_fund = spend_build._build_fund_script(
             temp_template=temp_template,

--- a/cardano_node_tests/tests/tests_plutus/test_spend_negative_raw.py
+++ b/cardano_node_tests/tests/tests_plutus/test_spend_negative_raw.py
@@ -309,7 +309,7 @@ class TestNegative:
             issuer_addr=payment_addrs[0],
             amount=token_amount,
         )
-        tokens_rec = [plutus_common.Token(coin=t.token, amount=t.amount) for t in tokens]
+        tokens_rec = [clusterlib_utils.Token(coin=t.token, amount=t.amount) for t in tokens]
 
         script_utxos, collateral_utxos, __ = spend_raw._fund_script(
             temp_template=temp_template,

--- a/cardano_node_tests/tests/tests_plutus/test_spend_raw.py
+++ b/cardano_node_tests/tests/tests_plutus/test_spend_raw.py
@@ -785,7 +785,7 @@ class TestLocking:
             issuer_addr=payment_addrs[0],
             amount=token_amount,
         )
-        tokens_rec = [plutus_common.Token(coin=t.token, amount=t.amount) for t in tokens]
+        tokens_rec = [clusterlib_utils.Token(coin=t.token, amount=t.amount) for t in tokens]
 
         script_utxos, collateral_utxos, __ = spend_raw._fund_script(
             temp_template=temp_template,
@@ -854,7 +854,7 @@ class TestLocking:
             issuer_addr=payment_addrs[0],
             amount=token_amount_fund,
         )
-        tokens_fund_rec = [plutus_common.Token(coin=t.token, amount=t.amount) for t in tokens]
+        tokens_fund_rec = [clusterlib_utils.Token(coin=t.token, amount=t.amount) for t in tokens]
 
         script_utxos, collateral_utxos, __ = spend_raw._fund_script(
             temp_template=temp_template,
@@ -868,7 +868,7 @@ class TestLocking:
         )
 
         tokens_spend_rec = [
-            plutus_common.Token(coin=t.token, amount=token_amount_spend) for t in tokens
+            clusterlib_utils.Token(coin=t.token, amount=token_amount_spend) for t in tokens
         ]
 
         __, tx_output_spend = spend_raw._spend_locked_txin(

--- a/cardano_node_tests/tests/tests_plutus_v2/spend_build.py
+++ b/cardano_node_tests/tests/tests_plutus_v2/spend_build.py
@@ -50,7 +50,7 @@ def _build_fund_script(
     use_reference_script: bool = False,
     use_inline_datum: bool = True,
     collateral_amount: int | None = None,
-    tokens_collateral: list[plutus_common.Token]
+    tokens_collateral: list[clusterlib_utils.Token]
     | None = None,  # tokens must already be in `payment_addr`
 ) -> tuple[
     list[clusterlib.UTXOData],

--- a/cardano_node_tests/tests/tests_plutus_v2/spend_raw.py
+++ b/cardano_node_tests/tests/tests_plutus_v2/spend_raw.py
@@ -4,6 +4,7 @@ import logging
 from cardano_clusterlib import clusterlib
 
 from cardano_node_tests.tests import plutus_common
+from cardano_node_tests.utils import clusterlib_utils
 from cardano_node_tests.utils import dbsync_utils
 from cardano_node_tests.utils import tx_view
 from cardano_node_tests.utils.versions import VERSIONS
@@ -46,7 +47,7 @@ def _fund_script(
     use_reference_script: bool = False,
     use_inline_datum: bool = False,
     collateral_amount: int | None = None,
-    tokens_collateral: list[plutus_common.Token]
+    tokens_collateral: list[clusterlib_utils.Token]
     | None = None,  # tokens must already be in `payment_addr`
 ) -> tuple[
     list[clusterlib.UTXOData],

--- a/cardano_node_tests/tests/tests_plutus_v2/test_spend_collateral_build.py
+++ b/cardano_node_tests/tests/tests_plutus_v2/test_spend_collateral_build.py
@@ -290,7 +290,7 @@ class TestCollateralOutput:
             issuer_addr=payment_addr,
             amount=token_amount,
         )
-        tokens_rec = [plutus_common.Token(coin=token[0].token, amount=token[0].amount)]
+        tokens_rec = [clusterlib_utils.Token(coin=token[0].token, amount=token[0].amount)]
 
         # Fund the script address and create a UTxO for collateral
 

--- a/cardano_node_tests/tests/tests_plutus_v2/test_spend_collateral_raw.py
+++ b/cardano_node_tests/tests/tests_plutus_v2/test_spend_collateral_raw.py
@@ -246,7 +246,7 @@ class TestCollateralOutput:
             issuer_addr=payment_addr,
             amount=token_amount,
         )
-        tokens_rec = [plutus_common.Token(coin=token[0].token, amount=token[0].amount)]
+        tokens_rec = [clusterlib_utils.Token(coin=token[0].token, amount=token[0].amount)]
 
         # Fund the script address and create a UTxO for collateral
         script_utxos, collateral_utxos, *__ = spend_raw._fund_script(

--- a/cardano_node_tests/utils/clusterlib_utils.py
+++ b/cardano_node_tests/utils/clusterlib_utils.py
@@ -31,12 +31,18 @@ class UpdateProposal:
 
 
 @dataclasses.dataclass(frozen=True, order=True)
-class TokenRecord:
+class NativeTokenRec:
     token: str
     amount: int
     issuers_addrs: list[clusterlib.AddressRecord]
     token_mint_addr: clusterlib.AddressRecord
     script: pl.Path
+
+
+@dataclasses.dataclass(frozen=True, order=True)
+class Token:
+    coin: str
+    amount: int
 
 
 @dataclasses.dataclass(frozen=True, order=True)
@@ -572,7 +578,7 @@ def update_params_build(
 
 def mint_or_burn_witness(
     cluster_obj: clusterlib.ClusterLib,
-    new_tokens: list[TokenRecord],
+    new_tokens: list[NativeTokenRec],
     temp_template: str,
     invalid_hereafter: int | None = None,
     invalid_before: int | None = None,
@@ -697,7 +703,7 @@ def mint_or_burn_witness(
 
 def mint_or_burn_sign(
     cluster_obj: clusterlib.ClusterLib,
-    new_tokens: list[TokenRecord],
+    new_tokens: list[NativeTokenRec],
     temp_template: str,
     submit_method: str = submit_utils.SubmitMethods.CLI,
     use_build_cmd: bool = False,
@@ -874,7 +880,7 @@ def new_tokens(
     token_mint_addr: clusterlib.AddressRecord,
     issuer_addr: clusterlib.AddressRecord,
     amount: int,
-) -> list[TokenRecord]:
+) -> list[NativeTokenRec]:
     """Mint new token, sign using skeys."""
     # Create simple script
     keyhash = cluster_obj.g_address.get_payment_vkey_hash(payment_vkey_file=issuer_addr.vkey_file)
@@ -894,7 +900,7 @@ def new_tokens(
             raise AssertionError(msg)
 
         tokens_to_mint.append(
-            TokenRecord(
+            NativeTokenRec(
                 token=token,
                 amount=amount,
                 issuers_addrs=[issuer_addr],


### PR DESCRIPTION
Renamed the TokenRecord class to NativeTokenRec across multiple files for better clarity and consistency.
Moved Token class to clusterlib_utils as it is not Plutus speciffic.