### PR TITLE
fix: correct logging of rewards in testnet cleanup

### DIFF
--- a/cardano_node_tests/testnet_cleanup_info.py
+++ b/cardano_node_tests/testnet_cleanup_info.py
@@ -45,7 +45,7 @@ def main() -> int:
     location = args.artifacts_base_dir
     balance, rewards = testnet_cleanup.addresses_info(cluster_obj=cluster_obj, location=location)
     LOGGER.info(f"Uncleaned balance: {balance} Lovelace ({balance / 1_000_000} ADA)")
-    LOGGER.info(f"Uncleaned rewards: {rewards} Lovelace ({balance / 1_000_000} ADA)")
+    LOGGER.info(f"Uncleaned rewards: {rewards} Lovelace ({rewards / 1_000_000} ADA)")
 
     return 0
 

--- a/cardano_node_tests/utils/testnet_cleanup.py
+++ b/cardano_node_tests/utils/testnet_cleanup.py
@@ -412,7 +412,7 @@ def addresses_info(cluster_obj: clusterlib.ClusterLib, location: pl.Path) -> tp.
                 f_rewards = stake_addr_info.reward_account_balance
                 if f_rewards:
                     rewards += f_rewards
-                    LOGGER.info(f"{f_rewards} on '{fpath}'")
+                    LOGGER.info(f"{f_rewards / 1_000_000} ADA on '{fpath}'")
             else:
                 address = clusterlib.read_address_from_file(fpath)
                 utxos = cluster_obj.g_query.get_utxo(address=address)


### PR DESCRIPTION
- Fixed incorrect variable used in logging uncleaned rewards in `testnet_cleanup_info.py`.
- Updated logging format for rewards in `testnet_cleanup.py` to display in ADA.