### PR TITLE
feat: add --no-write-lock-file to nix build commands

### DIFF
--- a/.github/source_cardano_cli.sh
+++ b/.github/source_cardano_cli.sh
@@ -11,6 +11,7 @@ fi
 # Build `cardano-cli`
 nix build \
   --accept-flake-config \
+  --no-write-lock-file \
   "github://github.com/IntersectMBO/cardano-cli?ref=${CARDANO_CLI_REV}#cardano-cli" \
   -o cardano-cli-build || exit 1
 [ -e cardano-cli-build/bin/cardano-cli ] || exit 1

--- a/.github/source_plutus_apps.sh
+++ b/.github/source_plutus_apps.sh
@@ -11,6 +11,7 @@ fi
 # Build `create-script-context`
 nix build \
   --accept-flake-config \
+  --no-write-lock-file \
   "github://github.com/IntersectMBO/plutus-apps?ref=${PLUTUS_APPS_REV}#create-script-context" \
   -o create-script-context-build || exit 1
 [ -e create-script-context-build/bin/create-script-context ] || exit 1


### PR DESCRIPTION
Added the --no-write-lock-file option to nix build commands in source_cardano_cli.sh and source_plutus_apps.sh to prevent writing lock files during the build process.

Changes:
- Modified .github/source_cardano_cli.sh
- Modified .github/source_plutus_apps.sh