### PR TITLE
fix(tests): update governance poll error message

### DIFF
--- a/cardano_node_tests/tests/test_governance.py
+++ b/cardano_node_tests/tests/test_governance.py
@@ -37,7 +37,7 @@ class TestPoll:
     def governance_poll_available(self) -> None:
         if not clusterlib_utils.cli_has("compatible babbage governance create-poll"):
             pytest.fail(
-                "The `cardano-cli babbage governance` poll commands are no longer available."
+                "The `cardano-cli compatible babbage governance` poll commands are not available."
             )
 
     @pytest.fixture


### PR DESCRIPTION
Updated the error message in `test_governance.py` to reflect the correct command syntax for `cardano-cli compatible babbage governance`. This ensures clarity when the poll commands are unavailable.