### PR TITLE
refactor: use get_epoch and get_block_no methods

### DIFF
--- a/cardano_node_tests/tests/test_blocks.py
+++ b/cardano_node_tests/tests/test_blocks.py
@@ -353,7 +353,7 @@ class TestCollectData:
 
         tip = cluster.g_query.get_tip()
         epoch_end = cluster.time_to_epoch_end(tip)
-        curr_epoch = int(tip["epoch"])
+        curr_epoch = cluster.g_query.get_epoch(tip=tip)
         curr_time = time.time()
         epoch_end_timestamp = curr_time + epoch_end
         test_end_timestamp = epoch_end_timestamp + (num_epochs * cluster.epoch_length_sec)
@@ -510,7 +510,7 @@ class TestDynamicBlockProd:
         cluster_nodes.restart_all_nodes()
 
         tip = cluster.g_query.get_tip()
-        curr_epoch = int(tip["epoch"])
+        curr_epoch = cluster.g_query.get_epoch(tip=tip)
 
         assert reconf_epoch == curr_epoch, (
             "Failed to finish reconfiguration in single epoch, it would affect other checks"

--- a/cardano_node_tests/tests/test_dbsync.py
+++ b/cardano_node_tests/tests/test_dbsync.py
@@ -124,8 +124,8 @@ class TestDBSync:
         common.get_test_id(cluster)
 
         tip = cluster.g_query.get_tip()
-        block_no = int(tip["block"])
-        epoch = int(tip["epoch"])
+        block_no = cluster.g_query.get_block_no(tip=tip)
+        epoch = cluster.g_query.get_epoch(tip=tip)
 
         # Check records for last 50 epochs
         epoch_from = epoch - 50

--- a/cardano_node_tests/tests/test_pool_saturation.py
+++ b/cardano_node_tests/tests/test_pool_saturation.py
@@ -493,7 +493,7 @@ class TestPoolSaturation:
                         )
 
                 tip = cluster.g_query.get_tip()
-                if int(tip["epoch"]) != this_epoch:
+                if cluster.g_query.get_epoch(tip=tip) != this_epoch:
                     helpers.write_json(
                         out_file=f"{temp_template}_{this_epoch}_failed_tip.json", content=tip
                     )


### PR DESCRIPTION
Updated test cases to use cluster.g_query.get_epoch and cluster.g_query.get_block_no methods instead of directly accessing the tip dictionary. This improves code readability and maintainability.