### PR TITLE
feat(cli): add `--output-text` option to UTxO queries

### DIFF
--- a/cardano_node_tests/tests/test_cli.py
+++ b/cardano_node_tests/tests/test_cli.py
@@ -787,6 +787,7 @@ class TestQueryUTxO:
                     "utxo",
                     "--address",
                     dst_address,
+                    "--output-text",
                     *cluster.magic_args,
                 ]
             )

--- a/cardano_node_tests/tests/tests_plutus/test_mint_raw.py
+++ b/cardano_node_tests/tests/tests_plutus/test_mint_raw.py
@@ -60,6 +60,7 @@ def _check_pretty_utxo(
                 "utxo",
                 "--tx-in",
                 f"{txid}#0",
+                "--output-text",
                 *cluster_obj.magic_args,
             ]
         )

--- a/cardano_node_tests/tests/tests_plutus/test_spend_raw.py
+++ b/cardano_node_tests/tests/tests_plutus/test_spend_raw.py
@@ -81,6 +81,7 @@ def _check_pretty_utxo(
                 "utxo",
                 "--tx-in",
                 f"{txid}#0",
+                "--output-text",
                 *cluster_obj.magic_args,
             ]
         )


### PR DESCRIPTION
The `--output-text` flag has been added to CLI commands for querying UTxO information. This ensures the output is consistently formatted as plain text, not JSON.