### PR TITLE
refactor(testnet_cleanup): remove faucet address check

### DIFF
--- a/cardano_node_tests/utils/testnet_cleanup.py
+++ b/cardano_node_tests/utils/testnet_cleanup.py
@@ -516,8 +516,6 @@ def addresses_info(cluster_obj: clusterlib.ClusterLib, location: pl.Path) -> tp.
     seen_addrs = set()
     for fpath in files_found:
         f_name = fpath.name
-        if f_name == "faucet.addr":
-            continue
 
         address = clusterlib.read_address_from_file(fpath)
         if address in seen_addrs:


### PR DESCRIPTION
The `faucet.addr` file is already excluded by the `filter_addr_files` function. This simplifies the logic and ensures all addresses are processed uniformly.

Affected file:
- `cardano_node_tests/utils/testnet_cleanup.py`