### PR TITLE
fix(utils): update GitHub auth method for token usage

### DIFF
--- a/cardano_node_tests/utils/gh_issue.py
+++ b/cardano_node_tests/utils/gh_issue.py
@@ -30,7 +30,7 @@ class GHIssue:
         try:
             # Max 60 req/hr without token
             cls._github_instance = (
-                github.Github(login_or_token=cls.TOKEN) if cls.TOKEN else github.Github()
+                github.Github(auth=github.Auth.Token(cls.TOKEN)) if cls.TOKEN else github.Github()
             )
         except Exception:
             LOGGER.exception("Failed to get GitHub instance")


### PR DESCRIPTION
Updated the GitHub authentication method to use `github.Auth.Token` when a token is provided. This ensures compatibility with the latest GitHub API changes.