### PR TITLE
feat(docs): add test results for node tag 10.2.1

### DIFF
--- a/src_docs/source/test_results/node/tag_10_2_1.rst
+++ b/src_docs/source/test_results/node/tag_10_2_1.rst
@@ -1,0 +1,63 @@
+10.2.1
+======
+
+* Release notes - <https://github.com/IntersectMBO/cardano-node/releases/tag/10.2.1>
+
+
+Regression testing on a local cluster
+-------------------------------------
+
+.. list-table:: Regression Testsuite
+   :widths: 64 7
+   :header-rows: 0
+
+   * - P2P ON - `Conway PV10 <https://cardano-tests-reports-3-74-115-22.nip.io/01-regression-tests/10.2.1-conway10_p2p_01/>`__
+     - |:heavy_check_mark:|
+
+.. list-table:: Other Testing
+   :widths: 64 7
+   :header-rows: 0
+
+   * - Upgrade testing (10.1.4 to 10.2.1)
+     - |:heavy_check_mark:|
+   * - Rollback testing
+     - |:heavy_check_mark:|
+   * - Reconnection testing
+     - |:heavy_check_mark:|
+   * - Sanity checks of the submit-api REST service
+     - |:heavy_check_mark:|
+   * - P2P Dynamic Block Production testing
+     - |:heavy_check_mark:|
+
+
+Release testing checklist
+-------------------------
+
+.. list-table::
+   :widths: 64 7
+   :header-rows: 0
+
+   * - `10.2.1` pushed to `preview`
+     - |:heavy_check_mark:|
+   * - Regression testing against `preview`
+     - |:heavy_check_mark:|
+   * - `Sync testing ran against Mainnet (Linux) <https://docs.google.com/document/d/16TFXwt2HDFyDVHh-a7uXv1D2sQFl4zwaRZfYIzNBVlc/edit?tab=t.0#heading=h.1eyoor4zkkf9>`__
+     - |:heavy_check_mark:|
+   * - DB re-validation testing (ledger snapshots compatibility)
+     - |:heavy_check_mark:|
+   * - Backward compatibility testing (Node with version N-1)
+     - |:heavy_check_mark:|
+   * - Check build instructions changes
+     - |:hourglass_flowing_sand:|
+
+
+New functionalities in this tag
+-------------------------------
+
+
+New issues
+----------
+
+
+Breaking changes
+----------------

--- a/src_docs/source/test_results/tag_tests.rst
+++ b/src_docs/source/test_results/tag_tests.rst
@@ -4,6 +4,7 @@ Tag Testing
 .. toctree::
    :maxdepth: 4
 
+   node/tag_10_2_1.rst
    node/tag_10_1_2.rst
    node/tag_10_1_1.rst
    node/tag_9_0_0.rst


### PR DESCRIPTION
- Introduced a new documentation file for test results of node tag 10.2.1.
- Included regression, upgrade, rollback, and reconnection testing details.
- Updated `tag_tests.rst` to reference the new test results file.