### PR TITLE
fix(workflow): restrict failure emails to scheduled events

### DIFF
--- a/.github/workflows/regression_reusable.yaml
+++ b/.github/workflows/regression_reusable.yaml
@@ -164,7 +164,7 @@ jobs:
           path: cli_coverage.json
       - name: ✉ Mail failure report
         uses: dawidd6/action-send-mail@v4
-        if: (success() || failure()) && steps.testing-step.outcome != 'success' && env.CI_FAIL_MAILS
+        if: (success() || failure()) && steps.testing-step.outcome != 'success' && env.CI_FAIL_MAILS && github.event_name == 'schedule'
         with:
           server_address: smtp.gmail.com
           server_port: 465


### PR DESCRIPTION
Updated the mail failure report step in the regression workflow to only send emails when triggered by a scheduled event. This prevents unnecessary emails for other event types.