### PR TITLE
feat(workflows): add utxo_backend input to workflows

### DIFF
--- a/.github/workflows/regression-dbsync.yaml
+++ b/.github/workflows/regression-dbsync.yaml
@@ -43,6 +43,13 @@ on:
         - legacy
         - mixed
         default: p2p
+      utxo_backend:
+        type: choice
+        description: "UTxO backend"
+        options:
+        - mem
+        - disk
+        default: ""
       byron_cluster:
         type: boolean
         default: false
@@ -68,6 +75,7 @@ jobs:
       cluster_era: ${{ inputs.cluster_era }}
       markexpr: ${{ inputs.markexpr }}
       topology: ${{ inputs.topology }}
+      utxo_backend: ${{ inputs.utxo_backend }}
       byron_cluster: ${{ inputs.byron_cluster }}
       testrun_name: ${{ inputs.testrun_name }}
       skip_passed: ${{ inputs.skip_passed }}

--- a/.github/workflows/regression.yaml
+++ b/.github/workflows/regression.yaml
@@ -36,6 +36,13 @@ on:
         - legacy
         - mixed
         default: p2p
+      utxo_backend:
+        type: choice
+        description: "UTxO backend"
+        options:
+        - mem
+        - disk
+        default: ""
       byron_cluster:
         type: boolean
         default: false
@@ -60,6 +67,7 @@ jobs:
       cluster_era: ${{ inputs.cluster_era }}
       markexpr: ${{ inputs.markexpr }}
       topology: ${{ inputs.topology }}
+      utxo_backend: ${{ inputs.utxo_backend }}
       byron_cluster: ${{ inputs.byron_cluster }}
       testrun_name: ${{ inputs.testrun_name }}
       skip_passed: ${{ inputs.skip_passed }}

--- a/.github/workflows/regression_reusable.yaml
+++ b/.github/workflows/regression_reusable.yaml
@@ -35,6 +35,10 @@ on:
         required: false
         type: string
         default: ""
+      utxo_backend:
+        required: false
+        type: string
+        default: ""
       scripts_dirname:
         required: false
         type: string
@@ -94,6 +98,7 @@ jobs:
           echo "MARKEXPR=${{ inputs.markexpr }}" >> .github_ci_env
           echo "SCRIPTS_DIRNAME=${{ inputs.scripts_dirname }}" >> .github_ci_env
           echo "CI_TOPOLOGY=${{ inputs.topology }}" >> .github_ci_env
+          echo "UTXO_BACKEND=${{ inputs.utxo_backend }}" >> .github_ci_env
           echo "CI_BYRON_CLUSTER=${{ inputs.byron_cluster }}" >> .github_ci_env
           echo "CI_TESTRUN_NAME=${{ inputs.testrun_name }}" >> .github_ci_env
           echo "CI_SKIP_PASSED=${{ inputs.skip_passed }}" >> .github_ci_env


### PR DESCRIPTION
Added a new input parameter `utxo_backend` to the regression workflows (`regression-dbsync.yaml`, `regression.yaml`, and
`regression_reusable.yaml`). This parameter allows specifying the UTxO backend with options `mem` or `disk`.