### PR TITLE
feat(cluster-scripts): use genesis commands from "latest"

### DIFF
--- a/cardano_node_tests/cluster_scripts/conway/start-cluster
+++ b/cardano_node_tests/cluster_scripts/conway/start-cluster
@@ -322,7 +322,7 @@ cardano_cli_log byron genesis genesis \
 
 mv "${STATE_CLUSTER}/byron-params.json" "${STATE_CLUSTER}/byron/params.json"
 
-cardano_cli_log legacy genesis create \
+cardano_cli_log latest genesis create \
   --genesis-dir "${STATE_CLUSTER}/shelley" \
   --testnet-magic "$NETWORK_MAGIC" \
   --gen-genesis-keys "$NUM_BFT_NODES" \
@@ -379,11 +379,11 @@ GOV_ACTION_DEPOSIT="$(jq '.govActionDeposit' \
 
 BYRON_GENESIS_HASH="$(cardano_cli_log byron genesis print-genesis-hash --genesis-json \
   "${STATE_CLUSTER}/byron/genesis.json")"
-SHELLEY_GENESIS_HASH="$(cardano_cli_log legacy genesis hash --genesis \
+SHELLEY_GENESIS_HASH="$(cardano_cli_log latest genesis hash --genesis \
   "${STATE_CLUSTER}/shelley/genesis.json")"
-ALONZO_GENESIS_HASH="$(cardano_cli_log legacy genesis hash --genesis \
+ALONZO_GENESIS_HASH="$(cardano_cli_log latest genesis hash --genesis \
   "${STATE_CLUSTER}/shelley/genesis.alonzo.json")"
-CONWAY_GENESIS_HASH="$(cardano_cli_log legacy genesis hash --genesis \
+CONWAY_GENESIS_HASH="$(cardano_cli_log latest genesis hash --genesis \
   "${STATE_CLUSTER}/shelley/genesis.conway.json")"
 
 for conf in "$SCRIPT_DIR"/config-*.json; do

--- a/cardano_node_tests/cluster_scripts/conway_fast/start-cluster
+++ b/cardano_node_tests/cluster_scripts/conway_fast/start-cluster
@@ -259,7 +259,7 @@ cardano_cli_log byron genesis genesis \
 
 mv "${STATE_CLUSTER}/byron-params.json" "${STATE_CLUSTER}/byron/params.json"
 
-cardano_cli_log legacy genesis create-staked \
+cardano_cli_log latest genesis create-staked \
   --genesis-dir "${STATE_CLUSTER}/create_staked" \
   --testnet-magic "$NETWORK_MAGIC" \
   --gen-pools "$NUM_POOLS" \
@@ -329,11 +329,11 @@ DREP_DEPOSIT="$(jq '.dRepDeposit' \
 
 BYRON_GENESIS_HASH="$(cardano_cli_log byron genesis print-genesis-hash --genesis-json \
   "${STATE_CLUSTER}/byron/genesis.json")"
-SHELLEY_GENESIS_HASH="$(cardano_cli_log legacy genesis hash --genesis \
+SHELLEY_GENESIS_HASH="$(cardano_cli_log latest genesis hash --genesis \
   "${STATE_CLUSTER}/shelley/genesis.json")"
-ALONZO_GENESIS_HASH="$(cardano_cli_log legacy genesis hash --genesis \
+ALONZO_GENESIS_HASH="$(cardano_cli_log latest genesis hash --genesis \
   "${STATE_CLUSTER}/shelley/genesis.alonzo.json")"
-CONWAY_GENESIS_HASH="$(cardano_cli_log legacy genesis hash --genesis \
+CONWAY_GENESIS_HASH="$(cardano_cli_log latest genesis hash --genesis \
   "${STATE_CLUSTER}/shelley/genesis.conway.json")"
 
 for conf in "$SCRIPT_DIR"/config-*.json; do

--- a/cardano_node_tests/cluster_scripts/mainnet_fast/start-cluster
+++ b/cardano_node_tests/cluster_scripts/mainnet_fast/start-cluster
@@ -215,6 +215,7 @@ if [ -n "${DBSYNC_REPO:-""}" ] && [ -n "${SMASH:-""}" ]; then
     { echo "The \`${DBSYNC_REPO}/smash-server/bin/cardano-smash-server\` not found, line $LINENO" >&2; exit 1; }  # assert
 
   cat >> "${STATE_CLUSTER}/supervisor.conf" <<EoF
+
 [program:smash]
 command=${SCRIPT_DIR}/run-cardano-smash
 stderr_logfile=./${STATE_CLUSTER_NAME}/smash.stderr
@@ -258,7 +259,7 @@ cardano_cli_log byron genesis genesis \
 
 mv "${STATE_CLUSTER}/byron-params.json" "${STATE_CLUSTER}/byron/params.json"
 
-cardano_cli_log legacy genesis create-staked \
+cardano_cli_log latest genesis create-staked \
   --genesis-dir "${STATE_CLUSTER}/create_staked" \
   --testnet-magic "$NETWORK_MAGIC" \
   --gen-pools "$NUM_POOLS" \
@@ -328,11 +329,11 @@ DREP_DEPOSIT="$(jq '.dRepDeposit' \
 
 BYRON_GENESIS_HASH="$(cardano_cli_log byron genesis print-genesis-hash --genesis-json \
   "${STATE_CLUSTER}/byron/genesis.json")"
-SHELLEY_GENESIS_HASH="$(cardano_cli_log legacy genesis hash --genesis \
+SHELLEY_GENESIS_HASH="$(cardano_cli_log latest genesis hash --genesis \
   "${STATE_CLUSTER}/shelley/genesis.json")"
-ALONZO_GENESIS_HASH="$(cardano_cli_log legacy genesis hash --genesis \
+ALONZO_GENESIS_HASH="$(cardano_cli_log latest genesis hash --genesis \
   "${STATE_CLUSTER}/shelley/genesis.alonzo.json")"
-CONWAY_GENESIS_HASH="$(cardano_cli_log legacy genesis hash --genesis \
+CONWAY_GENESIS_HASH="$(cardano_cli_log latest genesis hash --genesis \
   "${STATE_CLUSTER}/shelley/genesis.conway.json")"
 
 for conf in "$SCRIPT_DIR"/config-*.json; do


### PR DESCRIPTION
Updated cluster scripts to replace "legacy" with "latest" in genesis commands.