### PR TITLE
feat(cli): ensure text output

### DIFF
--- a/cardano_node_tests/tests/test_cli.py
+++ b/cardano_node_tests/tests/test_cli.py
@@ -113,6 +113,7 @@ class TestCLI:
                     [
                         "transaction",
                         "calculate-min-fee",
+                        "--output-text",
                         "--protocol-params-file",
                         str(cluster.pparams_file),
                         "--tx-body-file",


### PR DESCRIPTION
The --output-text option was added to the "transaction calculate-min-fee" command invocation. This ensures the output format is text even though JSON is now the default output.