### PR TITLE
refactor(common): improve funding logic for addresses

### DIFF
--- a/cardano_node_tests/tests/common.py
+++ b/cardano_node_tests/tests/common.py
@@ -349,9 +349,14 @@ def _get_funded_addresses(
     If `amount` is provided, fund once and never re-fund.
     If `amount` is not provided, re-fund when balance drops below `min_amount`.
     """
-    fund_amount = amount or 150_000_000
-    # Re-fund the addresses if the amount is lower than this
-    min_amount = 50_000_000
+    if amount is None:
+        fund_amount = 150_000_000
+        # Re-fund the addresses if the amount is lower than this
+        min_amount = 50_000_000
+    else:
+        # Use the exact specified amount
+        fund_amount = amount
+        min_amount = amount
 
     if caching_key:
         fixture_cache: cluster_management.FixtureCache[list | None]


### PR DESCRIPTION
Refactored the `_get_funded_addresses` function to handle the `amount` parameter more explicitly. If `amount` is provided, it is used for both `fund_amount` and `min_amount`. Otherwise, default values are applied.

This change improves code clarity.