### PR TITLE
feat(plutus): minimize locked funds on spend script addresses

### DIFF
--- a/cardano_node_tests/tests/plutus_common.py
+++ b/cardano_node_tests/tests/plutus_common.py
@@ -90,14 +90,14 @@ class ExecutionCost:
 # Scripts execution cost for Txs with single UTxO input and single Plutus script
 ALWAYS_FAILS_COST = ExecutionCost(per_time=476_468, per_space=1_700, fixed_cost=133)
 ALWAYS_SUCCEEDS_COST = ExecutionCost(per_time=368_100, per_space=1_700, fixed_cost=125)
-GUESSING_GAME_COST = ExecutionCost(per_time=236_715_138, per_space=870_842, fixed_cost=67_315)
+GUESSING_GAME_COST = ExecutionCost(per_time=282_016_214, per_space=1_034_516, fixed_cost=80_025)
 GUESSING_GAME_UNTYPED_COST = ExecutionCost(per_time=4_985_806, per_space=11_368, fixed_cost=1_016)
 # TODO: fix once context equivalence tests can run again
 CONTEXT_EQUIVALENCE_COST = ExecutionCost(per_time=100_000_000, per_space=1_000_00, fixed_cost=947)
 
 ALWAYS_FAILS_V2_COST = ExecutionCost(per_time=230_100, per_space=1_100, fixed_cost=81)
 ALWAYS_SUCCEEDS_V2_COST = ExecutionCost(per_time=230_100, per_space=1_100, fixed_cost=81)
-GUESSING_GAME_V2_COST = ExecutionCost(per_time=168_868_800, per_space=540_612, fixed_cost=43_369)
+GUESSING_GAME_V2_COST = ExecutionCost(per_time=200_253_161, per_space=637_676, fixed_cost=51_233)
 GUESSING_GAME_UNTYPED_V2_COST = ExecutionCost(
     per_time=4_985_806, per_space=11_368, fixed_cost=1_016
 )

--- a/cardano_node_tests/tests/tests_plutus/test_spend_compat_build.py
+++ b/cardano_node_tests/tests/tests_plutus/test_spend_compat_build.py
@@ -76,6 +76,7 @@ class TestCompatibility:
             payment_addr=payment_addrs[0],
             dst_addr=payment_addrs[1],
             plutus_op=plutus_op,
+            amount=100_000,
         )
 
         with pytest.raises(clusterlib.CLIError) as excinfo:
@@ -87,7 +88,7 @@ class TestCompatibility:
                 script_utxos=script_utxos,
                 collateral_utxos=collateral_utxos,
                 plutus_op=plutus_op,
-                amount=2_000_000,
+                amount=-1,
                 submit_tx=False,
             )
 

--- a/cardano_node_tests/tests/tests_plutus/test_spend_compat_raw.py
+++ b/cardano_node_tests/tests/tests_plutus/test_spend_compat_raw.py
@@ -61,7 +61,7 @@ class TestCompatibility:
         * (optional) check transactions in db-sync
         """
         temp_template = common.get_test_id(cluster)
-        amount = 2_000_000
+        amount = 1_000_000
 
         plutus_op = plutus_common.PlutusOp(
             script_file=plutus_common.ALWAYS_SUCCEEDS["v2"].script_file,
@@ -83,6 +83,7 @@ class TestCompatibility:
             spend_raw._spend_locked_txin(
                 temp_template=temp_template,
                 cluster_obj=cluster,
+                payment_addr=payment_addrs[0],
                 dst_addr=payment_addrs[1],
                 script_utxos=script_utxos,
                 collateral_utxos=collateral_utxos,
@@ -114,7 +115,7 @@ class TestCompatibility:
         * (optional) check transactions in db-sync
         """
         temp_template = common.get_test_id(cluster)
-        amount = 2_000_000
+        amount = 1_000_000
 
         plutus_op = plutus_common.PlutusOp(
             script_file=plutus_common.ALWAYS_SUCCEEDS["v1"].script_file,
@@ -136,6 +137,7 @@ class TestCompatibility:
             spend_raw._spend_locked_txin(
                 temp_template=temp_template,
                 cluster_obj=cluster,
+                payment_addr=payment_addrs[0],
                 dst_addr=payment_addrs[1],
                 script_utxos=script_utxos,
                 collateral_utxos=collateral_utxos,

--- a/cardano_node_tests/tests/tests_plutus/test_spend_datum_build.py
+++ b/cardano_node_tests/tests/tests_plutus/test_spend_datum_build.py
@@ -323,6 +323,7 @@ class TestNegativeDatum:
                 payment_addr=payment_addrs[0],
                 dst_addr=payment_addrs[1],
                 plutus_op=plutus_op,
+                amount=100_000,
             )
 
         err_str = str(excinfo.value)
@@ -356,6 +357,7 @@ class TestNegativeDatum:
             payment_addr=payment_addrs[0],
             dst_addr=payment_addrs[1],
             plutus_op=plutus_op_1,
+            amount=1_000_000,
         )
 
         # Use a wrong datum to try to unlock the funds
