### PR TITLE
feat(common): move `get_registered_pool_user` utility

### DIFF
--- a/cardano_node_tests/tests/common.py
+++ b/cardano_node_tests/tests/common.py
@@ -463,6 +463,33 @@ def get_pool_user(
     )[0]
 
 
+def get_registered_pool_user(
+    name_template: str,
+    cluster_manager: cluster_management.ClusterManager,
+    cluster_obj: clusterlib.ClusterLib,
+    caching_key: str = "",
+    amount: int | None = None,
+) -> clusterlib.PoolUser:
+    """Create new registered pool users."""
+    pool_user = get_pool_user(
+        name_template=name_template,
+        cluster_manager=cluster_manager,
+        cluster_obj=cluster_obj,
+        caching_key=caching_key,
+        amount=amount,
+    )
+
+    # Register the stake address
+    clusterlib_utils.register_stake_address(
+        cluster_obj=cluster_obj,
+        pool_user=pool_user,
+        name_template=f"{name_template}_pool_user",
+        deposit_amt=cluster_obj.g_query.get_address_deposit(),
+    )
+
+    return pool_user
+
+
 def is_fee_in_interval(fee: float, expected_fee: float, frac: float = 0.1) -> bool:
     """Check that the fee is within the expected range on local testnet.
 

--- a/cardano_node_tests/tests/test_node_upgrade.py
+++ b/cardano_node_tests/tests/test_node_upgrade.py
@@ -75,9 +75,9 @@ class TestSetup:
     ) -> clusterlib.PoolUser:
         """Create a pool user for singleton."""
         name_template = common.get_test_id(cluster_singleton)
-        return conway_common.get_registered_pool_user(
-            cluster_manager=cluster_manager,
+        return common.get_registered_pool_user(
             name_template=name_template,
+            cluster_manager=cluster_manager,
             cluster_obj=cluster_singleton,
         )
 

--- a/cardano_node_tests/tests/tests_conway/test_committee.py
+++ b/cardano_node_tests/tests/tests_conway/test_committee.py
@@ -62,9 +62,9 @@ def pool_user(
     """Create a pool user."""
     key = helpers.get_current_line_str()
     name_template = common.get_test_id(cluster)
-    return conway_common.get_registered_pool_user(
-        cluster_manager=cluster_manager,
+    return common.get_registered_pool_user(
         name_template=name_template,
+        cluster_manager=cluster_manager,
         cluster_obj=cluster,
         caching_key=key,
     )
@@ -79,9 +79,9 @@ def pool_user_lg(
     cluster, __ = cluster_lock_governance
     key = helpers.get_current_line_str()
     name_template = common.get_test_id(cluster)
-    return conway_common.get_registered_pool_user(
-        cluster_manager=cluster_manager,
+    return common.get_registered_pool_user(
         name_template=name_template,
+        cluster_manager=cluster_manager,
         cluster_obj=cluster,
         caching_key=key,
     )
@@ -96,9 +96,9 @@ def pool_user_ug(
     cluster, __ = cluster_use_governance
     key = helpers.get_current_line_str()
     name_template = common.get_test_id(cluster)
-    return conway_common.get_registered_pool_user(
-        cluster_manager=cluster_manager,
+    return common.get_registered_pool_user(
         name_template=name_template,
+        cluster_manager=cluster_manager,
         cluster_obj=cluster,
         caching_key=key,
     )

--- a/cardano_node_tests/tests/tests_conway/test_constitution.py
+++ b/cardano_node_tests/tests/tests_conway/test_constitution.py
@@ -68,9 +68,9 @@ def pool_user_lg(
     cluster, __ = cluster_lock_gov_script
     key = helpers.get_current_line_str()
     name_template = common.get_test_id(cluster)
-    return conway_common.get_registered_pool_user(
-        cluster_manager=cluster_manager,
+    return common.get_registered_pool_user(
         name_template=name_template,
+        cluster_manager=cluster_manager,
         cluster_obj=cluster,
         caching_key=key,
     )

--- a/cardano_node_tests/tests/tests_conway/test_drep.py
+++ b/cardano_node_tests/tests/tests_conway/test_drep.py
@@ -1612,9 +1612,9 @@ class TestDRepActivity:
         """
         cluster, __ = cluster_lock_governance
         name_template = common.get_test_id(cluster)
