### PR TITLE
feat(tests): add handling for API issue 829

### DIFF
--- a/cardano_node_tests/tests/issues.py
+++ b/cardano_node_tests/tests/issues.py
@@ -5,12 +5,17 @@ api_269 = blockers.GH(
     repo="IntersectMBO/cardano-api",
     message="Broken `nextEpochEligibleLeadershipSlots`.",
 )
-
 api_484 = blockers.GH(
     issue=484,
     repo="IntersectMBO/cardano-api",
     fixed_in="8.11.0",  # Unknown yet, will be fixed/changed sometime in the future
     message="Repeated certificates stripped from Conway transaction.",
+)
+api_829 = blockers.GH(
+    issue=829,
+    repo="IntersectMBO/cardano-api",
+    fixed_in="10.8.0.1",  # Unknown yet, will be fixed/changed sometime in the future
+    message="Wrong autobalancing when there's no change.",
 )
 
 cli_49 = blockers.GH(

--- a/cardano_node_tests/tests/test_tx_basic.py
+++ b/cardano_node_tests/tests/test_tx_basic.py
@@ -295,6 +295,9 @@ class TestBasicTransactions:
                 )
             except clusterlib.CLIError as exc:
                 str_exc = str(exc)
+
+                if "does not meet the minimum UTxO threshold" in str_exc:
+                    issues.api_829.finish_test()
                 if "negative" not in str_exc:
                     raise
 


### PR DESCRIPTION
- Introduced a new blocker `api_829` for tracking the issue related to wrong autobalancing when there's no change in transactions.
- Updated `TestBasicTransactions` to handle the specific error message for minimum UTxO threshold.

The API issue: https://github.com/IntersectMBO/cardano-api/pull/829