### PR TITLE
fix(tests): correct order of error message assertions

### DIFF
--- a/cardano_node_tests/tests/test_cli.py
+++ b/cardano_node_tests/tests/test_cli.py
@@ -711,8 +711,8 @@ class TestKey:
 
         err_str = str(excinfo.value)
         assert (
-            "TextEnvelope type error:  Expected one of:" in err_str
-            or "key non-extended-key  Error: Invalid key." in err_str
+            "Error: Invalid key." in err_str
+            or "TextEnvelope type error:  Expected one of:" in err_str
         ), err_str
 
 


### PR DESCRIPTION
Reordered the error message assertions in `test_cli.py` to ensure the "Invalid key" error is checked first. This improves the clarity and accuracy of the test failure messages.