### PR TITLE
feat(env): update BASE_TAR_URL to version 10.3.1

### DIFF
--- a/.github/env_nightly_upgrade
+++ b/.github/env_nightly_upgrade
@@ -1,2 +1,2 @@
-BASE_TAR_URL=https://github.com/IntersectMBO/cardano-node/releases/download/10.2.1/cardano-node-10.2.1-linux.tar.gz
+BASE_TAR_URL=https://github.com/IntersectMBO/cardano-node/releases/download/10.3.1/cardano-node-10.3.1-linux.tar.gz
 CI_BYRON_CLUSTER=true


### PR DESCRIPTION
Updated the BASE_TAR_URL in the nightly upgrade environment file to point to the latest mainnet release 10.3.1 of the cardano-node.