### PR TITLE
feat: check fees only on local testnet

### DIFF
--- a/cardano_node_tests/tests/common.py
+++ b/cardano_node_tests/tests/common.py
@@ -10,6 +10,7 @@ from cardano_node_tests.tests import issues
 from cardano_node_tests.utils import cluster_nodes
 from cardano_node_tests.utils import clusterlib_utils
 from cardano_node_tests.utils import configuration
+from cardano_node_tests.utils import helpers
 from cardano_node_tests.utils import pytest_utils
 from cardano_node_tests.utils.versions import VERSIONS
 
@@ -450,3 +451,15 @@ def get_pool_user(
         caching_key=caching_key,
         amount=amount,
     )[0]
+
+
+def is_fee_in_interval(fee: float, expected_fee: float, frac: float = 0.1) -> bool:
+    """Check that the fee is within the expected range on local testnet.
+
+    The fee is considered to be within the expected range if it is within the expected_fee +/- frac
+    range.
+    """
+    # We have the fees calibrated only for local testnet
+    if cluster_nodes.get_cluster_type().type == cluster_nodes.ClusterType.TESTNET:
+        return True
+    return helpers.is_in_interval(fee, expected_fee, frac=frac)

--- a/cardano_node_tests/tests/test_native_tokens.py
+++ b/cardano_node_tests/tests/test_native_tokens.py
@@ -228,9 +228,9 @@ class TestMinting:
         assert not token_utxo, "The token was not burnt"
 
         # Check expected fees
