### PR TITLE
refactor(tests): remove forgotten debug code

### DIFF
--- a/cardano_node_tests/tests/test_scripts.py
+++ b/cardano_node_tests/tests/test_scripts.py
@@ -133,8 +133,6 @@ def multisig_tx(
         witness_files=witness_files,
         tx_name=temp_template,
     )
-    # if "from_single_0" in temp_template and submit_method == "api" and not use_build_cmd:
-    #     from IPython import embed; embed()
 
     # Submit signed TX
     submit_utils.submit_tx(


### PR DESCRIPTION
Removed commented-out debug code from test_scripts.py to clean up the codebase. This change ensures that no unnecessary debug statements remain in the production code.