### PR TITLE
refactor(logging): simplify logging format configuration

### DIFF
--- a/cardano_node_tests/cardano_cli_coverage.py
+++ b/cardano_node_tests/cardano_cli_coverage.py
@@ -274,10 +274,7 @@ def get_badge_icon(report: dict) -> str:
 
 
 def main() -> int:
-    logging.basicConfig(
-        format="%(name)s:%(levelname)s:%(message)s",
-        level=logging.INFO,
-    )
+    logging.basicConfig(format="%(levelname)s:%(message)s", level=logging.INFO)
     args = get_args()
 
     if not (args.output_file or args.print_coverage or args.badge_icon_url):

--- a/cardano_node_tests/chang_us_coverage.py
+++ b/cardano_node_tests/chang_us_coverage.py
@@ -47,10 +47,7 @@ def _get_color(status: str) -> str:
 
 
 def main() -> int:
-    logging.basicConfig(
-        format="%(name)s:%(levelname)s:%(message)s",
-        level=logging.INFO,
-    )
+    logging.basicConfig(format="%(levelname)s:%(message)s", level=logging.INFO)
     args = get_args()
 
     with open(args.report_template, encoding="utf-8") as in_fp:

--- a/cardano_node_tests/defragment_utxos.py
+++ b/cardano_node_tests/defragment_utxos.py
@@ -35,10 +35,7 @@ def get_args() -> argparse.Namespace:
 
 
 def main() -> int:
-    logging.basicConfig(
-        format="%(name)s:%(levelname)s:%(message)s",
-        level=logging.INFO,
-    )
+    logging.basicConfig(format="%(levelname)s:%(message)s", level=logging.INFO)
     args = get_args()
 
     socket_env = os.environ.get("CARDANO_NODE_SOCKET_PATH")

--- a/cardano_node_tests/dump_requirements_coverage.py
+++ b/cardano_node_tests/dump_requirements_coverage.py
@@ -44,10 +44,7 @@ def get_args() -> argparse.Namespace:
 
 
 def main() -> int:
-    logging.basicConfig(
-        format="%(name)s:%(levelname)s:%(message)s",
-        level=logging.INFO,
-    )
+    logging.basicConfig(format="%(levelname)s:%(message)s", level=logging.INFO)
     args = get_args()
 
     if not (args.artifacts_base_dir or args.input_files):

--- a/cardano_node_tests/prepare_cluster_scripts.py
+++ b/cardano_node_tests/prepare_cluster_scripts.py
@@ -76,10 +76,7 @@ def prepare_scripts_files(
 
 
 def main() -> int:
-    logging.basicConfig(
-        format="%(name)s:%(levelname)s:%(message)s",
-        level=logging.INFO,
-    )
+    logging.basicConfig(format="%(levelname)s:%(message)s", level=logging.INFO)
     args = get_args()
 
     destdir = pl.Path(args.dest_dir)

--- a/cardano_node_tests/split_topology.py
+++ b/cardano_node_tests/split_topology.py
@@ -43,10 +43,7 @@ def get_args() -> argparse.Namespace:
 
 
 def main() -> int:
-    logging.basicConfig(
-        format="%(name)s:%(levelname)s:%(message)s",
-        level=logging.INFO,
-    )
+    logging.basicConfig(format="%(levelname)s:%(message)s", level=logging.INFO)
     args = get_args()
 
     destdir = pl.Path(args.dest_dir)


### PR DESCRIPTION
Simplified the logging configuration in multiple scripts by removing the redundant `%(name)s` field from the log format. This change ensures a more concise and consistent log output.