### PR TITLE
Cabal build tests - Remove manual pkgconf build and update GHC and Cabal

### DIFF
--- a/cabal_build_tests/fedora/Dockerfile
+++ b/cabal_build_tests/fedora/Dockerfile
@@ -6,15 +6,8 @@ RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
 ENV TAGGED_VERSION ''
 COPY install-node.sh /
-# pkg-config 1.9.5 breaks cabal dependency checking
-# pkg-config 2 isn't available yet for fedora so we need to build it from source
 RUN yum update -y && \
-    yum install git diffutils gcc gcc-c++ tmux gmp-devel make tar xz wget zlib-devel libtool autoconf -y && \
-    mkdir -p /root/src/ && cd /root/src && \
-    curl -O https://distfiles.ariadne.space/pkgconf/pkgconf-2.0.3.tar.xz && \
-    tar -xvf pkgconf-2.0.3.tar.xz && \
-    cd pkgconf-2.0.3 && \
-    ./configure && make && make install && \
+    yum install git diffutils gcc gcc-c++ awk tmux gmp-devel make tar xz wget zlib-devel libtool autoconf -y && \
     chmod +x /install-node.sh
 
 CMD ./install-node.sh $TAGGED_VERSION

--- a/cabal_build_tests/install-node.sh
+++ b/cabal_build_tests/install-node.sh
@@ -7,8 +7,8 @@
 # Please note: 'source ~/.bashrc' cmd is not used because Docker runs this script as subscript
 
 # Versions
-GHC_VERSION="9.6.3"
-CABAL_VERSION="3.10.2.0"
+GHC_VERSION="9.6.7"
+CABAL_VERSION="3.12.1.0"
 
 echo ""
 


### PR DESCRIPTION
- remove manual `pkgconf` build
There is no need to download and build manually `pkg-config` on `Fedora` anymore as it is already updated: https://packages.fedoraproject.org/pkgs/pkgconf/pkgconf-pkg-config/

- update GHC to `9.6.7` and Cabal to `3.12.1.0` - so tests use the same versions as in recently updated instruction: https://github.com/cardano-foundation/developer-portal/commit/7edb2750563af45e6e6160a39714ad78fc843bb0

