### PR TITLE
fix(tests): handle ProposalReturnAccountDoesNotExist error

### DIFF
--- a/cardano_node_tests/tests/tests_conway/test_conway.py
+++ b/cardano_node_tests/tests/tests_conway/test_conway.py
@@ -111,6 +111,7 @@ class TestConway:
         if use_build_cmd:
             assert (
                 "Stake credential specified in the proposal is not registered on-chain" in err_str
+                or "ProposalReturnAccountDoesNotExist" in err_str  # In node <= 10.1.4
             ), err_str
         else:
             assert "ProposalReturnAccountDoesNotExist" in err_str, err_str


### PR DESCRIPTION
Update test_conway.py to account for the
ProposalReturnAccountDoesNotExist error in node versions <= 10.1.4.

This ensures compatibility with older node versions by adding an additional condition to the assertion in the test.