### PR TITLE
feat(cluster-scripts): add --output-text to query utxo

### DIFF
--- a/cardano_node_tests/cluster_scripts/conway/start-cluster
+++ b/cardano_node_tests/cluster_scripts/conway/start-cluster
@@ -153,7 +153,7 @@ wait_for_epoch() {
 check_spend_success() {
   for _ in {1..10}; do
     if ! cardano_cli_log latest query utxo "$@" \
-      --testnet-magic "$NETWORK_MAGIC" | grep -q lovelace; then
+      --testnet-magic "$NETWORK_MAGIC" --output-text | grep -q lovelace; then
       return 0
     fi
     sleep 3
@@ -184,6 +184,7 @@ get_txins() {
       fi
     done <<< "$(cardano_cli_log conway query utxo \
                 --testnet-magic "$NETWORK_MAGIC" \
+                --output-text \
                 --address "$txin_addr" |
                 grep -E "lovelace$|[0-9]$|lovelace \+ TxOutDatumNone$")"
 

--- a/cardano_node_tests/cluster_scripts/conway_fast/start-cluster
+++ b/cardano_node_tests/cluster_scripts/conway_fast/start-cluster
@@ -92,7 +92,7 @@ cardano_cli_log() {
 check_spend_success() {
   for _ in {1..10}; do
     if ! cardano_cli_log conway query utxo "$@" \
-      --testnet-magic "$NETWORK_MAGIC" | grep -q lovelace; then
+      --testnet-magic "$NETWORK_MAGIC" --output-text | grep -q lovelace; then
       return 0
     fi
     sleep 3
@@ -123,6 +123,7 @@ get_txins() {
       fi
     done <<< "$(cardano_cli_log conway query utxo \
                 --testnet-magic "$NETWORK_MAGIC" \
+                --output-text \
                 --address "$txin_addr" |
                 grep -E "lovelace$|[0-9]$|lovelace \+ TxOutDatumNone$")"
 

--- a/cardano_node_tests/cluster_scripts/mainnet_fast/start-cluster
+++ b/cardano_node_tests/cluster_scripts/mainnet_fast/start-cluster
@@ -92,7 +92,7 @@ cardano_cli_log() {
 check_spend_success() {
   for _ in {1..10}; do
     if ! cardano_cli_log conway query utxo "$@" \
-      --testnet-magic "$NETWORK_MAGIC" | grep -q lovelace; then
+      --testnet-magic "$NETWORK_MAGIC" --output-text | grep -q lovelace; then
       return 0
     fi
     sleep 3
@@ -123,6 +123,7 @@ get_txins() {
       fi
     done <<< "$(cardano_cli_log conway query utxo \
                 --testnet-magic "$NETWORK_MAGIC" \
+                --output-text \
                 --address "$txin_addr" |
                 grep -E "lovelace$|[0-9]$|lovelace \+ TxOutDatumNone$")"
 

--- a/cardano_node_tests/cluster_scripts/testnets/start-cluster
+++ b/cardano_node_tests/cluster_scripts/testnets/start-cluster
@@ -37,7 +37,7 @@ get_address_balance() {
         continue
       fi
       total_amount="$((total_amount + amount))"
-    done <<< "$(cardano-cli latest query utxo "$@" | grep " lovelace")"
+    done <<< "$(cardano-cli latest query utxo "$@" --output-text | grep " lovelace")"
 
     if [ "$total_amount" -gt 0 ]; then
       break


### PR DESCRIPTION
Add the `--output-text` flag to `cardano-cli query utxo` commands in cluster scripts to ensure consistent output format.