### PR TITLE
feat(logging): rename start cluster log file

### DIFF
--- a/cardano_node_tests/cluster_management/cluster_getter.py
+++ b/cardano_node_tests/cluster_management/cluster_getter.py
@@ -195,7 +195,7 @@ class ClusterGetter:
             # Save artifacts only when produced during this test run
             if cluster_running_file.exists() or i > 0:
                 artifacts.save_start_script_coverage(
-                    log_file=state_dir / common.CLUSTER_START_CMDS_LOG,
+                    log_file=state_dir / common.START_CLUSTER_LOG,
                     pytest_config=self.pytest_config,
                 )
                 artifacts.save_cluster_artifacts(save_dir=self.pytest_tmp_dir, state_dir=state_dir)

--- a/cardano_node_tests/cluster_management/common.py
+++ b/cardano_node_tests/cluster_management/common.py
@@ -2,7 +2,7 @@ from cardano_node_tests.utils import temptools
 
 CLUSTER_LOCK = ".cluster.lock"
 LOG_LOCK = ".manager_log.lock"
-CLUSTER_START_CMDS_LOG = "start_cluster_cmds.log"
+START_CLUSTER_LOG = "start-cluster.log"
 ADDRS_DATA_DIRNAME = "addrs_data"
 
 

--- a/cardano_node_tests/cluster_management/manager.py
+++ b/cardano_node_tests/cluster_management/manager.py
@@ -157,7 +157,7 @@ class ClusterManager:
                 continue
 
             artifacts.save_start_script_coverage(
-                log_file=state_dir / common.CLUSTER_START_CMDS_LOG,
+                log_file=state_dir / common.START_CLUSTER_LOG,
                 pytest_config=self.pytest_config,
             )
             artifacts.save_cluster_artifacts(save_dir=self.pytest_tmp_dir, state_dir=state_dir)

--- a/cardano_node_tests/cluster_scripts/conway/start-cluster
+++ b/cardano_node_tests/cluster_scripts/conway/start-cluster
@@ -59,7 +59,7 @@ fi
 cardano_cli_log() {
   local out retval _
 
-  echo cardano-cli "$@" >> "${STATE_CLUSTER}/start_cluster_cmds.log"
+  echo cardano-cli "$@" >> "${STATE_CLUSTER}/start-cluster.log"
 
   for _ in {1..3}; do
     set +e

--- a/cardano_node_tests/cluster_scripts/conway_fast/start-cluster
+++ b/cardano_node_tests/cluster_scripts/conway_fast/start-cluster
@@ -64,7 +64,7 @@ fi
 
 cardano_cli_log() {
   local out retval _
-  echo cardano-cli "$@" >> "${STATE_CLUSTER}/start_cluster_cmds.log"
+  echo cardano-cli "$@" >> "${STATE_CLUSTER}/start-cluster.log"
 
   for _ in {1..3}; do
     set +e

--- a/cardano_node_tests/cluster_scripts/mainnet_fast/start-cluster
+++ b/cardano_node_tests/cluster_scripts/mainnet_fast/start-cluster
@@ -64,7 +64,7 @@ fi
 
 cardano_cli_log() {
   local out retval _
-  echo cardano-cli "$@" >> "${STATE_CLUSTER}/start_cluster_cmds.log"
+  echo cardano-cli "$@" >> "${STATE_CLUSTER}/start-cluster.log"
 
   for _ in {1..3}; do
     set +e


### PR DESCRIPTION
Renamed the start cluster log file from `start_cluster_cmds.log` to `start-cluster.log`.

The log file can be used for all `start-cluster` logging.