-        return conway_common.get_registered_pool_user(
-            cluster_manager=cluster_manager,
+        return common.get_registered_pool_user(
             name_template=name_template,
+            cluster_manager=cluster_manager,
             cluster_obj=cluster,
         )
 

--- a/cardano_node_tests/tests/tests_conway/test_guardrails.py
+++ b/cardano_node_tests/tests/tests_conway/test_guardrails.py
@@ -70,9 +70,9 @@ def pool_user(
     """Create a pool user for "lock governance"."""
     cluster, __ = cluster_guardrails
     name_template = common.get_test_id(cluster)
-    return conway_common.get_registered_pool_user(
-        cluster_manager=cluster_manager,
+    return common.get_registered_pool_user(
         name_template=name_template,
+        cluster_manager=cluster_manager,
         cluster_obj=cluster,
     )
 

--- a/cardano_node_tests/tests/tests_conway/test_hardfork.py
+++ b/cardano_node_tests/tests/tests_conway/test_hardfork.py
@@ -33,9 +33,9 @@ def pool_user_lg(
     cluster, __ = cluster_lock_governance
     key = helpers.get_current_line_str()
     name_template = common.get_test_id(cluster)
-    return conway_common.get_registered_pool_user(
-        cluster_manager=cluster_manager,
+    return common.get_registered_pool_user(
         name_template=name_template,
+        cluster_manager=cluster_manager,
         cluster_obj=cluster,
         caching_key=key,
     )

--- a/cardano_node_tests/tests/tests_conway/test_info.py
+++ b/cardano_node_tests/tests/tests_conway/test_info.py
@@ -37,9 +37,9 @@ def pool_user_ug(
     cluster, __ = cluster_use_governance
     key = helpers.get_current_line_str()
     name_template = common.get_test_id(cluster)
-    return conway_common.get_registered_pool_user(
-        cluster_manager=cluster_manager,
+    return common.get_registered_pool_user(
         name_template=name_template,
+        cluster_manager=cluster_manager,
         cluster_obj=cluster,
         caching_key=key,
     )

--- a/cardano_node_tests/tests/tests_conway/test_no_confidence.py
+++ b/cardano_node_tests/tests/tests_conway/test_no_confidence.py
@@ -38,9 +38,9 @@ def pool_user_lg(
     cluster, __ = cluster_lock_governance
     key = helpers.get_current_line_str()
     name_template = common.get_test_id(cluster)
-    return conway_common.get_registered_pool_user(
-        cluster_manager=cluster_manager,
+    return common.get_registered_pool_user(
         name_template=name_template,
+        cluster_manager=cluster_manager,
         cluster_obj=cluster,
         caching_key=key,
     )

--- a/cardano_node_tests/tests/tests_conway/test_pparam_update.py
+++ b/cardano_node_tests/tests/tests_conway/test_pparam_update.py
@@ -208,12 +208,12 @@ class TestPParamUpdate:
         cluster, __ = cluster_lock_governance_plutus
         key = helpers.get_current_line_str()
         name_template = common.get_test_id(cluster)
-        return conway_common.get_registered_pool_user(
-            cluster_manager=cluster_manager,
+        return common.get_registered_pool_user(
             name_template=name_template,
+            cluster_manager=cluster_manager,
             cluster_obj=cluster,
             caching_key=key,
-            fund_amount=2000_000_000,
+            amount=2_000_000_000,
         )
 
     @allure.link(helpers.get_vcs_link())

--- a/cardano_node_tests/tests/tests_conway/test_treasury_withdrawals.py
+++ b/cardano_node_tests/tests/tests_conway/test_treasury_withdrawals.py
@@ -61,9 +61,9 @@ def pool_user_ug(
     cluster, __ = cluster_use_governance
     key = helpers.get_current_line_str()
     name_template = common.get_test_id(cluster)
-    return conway_common.get_registered_pool_user(
-        cluster_manager=cluster_manager,
+    return common.get_registered_pool_user(
         name_template=name_template,
+        cluster_manager=cluster_manager,
         cluster_obj=cluster,
         caching_key=key,
     )
@@ -78,9 +78,9 @@ def pool_user_ug_treasury(
     cluster, __ = cluster_use_governance_lock_treasury
     key = helpers.get_current_line_str()
     name_template = common.get_test_id(cluster)
-    return conway_common.get_registered_pool_user(
-        cluster_manager=cluster_manager,
+    return common.get_registered_pool_user(
         name_template=name_template,
+        cluster_manager=cluster_manager,
         cluster_obj=cluster,
         caching_key=key,
     )

--- a/cardano_node_tests/tests/tests_conway/test_update_plutusv2_builtins.py
+++ b/cardano_node_tests/tests/tests_conway/test_update_plutusv2_builtins.py
@@ -35,12 +35,12 @@ def pool_user_lgp(
     cluster, __ = cluster_lock_governance_plutus
     key = helpers.get_current_line_str()
     name_template = common.get_test_id(cluster)
-    return conway_common.get_registered_pool_user(
-        cluster_manager=cluster_manager,
+    return common.get_registered_pool_user(
         name_template=name_template,
+        cluster_manager=cluster_manager,
         cluster_obj=cluster,
         caching_key=key,
-        fund_amount=2000_000_000,
+        amount=2_000_000_000,
     )
 
 


### PR DESCRIPTION
- Introduced `get_registered_pool_user` in `common.py` to create and register pool users.
- Removed duplicate implementation of `get_registered_pool_user` from `conway_common.py`.
- Updated references in tests to use the new utility in `common.py`.

This change improves code reuse and simplifies pool user creation.