### PR TITLE
feat: add skipif markers for testnet and local clusters

### DIFF
--- a/cardano_node_tests/tests/common.py
+++ b/cardano_node_tests/tests/common.py
@@ -79,6 +79,16 @@ SKIPIF_PLUTUSV3_UNUSABLE = pytest.mark.skipif(
     reason=_PLUTUSV3_SKIP_REASON,
 )
 
+SKIPIF_ON_TESTNET = pytest.mark.skipif(
+    cluster_nodes.get_cluster_type().type != cluster_nodes.ClusterType.LOCAL,
+    reason="not supposed to run on long-running testnet",
+)
+
+SKIPIF_ON_LOCAL = pytest.mark.skipif(
+    cluster_nodes.get_cluster_type().type == cluster_nodes.ClusterType.LOCAL,
+    reason="supposed to run on long-running testnet",
+)
+
 
 # Common parametrization
 PARAM_USE_BUILD_CMD = pytest.mark.parametrize(

--- a/cardano_node_tests/tests/test_cli.py
+++ b/cardano_node_tests/tests/test_cli.py
@@ -1160,10 +1160,7 @@ class TestAdvancedQueries:
             "total_stake",
             pytest.param(
                 "all_pools",
-                marks=pytest.mark.skipif(
-                    cluster_nodes.get_cluster_type().type != cluster_nodes.ClusterType.LOCAL,
-                    reason="not supposed to run on testnet",
-                ),
+                marks=common.SKIPIF_ON_TESTNET,
             ),
         ),
     )

--- a/cardano_node_tests/tests/test_native_tokens.py
+++ b/cardano_node_tests/tests/test_native_tokens.py
@@ -25,7 +25,6 @@ from cardano_node_tests.cluster_management import cluster_management
 from cardano_node_tests.tests import common
 from cardano_node_tests.tests import issues
 from cardano_node_tests.utils import blockers
-from cardano_node_tests.utils import cluster_nodes
 from cardano_node_tests.utils import clusterlib_utils
 from cardano_node_tests.utils import dbsync_utils
 from cardano_node_tests.utils import helpers
@@ -2003,10 +2002,7 @@ class TestTransfer:
 
     @allure.link(helpers.get_vcs_link())
     @common.PARAM_USE_BUILD_CMD
-    @pytest.mark.skipif(
-        cluster_nodes.get_cluster_type().type != cluster_nodes.ClusterType.LOCAL,
-        reason="runs only on local cluster",
-    )
+    @common.SKIPIF_ON_TESTNET
     @pytest.mark.smoke
     def test_transfer_no_ada(
         self,

--- a/cardano_node_tests/tests/test_reconnect.py
+++ b/cardano_node_tests/tests/test_reconnect.py
@@ -25,10 +25,7 @@ TEST_RECONNECT = os.environ.get("TEST_RECONNECT") is not None
 TEST_METRICS_RECONNECT = os.environ.get("TEST_METRICS_RECONNECT") is not None
 
 
-@pytest.mark.skipif(
-    cluster_nodes.get_cluster_type().type != cluster_nodes.ClusterType.LOCAL,
-    reason="Runs only on local cluster",
-)
+@common.SKIPIF_ON_TESTNET
 @pytest.mark.skipif(
     VERSIONS.cluster_era != VERSIONS.transaction_era,
     reason="runs only with same cluster and Tx era",

--- a/cardano_node_tests/tests/test_rollback.py
+++ b/cardano_node_tests/tests/test_rollback.py
@@ -28,10 +28,7 @@ ROLLBACK_NODES_OFFSET = int(os.environ.get("ROLLBACK_NODES_OFFSET") or 1)
 LAST_POOL_NAME = f"pool{configuration.NUM_POOLS}"
 
 
-@pytest.mark.skipif(
-    cluster_nodes.get_cluster_type().type != cluster_nodes.ClusterType.LOCAL,
-    reason="runs only on local cluster",
-)
+@common.SKIPIF_ON_TESTNET
 @pytest.mark.skipif(
     VERSIONS.cluster_era != VERSIONS.transaction_era,
     reason="runs only with same cluster and Tx era",

--- a/cardano_node_tests/tests/test_staking_rewards.py
+++ b/cardano_node_tests/tests/test_staking_rewards.py
@@ -14,7 +14,6 @@ from cardano_node_tests.cluster_management import cluster_management
 from cardano_node_tests.cluster_management import resources_management
 from cardano_node_tests.tests import common
 from cardano_node_tests.tests import delegation
-from cardano_node_tests.utils import cluster_nodes
 from cardano_node_tests.utils import clusterlib_utils
 from cardano_node_tests.utils import dbsync_types
 from cardano_node_tests.utils import dbsync_utils
@@ -252,10 +251,7 @@ class TestRewards:
     """Tests for checking expected rewards."""
 
     @allure.link(helpers.get_vcs_link())
-    @pytest.mark.skipif(
-        cluster_nodes.get_cluster_type().type == cluster_nodes.ClusterType.LOCAL,
-        reason="supposed to run on testnet",
-    )
+    @common.SKIPIF_ON_LOCAL
     @pytest.mark.order(6)
     @pytest.mark.long
     @pytest.mark.testnets


### PR DESCRIPTION
- Introduced SKIPIF_ON_TESTNET and SKIPIF_ON_LOCAL markers in common.py
- Replaced existing skipif conditions with new markers in test files
- Removed unused imports from test_native_tokens.py and test_staking_rewards.py