@@ -376,7 +378,7 @@ class TestNegativeDatum:
                 script_utxos=script_utxos,
                 collateral_utxos=collateral_utxos,
                 plutus_op=plutus_op_2,
-                amount=2_000_000,
+                amount=-1,
                 submit_tx=False,
             )
         except clusterlib.CLIError as exc:
@@ -405,8 +407,8 @@ class TestNegativeDatum:
         """
         temp_template = common.get_test_id(cluster)
 
-        amount_fund = 4_000_000
-        amount_redeem = 2_000_000
+        amount_fund = 3_000_000
+        amount_redeem = 1_500_000
         amount_collateral = 2_000_000
 
         payment_addr = payment_addrs[0]

--- a/cardano_node_tests/tests/tests_plutus/test_spend_datum_raw.py
+++ b/cardano_node_tests/tests/tests_plutus/test_spend_datum_raw.py
@@ -141,7 +141,7 @@ class TestNegativeDatum:
         * check that the expected error was raised
         """
         temp_template = common.get_test_id(cluster)
-        amount = 2_000_000
+        amount = 1_000_000
 
         payment_addr = payment_addrs[0]
         dst_addr = payment_addrs[1]
@@ -190,6 +190,7 @@ class TestNegativeDatum:
             spend_raw._spend_locked_txin(
                 temp_template=temp_template,
                 cluster_obj=cluster,
+                payment_addr=payment_addr,
                 dst_addr=dst_addr,
                 script_utxos=script_utxos,
                 collateral_utxos=collateral_utxos,
@@ -264,7 +265,7 @@ class TestNegativeDatum:
         Expect failure.
         """
         temp_template = common.get_test_id(cluster)
-        amount = 2_000_000
+        amount = 1_000_000
 
         payment_addr = payment_addrs[0]
         dst_addr = payment_addrs[1]
@@ -298,6 +299,7 @@ class TestNegativeDatum:
             spend_raw._spend_locked_txin(
                 temp_template=temp_template,
                 cluster_obj=cluster,
+                payment_addr=payment_addr,
                 dst_addr=dst_addr,
                 script_utxos=script_utxos,
                 collateral_utxos=collateral_utxos,
@@ -390,6 +392,7 @@ class TestNegativeDatum:
             spend_raw._spend_locked_txin(
                 temp_template=temp_template,
                 cluster_obj=cluster,
+                payment_addr=payment_addr,
                 dst_addr=dst_addr,
                 script_utxos=[datum_utxo],
                 collateral_utxos=collateral_utxos,

--- a/cardano_node_tests/tests/tests_plutus/test_spend_negative_build.py
+++ b/cardano_node_tests/tests/tests_plutus/test_spend_negative_build.py
@@ -88,6 +88,7 @@ class TestNegative:
             payment_addr=payment_addrs[0],
             dst_addr=payment_addrs[1],
             plutus_op=plutus_op,
+            amount=1_000_000,
         )
 
         with pytest.raises(clusterlib.CLIError) as excinfo:
@@ -99,7 +100,7 @@ class TestNegative:
                 script_utxos=script_utxos,
                 collateral_utxos=collateral_utxos,
                 plutus_op=plutus_op2,
-                amount=2_000_000,
+                amount=-1,
             )
         err_str = str(excinfo.value)
         assert "points to a Plutus script that does not exist" in err_str, err_str
@@ -141,6 +142,7 @@ class TestNegative:
             payment_addr=payment_addrs[0],
             dst_addr=payment_addrs[1],
             plutus_op=plutus_op,
+            amount=1_000_000,
         )
 
         with pytest.raises(clusterlib.CLIError) as excinfo:
@@ -152,7 +154,7 @@ class TestNegative:
                 script_utxos=script_utxos,
                 collateral_utxos=collateral_utxos,
                 plutus_op=plutus_op2,
-                amount=2_000_000,
+                amount=-1,
             )
         err_str = str(excinfo.value)
         assert "(MissingScriptWitnessesUTXOW" in err_str, err_str
@@ -205,6 +207,7 @@ class TestNegative:
             payment_addr=payment_addrs[0],
             dst_addr=payment_addrs[1],
             plutus_op=plutus_op,
+            amount=1_000_000,
             tokens_collateral=tokens_rec,
         )
 
@@ -218,7 +221,7 @@ class TestNegative:
                 script_utxos=script_utxos,
                 collateral_utxos=collateral_utxos,
                 plutus_op=plutus_op,
-                amount=2_000_000,
+                amount=-1,
             )
         except clusterlib.CLIError as exc:
             exc_str = str(exc)
@@ -269,6 +272,7 @@ class TestNegative:
             payment_addr=payment_addrs[0],
             dst_addr=payment_addrs[1],
             plutus_op=plutus_op,
+            amount=1_000_000,
         )
 
         with pytest.raises(clusterlib.CLIError) as excinfo:
@@ -280,7 +284,7 @@ class TestNegative:
                 script_utxos=script_utxos,
                 collateral_utxos=script_utxos,
                 plutus_op=plutus_op,
-                amount=2_000_000,
+                amount=-1,
                 submit_tx=False,
             )
 
@@ -357,6 +361,7 @@ class TestNegative:
             payment_addr=payment_addrs[0],
             dst_addr=payment_addrs[1],
             plutus_op=plutus_op,
+            amount=1_000_000,
         )
 
         with pytest.raises(clusterlib.CLIError) as excinfo:
@@ -368,7 +373,7 @@ class TestNegative:
                 script_utxos=script_utxos,
                 collateral_utxos=collateral_utxos,
                 plutus_op=plutus_op,
-                amount=2_000_000,
+                amount=-1,
                 submit_tx=False,
             )
 
@@ -396,9 +401,7 @@ class TestNegative:
         * check that the expected error was raised
         """
         temp_template = common.get_test_id(cluster)
-        amount = 50_000_000
-
-        script_fund = 200_000_000
+        script_fund = 1_000_000
 
         protocol_params = cluster.g_query.get_protocol_params()
 
@@ -511,16 +514,24 @@ class TestNegative:
             ),
         ]
         tx_files_redeem = clusterlib.TxFiles(
-            signing_key_files=[payment_addrs[1].skey_file],
+            signing_key_files=[payment_addrs[0].skey_file, payment_addrs[1].skey_file],
+        )
+        fee_txin_redeem = next(
+            r
+            for r in clusterlib_utils.get_just_lovelace_utxos(
+                address_utxos=cluster.g_query.get_utxo(address=payment_addrs[0].address)
+            )
+            if r.amount >= 100_000_000
         )
         txouts_redeem = [
-            clusterlib.TxOut(address=payment_addrs[1].address, amount=amount * 2),
+            clusterlib.TxOut(address=payment_addrs[1].address, amount=script_fund * 2),
         ]
 
         with pytest.raises(clusterlib.CLIError) as excinfo:
             cluster.g_transaction.build_tx(
                 src_address=payment_addrs[0].address,
                 tx_name=f"{temp_template}_step2",
+                txins=[fee_txin_redeem],
                 tx_files=tx_files_redeem,
                 txouts=txouts_redeem,
                 script_txins=plutus_txins,
@@ -538,7 +549,7 @@ class TestNegativeRedeemer:
     """Tests for Tx output locking using Plutus smart contracts with wrong redeemer."""
 
     MIN_INT_VAL = -common.MAX_UINT64
-    AMOUNT = 2_000_000
+    AMOUNT = 800_000
 
     @pytest.fixture
     def fund_script_guessing_game_v1(
@@ -564,6 +575,7 @@ class TestNegativeRedeemer:
             payment_addr=payment_addrs[0],
             dst_addr=payment_addrs[1],
             plutus_op=plutus_op,
+            amount=1_000_000,
         )
 
         return script_utxos, collateral_utxos
@@ -592,6 +604,7 @@ class TestNegativeRedeemer:
             payment_addr=payment_addrs[0],
             dst_addr=payment_addrs[1],
             plutus_op=plutus_op,
+            amount=1_000_000,
         )
 
         return script_utxos, collateral_utxos