-        assert helpers.is_in_interval(
+        assert common.is_fee_in_interval(
             tx_out_mint.fee, expected_fee, frac=0.15
-        ) and helpers.is_in_interval(tx_out_burn.fee, expected_fee, frac=0.15), (
+        ) and common.is_fee_in_interval(tx_out_burn.fee, expected_fee, frac=0.15), (
             "TX fee doesn't fit the expected interval"
         )
 
@@ -327,9 +327,9 @@ class TestMinting:
         assert not token_utxo, "The token was not burnt"
 
         # Check expected fees
-        assert helpers.is_in_interval(
+        assert common.is_fee_in_interval(
             tx_out_mint.fee, expected_fee, frac=0.15
-        ) and helpers.is_in_interval(tx_out_burn.fee, expected_fee, frac=0.15), (
+        ) and common.is_fee_in_interval(tx_out_burn.fee, expected_fee, frac=0.15), (
             "TX fee doesn't fit the expected interval"
         )
 
@@ -443,9 +443,9 @@ class TestMinting:
             assert not utxo_burn, f"The {t.token} token was not burnt"
 
         # Check expected fees
-        assert helpers.is_in_interval(
+        assert common.is_fee_in_interval(
             tx_out_mint.fee, expected_fee, frac=0.15
-        ) and helpers.is_in_interval(tx_out_burn.fee, expected_fee, frac=0.15), (
+        ) and common.is_fee_in_interval(tx_out_burn.fee, expected_fee, frac=0.15), (
             "TX fee doesn't fit the expected interval"
         )
 
@@ -562,7 +562,7 @@ class TestMinting:
         assert not token2_burn_utxo, "The token was not burnt"
 
         # Check expected fees
-        assert helpers.is_in_interval(tx_out_mint_burn.fee, expected_fee, frac=0.15), (
+        assert common.is_fee_in_interval(tx_out_mint_burn.fee, expected_fee, frac=0.15), (
             "TX fee doesn't fit the expected interval"
         )
 
@@ -685,7 +685,7 @@ class TestMinting:
         assert token_utxo and token_utxo[0].amount == 1, "The token was not minted"
 
         # Check expected fees
-        assert helpers.is_in_interval(tx_output.fee, expected_fee, frac=0.15), (
+        assert common.is_fee_in_interval(tx_output.fee, expected_fee, frac=0.15), (
             "TX fee doesn't fit the expected interval"
         )
 
@@ -829,7 +829,7 @@ class TestMinting:
 
         # Check expected fees
         mint_fee = tx_out_mint.fee
-        assert helpers.is_in_interval(mint_fee, expected_fee, frac=0.15), (
+        assert common.is_fee_in_interval(mint_fee, expected_fee, frac=0.15), (
             "TX fee doesn't fit the expected interval"
         )
 
@@ -979,7 +979,7 @@ class TestMinting:
 
         # Check expected fees
         mint_fee = tx_out_mint.fee
-        assert helpers.is_in_interval(mint_fee, expected_fee, frac=0.15), (
+        assert common.is_fee_in_interval(mint_fee, expected_fee, frac=0.15), (
             "TX fee doesn't fit the expected interval"
         )
 
@@ -1077,7 +1077,7 @@ class TestMinting:
         )
 
         # Check expected fee
-        assert helpers.is_in_interval(tx_out_mint.fee, expected_fee, frac=0.15), (
+        assert common.is_fee_in_interval(tx_out_mint.fee, expected_fee, frac=0.15), (
             "TX fee doesn't fit the expected interval"
         )
 
@@ -1163,9 +1163,9 @@ class TestMinting:
         assert not token_utxo, "The token was not burnt"
 
         # Check expected fees
-        assert helpers.is_in_interval(
+        assert common.is_fee_in_interval(
             tx_out_mint.fee, expected_fee, frac=0.15
-        ) and helpers.is_in_interval(tx_out_burn.fee, expected_fee, frac=0.15), (
+        ) and common.is_fee_in_interval(tx_out_burn.fee, expected_fee, frac=0.15), (
             "TX fee doesn't fit the expected interval"
         )
 
@@ -1260,9 +1260,9 @@ class TestPolicies:
             assert not token_utxo, "The token was not burnt"
 
         # Check expected fees
-        assert helpers.is_in_interval(
+        assert common.is_fee_in_interval(
             tx_out_mint.fee, expected_fee, frac=0.15
-        ) and helpers.is_in_interval(tx_out_burn.fee, expected_fee, frac=0.15), (
+        ) and common.is_fee_in_interval(tx_out_burn.fee, expected_fee, frac=0.15), (
             "TX fee doesn't fit the expected interval"
         )
 
@@ -1354,9 +1354,9 @@ class TestPolicies:
             assert not token_utxo, "The token was not burnt"
 
         # Check expected fees
-        assert helpers.is_in_interval(
+        assert common.is_fee_in_interval(
             tx_out_mint.fee, expected_fee, frac=0.15
-        ) and helpers.is_in_interval(tx_out_burn.fee, expected_fee, frac=0.15), (
+        ) and common.is_fee_in_interval(tx_out_burn.fee, expected_fee, frac=0.15), (
             "TX fee doesn't fit the expected interval"
         )
 
@@ -2420,7 +2420,7 @@ class TestCLITxOutSyntax:
         assert token_utxo and token_utxo[0].amount == 1_000, "The token was not minted"
 
         # Check expected fees
-        assert helpers.is_in_interval(tx_raw_output.fee, expected_fee, frac=0.15), (
+        assert common.is_fee_in_interval(tx_raw_output.fee, expected_fee, frac=0.15), (
             "TX fee doesn't fit the expected interval"
         )
 
@@ -2592,7 +2592,7 @@ class TestReferenceUTxO:
         assert cluster.g_query.get_utxo(utxo=reference_utxo), "Reference input was spent"
 
         # Check expected fees
-        assert helpers.is_in_interval(tx_raw_output.fee, expected_fee, frac=0.15), (
+        assert common.is_fee_in_interval(tx_raw_output.fee, expected_fee, frac=0.15), (
             "TX fee doesn't fit the expected interval"
         )
 

--- a/cardano_node_tests/tests/test_scripts.py
+++ b/cardano_node_tests/tests/test_scripts.py
@@ -454,7 +454,7 @@ class TestBasic:
         expected_fee = 204_969
         for tx_out in from_single_tx_outputs:
             # Check expected fees
-            assert helpers.is_in_interval(tx_out.fee, expected_fee, frac=0.15), (
+            assert common.is_fee_in_interval(tx_out.fee, expected_fee, frac=0.15), (
                 "TX fee doesn't fit the expected interval"
             )
 
@@ -747,7 +747,7 @@ class TestBasic:
 
         # Check expected fees
         expected_fee = 176_809
-        assert helpers.is_in_interval(tx_out_from.fee, expected_fee, frac=0.15), (
+        assert common.is_fee_in_interval(tx_out_from.fee, expected_fee, frac=0.15), (
             "TX fee doesn't fit the expected interval"
         )
 
@@ -814,7 +814,7 @@ class TestBasic:
 
         # Check expected fees
         expected_fee = 176_765
-        assert helpers.is_in_interval(tx_out_from.fee, expected_fee, frac=0.15), (
+        assert common.is_fee_in_interval(tx_out_from.fee, expected_fee, frac=0.15), (
             "TX fee doesn't fit the expected interval"
         )
 
@@ -1257,7 +1257,7 @@ class TestTimeLocking:
 
         # Check expected fees
         expected_fee = 280_693 if use_build_cmd else 323_857
-        assert helpers.is_in_interval(tx_out_from.fee, expected_fee, frac=0.15), (
+        assert common.is_fee_in_interval(tx_out_from.fee, expected_fee, frac=0.15), (
             "TX fee doesn't fit the expected interval"
         )
 
@@ -1334,7 +1334,7 @@ class TestTimeLocking:
 
         # Check expected fees
         expected_fee = 279_241 if use_build_cmd else 323_989
-        assert helpers.is_in_interval(tx_out_from.fee, expected_fee, frac=0.15), (
+        assert common.is_fee_in_interval(tx_out_from.fee, expected_fee, frac=0.15), (
             "TX fee doesn't fit the expected interval"
         )
 

--- a/cardano_node_tests/tests/test_tx_fees.py
+++ b/cardano_node_tests/tests/test_tx_fees.py
@@ -294,7 +294,7 @@ class TestExpectedFees:
         tx_fee = cluster_obj.g_transaction.calculate_tx_fee(
             src_address=src_address, tx_name=tx_name, txins=txins, txouts=txouts, tx_files=tx_files
         )
-        assert helpers.is_in_interval(tx_fee, expected_fee), (
+        assert common.is_fee_in_interval(tx_fee, expected_fee), (
             "Expected fee doesn't match the actual fee"
         )
 
@@ -350,7 +350,7 @@ class TestExpectedFees:
         tx_fee = cluster.g_transaction.calculate_tx_fee(
             src_address=src_address, tx_name=temp_template, tx_files=tx_files
         )
-        assert helpers.is_in_interval(tx_fee, expected_fee), (
+        assert common.is_fee_in_interval(tx_fee, expected_fee), (
             "Expected fee doesn't match the actual fee"
         )
 
@@ -418,7 +418,7 @@ class TestExpectedFees:
         tx_fee = cluster.g_transaction.calculate_tx_fee(
             src_address=src_address, tx_name=temp_template, tx_files=tx_files
         )
-        assert helpers.is_in_interval(tx_fee, expected_fee), (
+        assert common.is_fee_in_interval(tx_fee, expected_fee), (
             "Expected fee doesn't match the actual fee"
         )
 
@@ -459,7 +459,7 @@ class TestExpectedFees:
         tx_fee = cluster.g_transaction.calculate_tx_fee(
             src_address=src_address, tx_name=temp_template, tx_files=tx_files
         )
-        assert helpers.is_in_interval(tx_fee, expected_fee), (
+        assert common.is_fee_in_interval(tx_fee, expected_fee), (
             "Expected fee doesn't match the actual fee"
         )
 
@@ -500,7 +500,7 @@ class TestExpectedFees:
         tx_fee = cluster.g_transaction.calculate_tx_fee(
             src_address=src_address, tx_name=temp_template, tx_files=tx_files
         )
-        assert helpers.is_in_interval(tx_fee, expected_fee), (
+        assert common.is_fee_in_interval(tx_fee, expected_fee), (
             "Expected fee doesn't match the actual fee"
         )
 

--- a/cardano_node_tests/tests/tests_plutus/test_mint_build.py
+++ b/cardano_node_tests/tests/tests_plutus/test_mint_build.py
@@ -217,10 +217,10 @@ class TestBuildMinting:
 
         # Check expected fees
         expected_fee_step1 = 168_977
-        assert helpers.is_in_interval(tx_output_step1.fee, expected_fee_step1, frac=0.15)
+        assert common.is_fee_in_interval(tx_output_step1.fee, expected_fee_step1, frac=0.15)
 
         expected_fee_step2 = 187_031 if plutus_version == "v3" else 350_000
-        assert helpers.is_in_interval(tx_output_step2.fee, expected_fee_step2, frac=0.15)
+        assert common.is_fee_in_interval(tx_output_step2.fee, expected_fee_step2, frac=0.15)
 
         plutus_common.check_plutus_costs(
             plutus_costs=plutus_costs,
@@ -487,10 +487,10 @@ class TestBuildMinting:
 
         # Check expected fees
         expected_fee_step1 = 167_349
-        assert helpers.is_in_interval(tx_output_step1.fee, expected_fee_step1, frac=0.15)
+        assert common.is_fee_in_interval(tx_output_step1.fee, expected_fee_step1, frac=0.15)
 
         expected_fee_step2 = 346_952 if plutus_version == "v3" else 411_175
-        assert helpers.is_in_interval(tx_output_step2.fee, expected_fee_step2, frac=0.15)
+        assert common.is_fee_in_interval(tx_output_step2.fee, expected_fee_step2, frac=0.15)
 
         plutus_common.check_plutus_costs(
             plutus_costs=plutus_costs,
@@ -754,10 +754,10 @@ class TestBuildMinting:
 
         # Check expected fees
         expected_fee_step1 = 168_977
-        assert helpers.is_in_interval(tx_output_step1.fee, expected_fee_step1, frac=0.15)
+        assert common.is_fee_in_interval(tx_output_step1.fee, expected_fee_step1, frac=0.15)
 
         expected_fee_step2 = 428_543 if plutus_version == "mix_v3_v1" else 633_269
-        assert helpers.is_in_interval(tx_output_step2.fee, expected_fee_step2, frac=0.15)
+        assert common.is_fee_in_interval(tx_output_step2.fee, expected_fee_step2, frac=0.15)
 
         plutus_common.check_plutus_costs(
             plutus_costs=plutus_costs,
@@ -1115,10 +1115,10 @@ class TestBuildMinting:
 
         # Check expected fees
         expected_fee_step1 = 167_349
-        assert helpers.is_in_interval(tx_output_step1.fee, expected_fee_step1, frac=0.15)
+        assert common.is_fee_in_interval(tx_output_step1.fee, expected_fee_step1, frac=0.15)
 
         expected_fee_step2 = 372_438
-        assert helpers.is_in_interval(tx_output_step2.fee, expected_fee_step2, frac=0.15)
+        assert common.is_fee_in_interval(tx_output_step2.fee, expected_fee_step2, frac=0.15)
 
         plutus_common.check_plutus_costs(
             plutus_costs=plutus_costs,

--- a/cardano_node_tests/tests/tests_plutus/test_spend_build.py
+++ b/cardano_node_tests/tests/tests_plutus/test_spend_build.py
@@ -122,10 +122,10 @@ class TestBuildLocking:
 
         # Check expected fees
         expected_fee_fund = 168_845
-        assert helpers.is_in_interval(tx_output_fund.fee, expected_fee_fund, frac=0.15)
+        assert common.is_fee_in_interval(tx_output_fund.fee, expected_fee_fund, frac=0.15)
 
         expected_fee = 170_782
-        assert tx_output and helpers.is_in_interval(tx_output.fee, expected_fee, frac=0.15)
+        assert tx_output and common.is_fee_in_interval(tx_output.fee, expected_fee, frac=0.15)
 
         plutus_common.check_plutus_costs(
             plutus_costs=plutus_costs,
@@ -245,7 +245,7 @@ class TestBuildLocking:
         # Check expected fees
         if tx_output:
             expected_fee = 372_438
-            assert helpers.is_in_interval(tx_output.fee, expected_fee, frac=0.15)
+            assert common.is_fee_in_interval(tx_output.fee, expected_fee, frac=0.15)
 
     @allure.link(helpers.get_vcs_link())
     @pytest.mark.parametrize("embed_datum", (True, False), ids=("embedded_datum", "datum"))
@@ -351,7 +351,7 @@ class TestBuildLocking:
 
         # Check expected fees
         expected_fee_fund = 168_845
-        assert helpers.is_in_interval(tx_output_fund.fee, expected_fee_fund, frac=0.15)
+        assert common.is_fee_in_interval(tx_output_fund.fee, expected_fee_fund, frac=0.15)
 
         plutus_common.check_plutus_costs(
             plutus_costs=plutus_costs,
@@ -613,8 +613,8 @@ class TestBuildLocking:
             )
 
         # Check expected fees
-        assert helpers.is_in_interval(tx_output_fund.fee, expected_fee_fund, frac=0.15)
-        assert helpers.is_in_interval(tx_output_redeem.fee, expected_fee_redeem, frac=0.15)
+        assert common.is_fee_in_interval(tx_output_fund.fee, expected_fee_fund, frac=0.15)
+        assert common.is_fee_in_interval(tx_output_redeem.fee, expected_fee_redeem, frac=0.15)
 
         plutus_common.check_plutus_costs(
             plutus_costs=plutus_costs,
@@ -692,7 +692,7 @@ class TestBuildLocking:
 
         # Check expected fees
         expected_fee_fund = 168_845
-        assert helpers.is_in_interval(tx_output_fund.fee, expected_fee_fund, frac=0.15)
+        assert common.is_fee_in_interval(tx_output_fund.fee, expected_fee_fund, frac=0.15)
 
     @allure.link(helpers.get_vcs_link())
     @common.PARAM_PLUTUS3_VERSION
@@ -754,11 +754,11 @@ class TestBuildLocking:
 
         # Check expected fees
         expected_fee_fund = 168_845
-        assert helpers.is_in_interval(tx_output_fund.fee, expected_fee_fund, frac=0.15)
+        assert common.is_fee_in_interval(tx_output_fund.fee, expected_fee_fund, frac=0.15)
 
         if tx_output:
             expected_fee = 171_309
-            assert helpers.is_in_interval(tx_output.fee, expected_fee, frac=0.15)
+            assert common.is_fee_in_interval(tx_output.fee, expected_fee, frac=0.15)
 
     @allure.link(helpers.get_vcs_link())
     @common.PARAM_PLUTUS3_VERSION
@@ -828,10 +828,10 @@ class TestBuildLocking:
 
         # Check expected fees
         expected_fee_fund = 173_597
-        assert helpers.is_in_interval(tx_output_fund.fee, expected_fee_fund, frac=0.15)
+        assert common.is_fee_in_interval(tx_output_fund.fee, expected_fee_fund, frac=0.15)
 
         expected_fee = 175_710
-        assert tx_output_spend and helpers.is_in_interval(
+        assert tx_output_spend and common.is_fee_in_interval(
             tx_output_spend.fee, expected_fee, frac=0.15
         )
 
@@ -957,10 +957,10 @@ class TestBuildLocking:
 
         # Check expected fees
         expected_fee_fund = 173_597
-        assert helpers.is_in_interval(tx_output_fund.fee, expected_fee_fund, frac=0.15)
+        assert common.is_fee_in_interval(tx_output_fund.fee, expected_fee_fund, frac=0.15)
 
         expected_fee = 183_366
-        assert tx_output_spend and helpers.is_in_interval(
+        assert tx_output_spend and common.is_fee_in_interval(
             tx_output_spend.fee, expected_fee, frac=0.15
         )
 
@@ -1082,10 +1082,10 @@ class TestBuildLocking:
 
         # Check expected fees
         expected_fee_step1 = 168_845
-        assert helpers.is_in_interval(tx_output_step1.fee, expected_fee_step1, frac=0.15)
+        assert common.is_fee_in_interval(tx_output_step1.fee, expected_fee_step1, frac=0.15)
 
         expected_fee_step2 = 176_986
-        assert helpers.is_in_interval(tx_output_step2.fee, expected_fee_step2, frac=0.15)
+        assert common.is_fee_in_interval(tx_output_step2.fee, expected_fee_step2, frac=0.15)
 
         dbsync_utils.check_tx(cluster_obj=cluster, tx_raw_output=tx_output_step1)
         dbsync_utils.check_tx(cluster_obj=cluster, tx_raw_output=tx_output_step2)

--- a/cardano_node_tests/tests/tests_plutus/test_spend_datum_build.py
+++ b/cardano_node_tests/tests/tests_plutus/test_spend_datum_build.py
@@ -284,7 +284,7 @@ class TestNegativeDatum:
 
         # Check expected fees
         expected_fee_fund = 199_087
-        assert helpers.is_in_interval(tx_output_fund.fee, expected_fee_fund, frac=0.15)
+        assert common.is_fee_in_interval(tx_output_fund.fee, expected_fee_fund, frac=0.15)
 
     @allure.link(helpers.get_vcs_link())
     @hypothesis.given(datum_value=st.text())

--- a/cardano_node_tests/tests/tests_plutus/test_spend_negative_build.py
+++ b/cardano_node_tests/tests/tests_plutus/test_spend_negative_build.py
@@ -233,7 +233,7 @@ class TestNegative:
 
         # Check expected fees
         expected_fee_fund = 173597
-        assert helpers.is_in_interval(tx_output_fund.fee, expected_fee_fund, frac=0.15)
+        assert common.is_fee_in_interval(tx_output_fund.fee, expected_fee_fund, frac=0.15)
 
     @allure.link(helpers.get_vcs_link())
     @common.PARAM_PLUTUS3_VERSION
@@ -299,7 +299,7 @@ class TestNegative:
 
         # Check expected fees
         expected_fee_fund = 168_845
-        assert helpers.is_in_interval(tx_output_fund.fee, expected_fee_fund, frac=0.15)
+        assert common.is_fee_in_interval(tx_output_fund.fee, expected_fee_fund, frac=0.15)
 
     @allure.link(helpers.get_vcs_link())
     @pytest.mark.parametrize(

--- a/cardano_node_tests/tests/tests_plutus_v2/test_mint_build.py
+++ b/cardano_node_tests/tests/tests_plutus_v2/test_mint_build.py
@@ -232,8 +232,12 @@ class TestBuildMinting:
 
         script_expected_fee = expected_fees[plutus_version]
 
-        assert helpers.is_in_interval(tx_output_step2.fee, script_expected_fee["fee_2"], frac=0.15)
-        assert helpers.is_in_interval(tx_output_step1.fee, script_expected_fee["fee_1"], frac=0.15)
+        assert common.is_fee_in_interval(
+            tx_output_step2.fee, script_expected_fee["fee_2"], frac=0.15
+        )
+        assert common.is_fee_in_interval(
+            tx_output_step1.fee, script_expected_fee["fee_1"], frac=0.15
+        )
 
         plutus_common.check_plutus_costs(
             plutus_costs=plutus_costs,

--- a/cardano_node_tests/tests/tests_plutus_v2/test_spend_build.py
+++ b/cardano_node_tests/tests/tests_plutus_v2/test_spend_build.py
@@ -199,8 +199,8 @@ class TestBuildLocking:
             expected_fee_fund = 167_965
             expected_fee_redeem = 293_393
 
-        assert helpers.is_in_interval(tx_output_fund.fee, expected_fee_fund, frac=0.15)
-        assert helpers.is_in_interval(tx_output_redeem.fee, expected_fee_redeem, frac=0.15)
+        assert common.is_fee_in_interval(tx_output_fund.fee, expected_fee_fund, frac=0.15)
+        assert common.is_fee_in_interval(tx_output_redeem.fee, expected_fee_redeem, frac=0.15)
 
         assert spend_build.PLUTUS_OP_GUESSING_GAME.execution_cost  # for mypy
         plutus_common.check_plutus_costs(
@@ -319,6 +319,6 @@ class TestBuildLocking:
             txouts=joined_txouts[0]
         ).value
 
-        assert helpers.is_in_interval(
+        assert common.is_fee_in_interval(
             min_required_utxo, expected_min_required_utxo[test_scenario], frac=0.15
         )

--- a/cardano_node_tests/tests/tests_plutus_v2/test_spend_datum_build.py
+++ b/cardano_node_tests/tests/tests_plutus_v2/test_spend_datum_build.py
@@ -82,7 +82,7 @@ class TestInlineDatum:
         ).value
 
         expected_min_small_inline_datum = 892_170
-        assert helpers.is_in_interval(
+        assert common.is_fee_in_interval(
             min_utxo_small_inline_datum, expected_min_small_inline_datum, frac=0.15
         )
 
@@ -103,7 +103,7 @@ class TestInlineDatum:
         ).value
 
         expected_min_small_datum_hash = 1_017_160
-        assert helpers.is_in_interval(
+        assert common.is_fee_in_interval(
             min_utxo_small_datum_hash, expected_min_small_datum_hash, frac=0.15
         )
 
@@ -122,7 +122,7 @@ class TestInlineDatum:
         ).value
 
         expected_min_big_inline_datum = 1_193_870
-        assert helpers.is_in_interval(
+        assert common.is_fee_in_interval(
             min_utxo_big_inline_datum, expected_min_big_inline_datum, frac=0.15
         )
 
@@ -143,7 +143,7 @@ class TestInlineDatum:
         ).value
 
         expected_min_big_datum_hash = 1_017_160
-        assert helpers.is_in_interval(
+        assert common.is_fee_in_interval(
             min_utxo_big_datum_hash, expected_min_big_datum_hash, frac=0.15
         )
 

--- a/cardano_node_tests/tests/tests_plutus_v2/test_spend_raw.py
+++ b/cardano_node_tests/tests/tests_plutus_v2/test_spend_raw.py
@@ -172,7 +172,7 @@ class TestLockingV2:
             + redeem_cost.fee
         )
 
-        assert helpers.is_in_interval(fee, expected_fee_redeem, frac=0.15)
+        assert common.is_fee_in_interval(fee, expected_fee_redeem, frac=0.15)
 
         dbsync_utils.check_tx(cluster_obj=cluster, tx_raw_output=tx_output_redeem)
 

--- a/cardano_node_tests/tests/tests_plutus_v2/test_spend_ref_inputs_build.py
+++ b/cardano_node_tests/tests/tests_plutus_v2/test_spend_ref_inputs_build.py
@@ -158,7 +158,7 @@ class TestReadonlyReferenceInputs:
         )
 
         expected_redeem_fee = 172_578
-        assert helpers.is_in_interval(tx_output_redeem.fee, expected_redeem_fee, frac=0.15), (
+        assert common.is_fee_in_interval(tx_output_redeem.fee, expected_redeem_fee, frac=0.15), (
             "Expected fee doesn't match the actual fee"
         )
 

--- a/cardano_node_tests/tests/tests_plutus_v2/test_spend_ref_scripts_build.py
+++ b/cardano_node_tests/tests/tests_plutus_v2/test_spend_ref_scripts_build.py
@@ -230,7 +230,7 @@ class TestReferenceScripts:
         min_required_utxo = cluster.g_transaction.calculate_min_req_utxo(txouts=[txouts[2]]).value
 
         expected_min_required_utxo = 926_650
-        assert helpers.is_in_interval(min_required_utxo, expected_min_required_utxo, frac=0.15)
+        assert common.is_fee_in_interval(min_required_utxo, expected_min_required_utxo, frac=0.15)
 
     @allure.link(helpers.get_vcs_link())
     @pytest.mark.smoke

--- a/cardano_node_tests/tests/tests_plutus_v3/test_spend_build.py
+++ b/cardano_node_tests/tests/tests_plutus_v3/test_spend_build.py
@@ -94,10 +94,10 @@ class TestBuildLocking:
 
         # Check expected fees
         expected_fee_fund = 168_845
-        assert helpers.is_in_interval(tx_output_fund.fee, expected_fee_fund, frac=0.15)
+        assert common.is_fee_in_interval(tx_output_fund.fee, expected_fee_fund, frac=0.15)
 
         expected_fee = 170_782
-        assert tx_output and helpers.is_in_interval(tx_output.fee, expected_fee, frac=0.15)
+        assert tx_output and common.is_fee_in_interval(tx_output.fee, expected_fee, frac=0.15)
 
         plutus_common.check_plutus_costs(
             plutus_costs=plutus_costs,


### PR DESCRIPTION
- Added `is_fee_in_interval` function to `common.py` for checking if the fee is within the expected range on local testnet.
- Replaced `helpers.is_in_interval` with `common.is_fee_in_interval` in various test files to use the new function.