### PR TITLE
fix(testnet_cleanup): improve stake addr re-registration

### DIFF
--- a/cardano_node_tests/utils/testnet_cleanup.py
+++ b/cardano_node_tests/utils/testnet_cleanup.py
@@ -77,10 +77,19 @@ def reregister_stake_addr(
                 deposit=rereg_deposit,
             )
         except clusterlib.CLIError:
-            LOGGER.exception(f"Failed to re-register stake address '{stake_addr.address}'")
+            LOGGER.exception(
+                f"Failed to submit stake address re-registration '{stake_addr.address}'"
+            )
         else:
-            LOGGER.debug(f"Re-registered stake address '{stake_addr.address}'")
-            stake_addr_info = cluster_obj.g_query.get_stake_addr_info(stake_addr.address)
+            for ch in range(3):
+                if ch > 0:
+                    cluster_obj.wait_for_new_block()
+                stake_addr_info = cluster_obj.g_query.get_stake_addr_info(stake_addr.address)
+                if stake_addr_info:
+                    LOGGER.debug(f"Re-registered stake address '{stake_addr.address}'")
+                    break
+            else:
+                LOGGER.exception(f"Failed to re-register stake address '{stake_addr.address}'")
 
     return stake_addr_info
 


### PR DESCRIPTION
Enhance the re-registration process for stake addresses by adding a retry mechanism. The function now waits for new blocks and retries querying stake address info up to three times. This ensures better handling of potential delays in stake address updates.

Additionally, updated log messages for better clarity and debugging.