### PR TITLE
fix: handle improper coverage format with warning

### DIFF
--- a/cardano_node_tests/cardano_cli_coverage.py
+++ b/cardano_node_tests/cardano_cli_coverage.py
@@ -176,8 +176,8 @@ def get_coverage(coverage_files: list[pl.Path], available_commands: dict) -> dic
             coverage = get_log_coverage(in_coverage)
 
         if coverage.get("cardano-cli", {}).get("_count") is None:
-            msg = f"Data in '{in_coverage}' doesn't seem to be in proper coverage format."
-            raise AttributeError(msg)
+            LOGGER.warning(f"Data in '{in_coverage}' doesn't seem to be in proper coverage format")
+            continue
 
         coverage_dict = merge_coverage(coverage_dict, coverage)
 


### PR DESCRIPTION
The start-cluster.log can now contain also information other than `cardano-cli` commands.

Previously, an AttributeError was raised when the coverage data was not in the proper format. This change updates the code to log a warning message instead and continue processing. This prevents the program from stopping abruptly due to format issues.