### PR TITLE
feat: add START_CLUSTER_LOG variable for logging

### DIFF
--- a/cardano_node_tests/cluster_scripts/conway/start-cluster
+++ b/cardano_node_tests/cluster_scripts/conway/start-cluster
@@ -17,6 +17,7 @@ SOCKET_PATH="$(readlink -m "$CARDANO_NODE_SOCKET_PATH")"
 STATE_CLUSTER="${SOCKET_PATH%/*}"
 STATE_CLUSTER_NAME="${STATE_CLUSTER##*/}"
 SUPERVISORD_SOCKET_PATH="${STATE_CLUSTER}/supervisord.sock"
+START_CLUSTER_LOG="${STATE_CLUSTER}/start-cluster.log"
 
 INSTANCE_NUM="%%INSTANCE_NUM%%"
 if [[ "$SOCKET_PATH" != *"/state-cluster${INSTANCE_NUM}/"* ]]; then
@@ -59,7 +60,7 @@ fi
 cardano_cli_log() {
   local out retval _
 
-  echo cardano-cli "$@" >> "${STATE_CLUSTER}/start-cluster.log"
+  echo cardano-cli "$@" >> "$START_CLUSTER_LOG"
 
   for _ in {1..3}; do
     set +e

--- a/cardano_node_tests/cluster_scripts/conway_fast/start-cluster
+++ b/cardano_node_tests/cluster_scripts/conway_fast/start-cluster
@@ -17,6 +17,7 @@ SOCKET_PATH="$(readlink -m "$CARDANO_NODE_SOCKET_PATH")"
 STATE_CLUSTER="${SOCKET_PATH%/*}"
 STATE_CLUSTER_NAME="${STATE_CLUSTER##*/}"
 SUPERVISORD_SOCKET_PATH="${STATE_CLUSTER}/supervisord.sock"
+START_CLUSTER_LOG="${STATE_CLUSTER}/start-cluster.log"
 
 INSTANCE_NUM="%%INSTANCE_NUM%%"
 if [[ "$SOCKET_PATH" != *"/state-cluster${INSTANCE_NUM}/"* ]]; then
@@ -64,7 +65,7 @@ fi
 
 cardano_cli_log() {
   local out retval _
-  echo cardano-cli "$@" >> "${STATE_CLUSTER}/start-cluster.log"
+  echo cardano-cli "$@" >> "$START_CLUSTER_LOG"
 
   for _ in {1..3}; do
     set +e

--- a/cardano_node_tests/cluster_scripts/mainnet_fast/start-cluster
+++ b/cardano_node_tests/cluster_scripts/mainnet_fast/start-cluster
@@ -17,6 +17,7 @@ SOCKET_PATH="$(readlink -m "$CARDANO_NODE_SOCKET_PATH")"
 STATE_CLUSTER="${SOCKET_PATH%/*}"
 STATE_CLUSTER_NAME="${STATE_CLUSTER##*/}"
 SUPERVISORD_SOCKET_PATH="${STATE_CLUSTER}/supervisord.sock"
+START_CLUSTER_LOG="${STATE_CLUSTER}/start-cluster.log"
 
 INSTANCE_NUM="%%INSTANCE_NUM%%"
 if [[ "$SOCKET_PATH" != *"/state-cluster${INSTANCE_NUM}/"* ]]; then
@@ -64,7 +65,7 @@ fi
 
 cardano_cli_log() {
   local out retval _
-  echo cardano-cli "$@" >> "${STATE_CLUSTER}/start-cluster.log"
+  echo cardano-cli "$@" >> "$START_CLUSTER_LOG"
 
   for _ in {1..3}; do
     set +e

--- a/cardano_node_tests/cluster_scripts/testnets/start-cluster
+++ b/cardano_node_tests/cluster_scripts/testnets/start-cluster
@@ -8,6 +8,7 @@ SOCKET_PATH="$(readlink -m "$CARDANO_NODE_SOCKET_PATH")"
 STATE_CLUSTER="${SOCKET_PATH%/*}"
 STATE_CLUSTER_NAME="${STATE_CLUSTER##*/}"
 SUPERVISORD_SOCKET_PATH="${STATE_CLUSTER}/supervisord.sock"
+START_CLUSTER_LOG="${STATE_CLUSTER}/start-cluster.log"
 
 INSTANCE_NUM="%%INSTANCE_NUM%%"
 if [[ "$SOCKET_PATH" != *"/state-cluster${INSTANCE_NUM}/"* ]]; then
@@ -239,6 +240,6 @@ fi
 get_address_balance \
   --testnet-magic "$NETWORK_MAGIC" \
   --address "$(<"$STATE_CLUSTER/shelley/faucet.addr")" \
-  > "${STATE_CLUSTER}/start-cluster.log"
+  > "$START_CLUSTER_LOG"
 
 echo "Cluster started. Run \`$SCRIPT_DIR/stop-cluster\` to stop"


### PR DESCRIPTION
- Introduced START_CLUSTER_LOG variable in start-cluster scripts
- Updated cardano_cli_log function to use START_CLUSTER_LOG
- Ensured consistent logging path across different cluster scripts