### PR TITLE
feat(utils): add custom ClusterLib with extended functionality

### DIFF
--- a/cardano_node_tests/utils/cluster_nodes.py
+++ b/cardano_node_tests/utils/cluster_nodes.py
@@ -15,6 +15,7 @@ from cardano_clusterlib import clusterlib
 
 from cardano_node_tests.utils import cluster_scripts
 from cardano_node_tests.utils import configuration
+from cardano_node_tests.utils import custom_clusterlib
 from cardano_node_tests.utils import faucet
 from cardano_node_tests.utils import helpers
 
@@ -118,7 +119,7 @@ class LocalCluster(ClusterType):
     def get_cluster_obj(self, command_era: str = "") -> clusterlib.ClusterLib:
         """Return instance of `ClusterLib` (cluster_obj)."""
         cluster_env = get_cluster_env()
-        cluster_obj = clusterlib.ClusterLib(
+        cluster_obj = custom_clusterlib.ClusterLib(
             state_dir=cluster_env.state_dir,
             command_era=command_era or cluster_env.command_era or clusterlib.CommandEras.LATEST,
         )
@@ -235,7 +236,7 @@ class TestnetCluster(ClusterType):
     def get_cluster_obj(self, command_era: str = "") -> clusterlib.ClusterLib:
         """Return instance of `ClusterLib` (cluster_obj)."""
         cluster_env = get_cluster_env()
-        cluster_obj = clusterlib.ClusterLib(
+        cluster_obj = custom_clusterlib.ClusterLib(
             state_dir=cluster_env.state_dir,
             command_era=command_era or cluster_env.command_era or clusterlib.CommandEras.LATEST,
         )

--- a/cardano_node_tests/utils/custom_clusterlib.py
+++ b/cardano_node_tests/utils/custom_clusterlib.py
@@ -1,0 +1,40 @@
+"""Custom `ClusterLib` extended with functionality that is useful for testing."""
+
+import logging
+import os
+import pathlib as pl
+
+from cardano_clusterlib import clusterlib
+from cardano_clusterlib import transaction_group
+
+LOGGER = logging.getLogger(__name__)
+
+
+class ClusterLib(clusterlib.ClusterLib):
+    @property
+    def g_transaction(self) -> transaction_group.TransactionGroup:
+        """Transaction group."""
+        if not self._transaction_group:
+            self._transaction_group = TransactionGroup(clusterlib_obj=self)
+        return self._transaction_group
+
+
+class TransactionGroup(transaction_group.TransactionGroup):
+    def submit_tx(
+        self,
+        tx_file: clusterlib.FileType,
+        txins: list[clusterlib.UTXOData],
+        wait_blocks: int | None = None,
+    ) -> str:
+        """Create a `.submitted` status file when the Tx was successfully submitted."""
+        txid = super().submit_tx(tx_file=tx_file, txins=txins, wait_blocks=wait_blocks)
+        tx_path = pl.Path(tx_file)
+        submitted_symlink = tx_path.with_name(f"{tx_path.name}.submitted")
+        try:
+            relative_target = os.path.relpath(tx_path, start=submitted_symlink.parent)
+            submitted_symlink.symlink_to(relative_target)
+        except OSError as exc:
+            LOGGER.warning(
+                f"Cannot create symlink '{submitted_symlink}' -> '{relative_target}': {exc}"
+            )
+        return txid


### PR DESCRIPTION
Introduce a custom `ClusterLib` class that extends the original `ClusterLib` with additional features useful for testing. This includes a `TransactionGroup` that creates a `.submitted` status file upon successful transaction submission.

Changes:
- Updated `cluster_nodes.py` to use `custom_clusterlib.ClusterLib`.
- Added `custom_clusterlib.py` with the extended `ClusterLib` class.
- Enhanced `submit_api.py` to create `.submitted` status files.

These changes improve transaction tracking and testing capabilities.