### PR TITLE
feat(testnet_cleanup): add fee calculation for transactions

### DIFF
--- a/cardano_node_tests/testnet_cleanup_info.py
+++ b/cardano_node_tests/testnet_cleanup_info.py
@@ -25,6 +25,13 @@ def get_args() -> argparse.Namespace:
         type=helpers.check_dir_arg_keep,
         help="Path to a directory with testing artifacts",
     )
+    parser.add_argument(
+        "-f",
+        "--fee",
+        action="store_true",
+        required=False,
+        help="Print total fees of signed transactions",
+    )
     return parser.parse_args()
 
 
@@ -40,9 +47,16 @@ def main() -> int:
     state_dir = pl.Path(socket_env).parent
     cluster_obj = clusterlib.ClusterLib(state_dir=state_dir)
     location = args.artifacts_base_dir
-    balance, rewards = testnet_cleanup.addresses_info(cluster_obj=cluster_obj, location=location)
-    LOGGER.info(f"Uncleaned balance: {balance} Lovelace ({balance / 1_000_000} ADA)")
-    LOGGER.info(f"Uncleaned rewards: {rewards} Lovelace ({rewards / 1_000_000} ADA)")
+
+    if args.fee:
+        fees = testnet_cleanup.fees_info(cluster_obj=cluster_obj, location=location)
+        LOGGER.info(f"Total fees: {fees} Lovelace ({fees / 1_000_000} ADA)")
+    else:
+        balance, rewards = testnet_cleanup.addresses_info(
+            cluster_obj=cluster_obj, location=location
+        )
+        LOGGER.info(f"Uncleaned balance: {balance} Lovelace ({balance / 1_000_000} ADA)")
+        LOGGER.info(f"Uncleaned rewards: {rewards} Lovelace ({rewards / 1_000_000} ADA)")
 
     return 0
 

--- a/cardano_node_tests/utils/testnet_cleanup.py
+++ b/cardano_node_tests/utils/testnet_cleanup.py
@@ -305,17 +305,17 @@ def create_addr_record(addr_file: pl.Path) -> clusterlib.AddressRecord:
 
 
 def find_addr_files(location: pl.Path) -> tp.Generator[pl.Path, None, None]:
-    r"""Find all '\*.addr' files in given location and it's subdirectories."""
+    r"""Find all '\*.addr' files in given location and its subdirectories."""
     return location.glob("**/*.addr")
 
 
 def find_submitted_tx_files(location: pl.Path) -> tp.Generator[pl.Path, None, None]:
-    r"""Find all '\*.submitted' files in given location and it's subdirectories."""
+    r"""Find all '\*.submitted' files in given location and its subdirectories."""
     return location.glob("**/*.submitted")
 
 
 def find_cert_files(location: pl.Path) -> tp.Generator[pl.Path, None, None]:
-    r"""Find all '\*_drep_reg.cert' files in given location and it's subdirectories."""
+    r"""Find all '\*_drep_reg.cert' files in given location and its subdirectories."""
     return location.glob("**/*_drep_reg.cert")
 
 

--- a/cardano_node_tests/utils/testnet_cleanup.py
+++ b/cardano_node_tests/utils/testnet_cleanup.py
@@ -20,6 +20,7 @@ from cardano_clusterlib import clusterlib
 from cardano_node_tests.utils import cluster_nodes
 from cardano_node_tests.utils import defragment_utxos
 from cardano_node_tests.utils import helpers
+from cardano_node_tests.utils import tx_view
 
 LOGGER = logging.getLogger(__name__)
 
@@ -308,6 +309,11 @@ def find_addr_files(location: pl.Path) -> tp.Generator[pl.Path, None, None]:
     return location.glob("**/*.addr")
 
 
+def find_submitted_tx_files(location: pl.Path) -> tp.Generator[pl.Path, None, None]:
+    r"""Find all '\*.submitted' files in given location and it's subdirectories."""
+    return location.glob("**/*.submitted")
+
+
 def find_cert_files(location: pl.Path) -> tp.Generator[pl.Path, None, None]:
     r"""Find all '\*_drep_reg.cert' files in given location and it's subdirectories."""
     return location.glob("**/*_drep_reg.cert")
@@ -546,6 +552,17 @@ def addresses_info(cluster_obj: clusterlib.ClusterLib, location: pl.Path) -> tp.
                 balance += f_balance
 
     return balance, rewards
+
+
+def fees_info(cluster_obj: clusterlib.ClusterLib, location: pl.Path) -> int:
+    """Return the total fees of all signed transactions in the given location."""
+    fees = 0
+    for fpath in find_submitted_tx_files(location):
+        tx_loaded = tx_view.load_tx_view(cluster_obj=cluster_obj, tx_body_file=fpath)
+        tx_fee = int(tx_loaded.get("fee", "0 Lovelace").split()[0])
+        LOGGER.info(f"{tx_fee} Lovelace fee on '{fpath}'")
+        fees += tx_fee
+    return fees
 
 
 def cleanup(


### PR DESCRIPTION
Added a new CLI option `--fee` to calculate and display the total fees of signed transactions in the specified directory. Introduced a helper function `fees_info` to compute the fees and log details for each transaction. Updated `testnet_cleanup_info.py` and `testnet_cleanup.py` accordingly.