### PR TITLE
fix(tests): ensure sufficient funds for DRep deposits

### DIFF
--- a/cardano_node_tests/utils/faucet.py
+++ b/cardano_node_tests/utils/faucet.py
@@ -24,7 +24,7 @@ def fund_from_faucet(
 ) -> clusterlib.TxRawOutput | None:
     """Transfer `amount` from faucet addr to all `dst_addrs`."""
     if amount is None:
-        amount = 1000_000_000
+        amount = 1_000_000_000
 
     if not (faucet_data or all_faucets):
         msg = "Either `faucet_data` or `all_faucets` must be provided."


### PR DESCRIPTION
- Added checks to ensure payment addresses have enough funds for DRep deposits in long-running testnets.
- Updated `fund_from_faucet` default amount formatting.
- Fixed typos and improved variable naming for clarity.