### PR TITLE
feat: Spend all funds locked on simple scripts

### DIFF
--- a/cardano_node_tests/utils/clusterlib_utils.py
+++ b/cardano_node_tests/utils/clusterlib_utils.py
@@ -626,7 +626,7 @@ def mint_or_burn_witness(
             src_address=token_mint_addr.address,
             tx_name=temp_template,
             txouts=txouts,
-            fee_buffer=2000_000,
+            fee_buffer=2_000_000,
             mint=mint,
             invalid_hereafter=invalid_hereafter,
             invalid_before=invalid_before,


### PR DESCRIPTION
Modified tests to use additional UTxO for covering fees in order to be able to spend all funds locked on script UTxOs.

Negative tests that don't spend the locked UTxOs were disabled on long-running testnets.