--- a/cardano_node_tests/tests/tests_plutus_v2/spend_build.py
+++ b/cardano_node_tests/tests/tests_plutus_v2/spend_build.py
@@ -47,6 +47,7 @@ def _build_fund_script(
     payment_addr: clusterlib.AddressRecord,
     dst_addr: clusterlib.AddressRecord,
     plutus_op: plutus_common.PlutusOp,
+    amount: int,
     use_reference_script: bool = False,
     use_inline_datum: bool = True,
     collateral_amount: int | None = None,
@@ -64,8 +65,6 @@ def _build_fund_script(
     """
     # For mypy
     assert plutus_op.execution_cost
-
-    script_fund = 200_000_000
 
     script_address = cluster.g_address.gen_payment_addr(
         addr_name=temp_template, payment_script_file=plutus_op.script_file
@@ -85,7 +84,7 @@ def _build_fund_script(
     txouts = [
         clusterlib.TxOut(
             address=script_address,
-            amount=script_fund,
+            amount=amount,
             inline_datum_file=(
                 plutus_op.datum_file if plutus_op.datum_file and use_inline_datum else ""
             ),
@@ -109,7 +108,7 @@ def _build_fund_script(
         txouts.append(
             clusterlib.TxOut(
                 address=dst_addr.address,
-                amount=10_000_000,
+                amount=amount,
                 reference_script_file=plutus_op.script_file,
             )
         )

--- a/cardano_node_tests/tests/tests_plutus_v2/test_spend_compat_build.py
+++ b/cardano_node_tests/tests/tests_plutus_v2/test_spend_compat_build.py
@@ -76,6 +76,7 @@ class TestCompatibility:
                 payment_addr=payment_addrs[0],
                 dst_addr=payment_addrs[1],
                 plutus_op=plutus_op,
+                amount=1_000_000,
             )
         except clusterlib.CLIError as exc:
             if "Inline datums cannot be used" not in str(exc):
@@ -121,6 +122,7 @@ class TestCompatibility:
                 payment_addr=payment_addrs[0],
                 dst_addr=payment_addrs[1],
                 plutus_op=plutus_op,
+                amount=1_000_000,
                 use_reference_script=True,
                 use_inline_datum=False,
             )

--- a/cardano_node_tests/tests/tests_plutus_v2/test_spend_ref_inputs_build.py
+++ b/cardano_node_tests/tests/tests_plutus_v2/test_spend_ref_inputs_build.py
@@ -70,6 +70,7 @@ class TestReadonlyReferenceInputs:
 
         plutus_op = spend_build.PLUTUS_OP_ALWAYS_SUCCEEDS
 
+        script_fund = 1_000_000
         reference_input_amount = 2_000_000
 
         # For mypy
@@ -85,6 +86,7 @@ class TestReadonlyReferenceInputs:
             payment_addr=payment_addrs[0],
             dst_addr=payment_addrs[1],
             plutus_op=plutus_op,
+            amount=script_fund,
             use_inline_datum=False,
         )
 
@@ -112,10 +114,17 @@ class TestReadonlyReferenceInputs:
         ]
 
         tx_files_redeem = clusterlib.TxFiles(
-            signing_key_files=[payment_addrs[1].skey_file],
+            signing_key_files=[payment_addrs[0].skey_file, payment_addrs[1].skey_file],
+        )
+        fee_txin_redeem = next(
+            r
+            for r in clusterlib_utils.get_just_lovelace_utxos(
+                address_utxos=cluster.g_query.get_utxo(address=payment_addrs[0].address)
+            )
+            if r.amount >= 100_000_000
         )
         txouts_redeem = [
-            clusterlib.TxOut(address=payment_addrs[1].address, amount=-1),
+            clusterlib.TxOut(address=payment_addrs[1].address, amount=script_fund),
         ]
 
         if reference_input_scenario == "single":
@@ -126,10 +135,12 @@ class TestReadonlyReferenceInputs:
         tx_output_redeem = cluster.g_transaction.build_tx(
             src_address=payment_addrs[0].address,
             tx_name=f"{temp_template}_step2",
+            txins=[fee_txin_redeem],
             tx_files=tx_files_redeem,
             readonly_reference_txins=readonly_reference_txins,
             txouts=txouts_redeem,
             script_txins=plutus_txins,
+            change_address=payment_addrs[0].address,
         )
 
         tx_signed = cluster.g_transaction.sign_tx(
@@ -177,6 +188,7 @@ class TestReadonlyReferenceInputs:
 
         plutus_op = spend_build.PLUTUS_OP_ALWAYS_SUCCEEDS
 
+        script_fund = 1_000_000
         reference_input_amount = 2_000_000
 
         # For mypy
@@ -192,6 +204,7 @@ class TestReadonlyReferenceInputs:
             payment_addr=payment_addrs[0],
             dst_addr=payment_addrs[1],
             plutus_op=plutus_op,
+            amount=script_fund,
             use_inline_datum=False,
         )
 
@@ -220,20 +233,28 @@ class TestReadonlyReferenceInputs:
         ]
 
         tx_files_redeem = clusterlib.TxFiles(
-            signing_key_files=[payment_addrs[1].skey_file],
+            signing_key_files=[payment_addrs[0].skey_file, payment_addrs[1].skey_file],
+        )
+        fee_txin_redeem = next(
+            r
+            for r in clusterlib_utils.get_just_lovelace_utxos(
+                address_utxos=cluster.g_query.get_utxo(address=payment_addrs[0].address)
+            )
+            if r.amount >= 100_000_000
         )
         txouts_redeem = [
-            clusterlib.TxOut(address=payment_addrs[1].address, amount=-1),
+            clusterlib.TxOut(address=payment_addrs[1].address, amount=script_fund),
         ]
 
         tx_output_redeem = cluster.g_transaction.build_tx(
             src_address=payment_addrs[0].address,
             tx_name=f"{temp_template}_step2",
-            txins=reference_input,
+            txins=[*reference_input, fee_txin_redeem],
             tx_files=tx_files_redeem,
             readonly_reference_txins=reference_input,
             txouts=txouts_redeem,
             script_txins=plutus_txins,
+            change_address=payment_addrs[0].address,
         )
 
         tx_signed = cluster.g_transaction.sign_tx(
@@ -426,6 +447,7 @@ class TestNegativeReadonlyReferenceInputs:
 
         plutus_op = spend_build.PLUTUS_OP_ALWAYS_SUCCEEDS
 
+        script_fund = 1_000_000
         reference_input_amount = 2_000_000
 
         # For mypy
@@ -441,6 +463,7 @@ class TestNegativeReadonlyReferenceInputs:
             payment_addr=payment_addrs[0],
             dst_addr=payment_addrs[1],
             plutus_op=plutus_op,
+            amount=script_fund,
             use_inline_datum=False,
         )
 
@@ -492,20 +515,29 @@ class TestNegativeReadonlyReferenceInputs:
         ]
 
         tx_files_redeem = clusterlib.TxFiles(
-            signing_key_files=[payment_addrs[1].skey_file],
+            signing_key_files=[payment_addrs[0].skey_file, payment_addrs[1].skey_file],
+        )
+        fee_txin_redeem = next(
+            r
+            for r in clusterlib_utils.get_just_lovelace_utxos(
+                address_utxos=cluster.g_query.get_utxo(address=payment_addrs[0].address)
+            )
+            if r.amount >= 100_000_000
         )
         txouts_redeem = [
-            clusterlib.TxOut(address=payment_addrs[1].address, amount=-1),
+            clusterlib.TxOut(address=payment_addrs[1].address, amount=script_fund),
         ]
 
         with pytest.raises(clusterlib.CLIError) as excinfo:
             cluster.g_transaction.build_tx(
                 src_address=payment_addrs[0].address,
                 tx_name=f"{temp_template}_step2",
+                txins=[fee_txin_redeem],
                 tx_files=tx_files_redeem,
                 readonly_reference_txins=reference_input,
                 txouts=txouts_redeem,
                 script_txins=plutus_txins,
+                change_address=payment_addrs[0].address,
             )
         err_str = str(excinfo.value)
         assert (
@@ -533,6 +565,7 @@ class TestNegativeReadonlyReferenceInputs:
         """
         __: tp.Any  # mypy workaround
         temp_template = common.get_test_id(cluster)
+        script_fund = 1_000_000
 
         plutus_op = plutus_common.PlutusOp(
             script_file=plutus_common.ALWAYS_SUCCEEDS_PLUTUS_V1,
@@ -554,6 +587,7 @@ class TestNegativeReadonlyReferenceInputs:
             payment_addr=payment_addrs[0],
             dst_addr=payment_addrs[1],
             plutus_op=plutus_op,
+            amount=script_fund,
             use_inline_datum=False,
         )
 
@@ -583,20 +617,29 @@ class TestNegativeReadonlyReferenceInputs:
         ]
 
         tx_files_redeem = clusterlib.TxFiles(
-            signing_key_files=[payment_addrs[1].skey_file],
+            signing_key_files=[payment_addrs[0].skey_file, payment_addrs[1].skey_file],
+        )
+        fee_txin_redeem = next(
+            r
+            for r in clusterlib_utils.get_just_lovelace_utxos(
+                address_utxos=cluster.g_query.get_utxo(address=payment_addrs[0].address)
+            )
+            if r.amount >= 100_000_000
         )
         txouts_redeem = [
-            clusterlib.TxOut(address=payment_addrs[1].address, amount=-1),
+            clusterlib.TxOut(address=payment_addrs[1].address, amount=script_fund),
         ]
 
         try:
             cluster.g_transaction.build_tx(
                 src_address=payment_addrs[0].address,
                 tx_name=f"{temp_template}_step2",
+                txins=[fee_txin_redeem],
                 tx_files=tx_files_redeem,
                 readonly_reference_txins=reference_input,
                 txouts=txouts_redeem,
                 script_txins=plutus_txins,
+                change_address=payment_addrs[0].address,
             )
         except clusterlib.CLIError as exc:
             if VERSIONS.transaction_era >= VERSIONS.CONWAY:

--- a/cardano_node_tests/tests/tests_plutus_v2/test_spend_ref_scripts_build.py
+++ b/cardano_node_tests/tests/tests_plutus_v2/test_spend_ref_scripts_build.py
@@ -79,7 +79,7 @@ class TestReferenceScripts:
 
         # Create a Tx output with an inline datum at the script address
 
-        script_fund = 100_000_000
+        script_fund = 1_000_000
 
         script_address_1 = cluster.g_address.gen_payment_addr(
             addr_name=f"{temp_template}_addr1", payment_script_file=plutus_op1.script_file
@@ -186,18 +186,27 @@ class TestReferenceScripts:
         ]
 
         tx_files_redeem = clusterlib.TxFiles(
-            signing_key_files=[payment_addrs[1].skey_file],
+            signing_key_files=[payment_addrs[0].skey_file, payment_addrs[1].skey_file],
+        )
+        fee_txin_redeem = next(
+            r
+            for r in clusterlib_utils.get_just_lovelace_utxos(
+                address_utxos=cluster.g_query.get_utxo(address=payment_addrs[0].address)
+            )
+            if r.amount >= 100_000_000
         )
         txouts_redeem = [
-            clusterlib.TxOut(address=payment_addrs[1].address, amount=-1),
+            clusterlib.TxOut(address=payment_addrs[1].address, amount=script_fund),
         ]
 
         tx_output_redeem = cluster.g_transaction.build_tx(
             src_address=payment_addrs[0].address,
             tx_name=f"{temp_template}_step2",
+            txins=[fee_txin_redeem],
             tx_files=tx_files_redeem,
             txouts=txouts_redeem,
             script_txins=plutus_txins,
+            change_address=payment_addrs[0].address,
         )
 
         tx_signed = cluster.g_transaction.sign_tx(
@@ -249,7 +258,7 @@ class TestReferenceScripts:
 
         # Create a Tx output with an inline datum at the script address
 
-        script_fund = 200_000_000
+        script_fund = 1_000_000
 
         script_address_1 = cluster.g_address.gen_payment_addr(
             addr_name=f"{temp_template}_addr1", payment_script_file=plutus_op.script_file
@@ -341,18 +350,27 @@ class TestReferenceScripts:
         ]
 
         tx_files_redeem = clusterlib.TxFiles(
-            signing_key_files=[payment_addrs[1].skey_file],
+            signing_key_files=[payment_addrs[0].skey_file, payment_addrs[1].skey_file],
+        )
+        fee_txin_redeem = next(
+            r
+            for r in clusterlib_utils.get_just_lovelace_utxos(
+                address_utxos=cluster.g_query.get_utxo(address=payment_addrs[0].address)
+            )
+            if r.amount >= 100_000_000
         )
         txouts_redeem = [
-            clusterlib.TxOut(address=payment_addrs[1].address, amount=-1),
+            clusterlib.TxOut(address=payment_addrs[1].address, amount=script_fund),
         ]
 
         tx_output_redeem = cluster.g_transaction.build_tx(
             src_address=payment_addrs[0].address,
             tx_name=f"{temp_template}_step2",
+            txins=[fee_txin_redeem],
             tx_files=tx_files_redeem,
             txouts=txouts_redeem,
             script_txins=plutus_txins,
+            change_address=payment_addrs[0].address,
         )
 
         tx_signed = cluster.g_transaction.sign_tx(
@@ -397,7 +415,7 @@ class TestReferenceScripts:
 
         # Create the necessary UTxOs
 
-        script_fund = 100_000_000
+        script_fund = 2_000_000
 
         script_address_1 = cluster.g_address.gen_payment_addr(
             addr_name=f"{temp_template}_addr1", payment_script_file=plutus_op1.script_file
@@ -493,18 +511,27 @@ class TestReferenceScripts:
         ]
 
         tx_files_redeem = clusterlib.TxFiles(
-            signing_key_files=[payment_addrs[1].skey_file],
+            signing_key_files=[payment_addrs[0].skey_file, payment_addrs[1].skey_file],
+        )
+        fee_txin_redeem = next(
+            r
+            for r in clusterlib_utils.get_just_lovelace_utxos(
+                address_utxos=cluster.g_query.get_utxo(address=payment_addrs[0].address)
+            )
+            if r.amount >= 100_000_000
         )
         txouts_redeem = [
-            clusterlib.TxOut(address=payment_addrs[1].address, amount=-1),
+            clusterlib.TxOut(address=payment_addrs[1].address, amount=script_fund),
         ]
 
         tx_output_redeem = cluster.g_transaction.build_tx(
             src_address=payment_addrs[0].address,
             tx_name=f"{temp_template}_step2",
+            txins=[fee_txin_redeem],
             tx_files=tx_files_redeem,
             txouts=txouts_redeem,
             script_txins=plutus_txins,
+            change_address=payment_addrs[0].address,
         )
 
         plutus_costs = cluster.g_transaction.calculate_plutus_script_cost(
@@ -733,6 +760,7 @@ class TestNegativeReferenceScripts:
                 payment_addr=payment_addrs[0],
                 dst_addr=payment_addrs[1],
                 plutus_op=plutus_op,
+                amount=100_000,
                 use_reference_script=True,
             )
         err_str = str(excinfo.value)
@@ -761,7 +789,7 @@ class TestNegativeReferenceScripts:
 
         # Create a Tx output with an inline datum at the script address
 
-        script_fund = 100_000_000
+        script_fund = 1_000_000
 
         script_address_1 = cluster.g_address.gen_payment_addr(
             addr_name=f"{temp_template}_addr1", payment_script_file=plutus_op1.script_file
@@ -868,19 +896,28 @@ class TestNegativeReferenceScripts:
         ]
 
         tx_files_redeem = clusterlib.TxFiles(
-            signing_key_files=[payment_addrs[1].skey_file],
+            signing_key_files=[payment_addrs[0].skey_file, payment_addrs[1].skey_file],
+        )
+        fee_txin_redeem = next(
+            r
+            for r in clusterlib_utils.get_just_lovelace_utxos(
+                address_utxos=cluster.g_query.get_utxo(address=payment_addrs[0].address)
+            )
+            if r.amount >= 100_000_000
         )
         txouts_redeem = [
-            clusterlib.TxOut(address=payment_addrs[1].address, amount=-1),
+            clusterlib.TxOut(address=payment_addrs[1].address, amount=script_fund),
         ]
 
         with pytest.raises(clusterlib.CLIError) as excinfo:
             cluster.g_transaction.build_tx(
                 src_address=payment_addrs[0].address,
                 tx_name=f"{temp_template}_step2",
+                txins=[fee_txin_redeem],
                 tx_files=tx_files_redeem,
                 txouts=txouts_redeem,
                 script_txins=plutus_txins,
+                change_address=payment_addrs[0].address,
             )
         err_str = str(excinfo.value)
         assert (
@@ -901,6 +938,7 @@ class TestNegativeReferenceScripts:
         Expect failure.
         """
         temp_template = common.get_test_id(cluster)
+        script_fund = 1_000_000
 
         plutus_op = plutus_common.PlutusOp(
             script_file=plutus_common.ALWAYS_SUCCEEDS["v1"].script_file,
@@ -922,6 +960,7 @@ class TestNegativeReferenceScripts:
             payment_addr=payment_addrs[0],
             dst_addr=payment_addrs[1],
             plutus_op=plutus_op,
+            amount=script_fund,
             use_reference_script=True,
         )
         assert reference_utxo, "No reference script UTxO"
@@ -944,19 +983,28 @@ class TestNegativeReferenceScripts:
         ]
 
         tx_files_redeem = clusterlib.TxFiles(
-            signing_key_files=[payment_addrs[1].skey_file],
+            signing_key_files=[payment_addrs[0].skey_file, payment_addrs[1].skey_file],
+        )
+        fee_txin_redeem = next(
+            r
+            for r in clusterlib_utils.get_just_lovelace_utxos(
+                address_utxos=cluster.g_query.get_utxo(address=payment_addrs[0].address)
+            )
+            if r.amount >= 100_000_000
         )
         txouts_redeem = [
-            clusterlib.TxOut(address=payment_addrs[1].address, amount=-1),
+            clusterlib.TxOut(address=payment_addrs[1].address, amount=script_fund),
         ]
 
         with pytest.raises(clusterlib.CLIError) as excinfo:
             cluster.g_transaction.build_tx(
                 src_address=payment_addrs[0].address,
                 tx_name=f"{temp_template}_step2",
+                txins=[fee_txin_redeem],
                 tx_files=tx_files_redeem,
                 txouts=txouts_redeem,
                 script_txins=plutus_txins,
+                change_address=payment_addrs[0].address,
             )
         err_str = str(excinfo.value)
         assert (
@@ -996,7 +1044,7 @@ class TestNegativeReferenceScripts:
 
         # Create a Tx output with an inline datum at the script address
 
-        script_fund = 200_000_000
+        script_fund = 1_000_000
 
         script_address_1 = cluster.g_address.gen_payment_addr(
             addr_name=f"{temp_template}_addr1", payment_script_file=plutus_op1.script_file
@@ -1090,19 +1138,28 @@ class TestNegativeReferenceScripts:
         ]
 
         tx_files_redeem = clusterlib.TxFiles(
-            signing_key_files=[payment_addrs[1].skey_file],
+            signing_key_files=[payment_addrs[0].skey_file, payment_addrs[1].skey_file],
+        )
+        fee_txin_redeem = next(
+            r
+            for r in clusterlib_utils.get_just_lovelace_utxos(
+                address_utxos=cluster.g_query.get_utxo(address=payment_addrs[0].address)
+            )
+            if r.amount >= 100_000_000
         )
         txouts_redeem = [
-            clusterlib.TxOut(address=payment_addrs[1].address, amount=-1),
+            clusterlib.TxOut(address=payment_addrs[1].address, amount=script_fund),
         ]
 
         with pytest.raises(clusterlib.CLIError) as excinfo:
             cluster.g_transaction.build_tx(
                 src_address=payment_addrs[0].address,
                 tx_name=f"{temp_template}_step2",
+                txins=[fee_txin_redeem],
                 tx_files=tx_files_redeem,
                 txouts=txouts_redeem,
                 script_txins=plutus_txins,
+                change_address=payment_addrs[0].address,
             )
         err_str = str(excinfo.value)
         assert (
@@ -1125,6 +1182,7 @@ class TestNegativeReferenceScripts:
         __: tp.Any  # mypy workaround
         temp_template = common.get_test_id(cluster)
 
+        script_fund = 1_000_000
         plutus_op = spend_build.PLUTUS_OP_ALWAYS_SUCCEEDS
 
         # For mypy
@@ -1140,6 +1198,7 @@ class TestNegativeReferenceScripts:
             payment_addr=payment_addrs[0],
             dst_addr=payment_addrs[1],
             plutus_op=plutus_op,
+            amount=1_000_000,
             use_reference_script=False,
         )
 
@@ -1176,19 +1235,28 @@ class TestNegativeReferenceScripts:
         ]
 
         tx_files_redeem = clusterlib.TxFiles(
-            signing_key_files=[payment_addrs[1].skey_file],
+            signing_key_files=[payment_addrs[0].skey_file, payment_addrs[1].skey_file],
+        )
+        fee_txin_redeem = next(
+            r
+            for r in clusterlib_utils.get_just_lovelace_utxos(
+                address_utxos=cluster.g_query.get_utxo(address=payment_addrs[0].address)
+            )
+            if r.amount >= 100_000_000
         )
         txouts_redeem = [
-            clusterlib.TxOut(address=payment_addrs[1].address, amount=-1),
+            clusterlib.TxOut(address=payment_addrs[1].address, amount=script_fund),
         ]
 
         with pytest.raises(clusterlib.CLIError) as excinfo:
             cluster.g_transaction.build_tx(
                 src_address=payment_addrs[0].address,
                 tx_name=f"{temp_template}_step2",
+                txins=[fee_txin_redeem],
                 tx_files=tx_files_redeem,
                 txouts=txouts_redeem,
                 script_txins=plutus_txins,
+                change_address=payment_addrs[0].address,
             )
         err_str = str(excinfo.value)
         assert "ByronTxOutInContext" in err_str, err_str

--- a/cardano_node_tests/tests/tests_plutus_v3/test_spend_build.py
+++ b/cardano_node_tests/tests/tests_plutus_v3/test_spend_build.py
@@ -78,6 +78,7 @@ class TestBuildLocking:
             payment_addr=payment_addrs[0],
             dst_addr=payment_addrs[1],
             plutus_op=plutus_op,
+            amount=1_000_000,
         )
 
         __, tx_output, plutus_costs = spend_build._build_spend_locked_txin(
@@ -88,7 +89,7 @@ class TestBuildLocking:
             script_utxos=script_utxos,
             collateral_utxos=collateral_utxos,
             plutus_op=plutus_op,
-            amount=2_000_000,
+            amount=-1,
         )
 
         # Check expected fees

--- a/cardano_node_tests/utils/clusterlib_utils.py
+++ b/cardano_node_tests/utils/clusterlib_utils.py
@@ -1467,3 +1467,10 @@ def build_stake_multisig_script(
         json.dump(script, fp_out, indent=4)
 
     return out_file
+
+
+def get_just_lovelace_utxos(address_utxos: list[clusterlib.UTXOData]) -> list[clusterlib.UTXOData]:
+    """Get UTxOs with just Lovelace."""
+    return cl_txtools._get_usable_utxos(
+        address_utxos=address_utxos, coins={clusterlib.DEFAULT_COIN}
+    )


### PR DESCRIPTION
- Updated execution costs for guessing game scripts
- Added `amount` parameter to `_build_fund_script` and `_build_spend_locked_txin`
- Adjusted test cases to use the new `amount` parameter
- Ensured additional funds are added to cover fees and Lovelace change
- Refactored to include payment address for additional funds