### PR TITLE
feat(workflows): add empty option for UTxO backend choice

### DIFF
--- a/.github/workflows/regression-dbsync.yaml
+++ b/.github/workflows/regression-dbsync.yaml
@@ -47,6 +47,7 @@ on:
         type: choice
         description: "UTxO backend"
         options:
+        - ""
         - mem
         - disk
         default: ""

--- a/.github/workflows/regression.yaml
+++ b/.github/workflows/regression.yaml
@@ -40,6 +40,7 @@ on:
         type: choice
         description: "UTxO backend"
         options:
+        - ""
         - mem
         - disk
         default: ""


### PR DESCRIPTION
Added an empty string option to the UTxO backend choice in both `regression-dbsync.yaml` and `regression.yaml` workflows. This ensures that users can explicitly select no backend if needed.