### PR TITLE
feat(tests): double deposit amount in drep test

### DIFF
--- a/cardano_node_tests/tests/tests_conway/test_drep.py
+++ b/cardano_node_tests/tests/tests_conway/test_drep.py
@@ -990,7 +990,7 @@ class TestNegativeDReps:
                 payment_addr,
                 cluster_obj=cluster,
                 all_faucets=cluster_manager.cache.addrs_data,
-                amount=deposit_drep_amt + 10_000_000,
+                amount=deposit_drep_amt * 2 + 10_000_000,
             )
 
         drep_metadata_file = pl.Path(f"{temp_template}_drep_metadata.json")


### PR DESCRIPTION
Increased the deposit amount in the drep test to ensure sufficient funds for testing. This change modifies the amount calculation to deposit_drep_amt * 2 + 10_000_000.