### PR TITLE
fix(tests): improve regex for tx-in error assertions

### DIFF
--- a/cardano_node_tests/tests/test_tx_negative.py
+++ b/cardano_node_tests/tests/test_tx_negative.py
@@ -1486,7 +1486,8 @@ class TestNegative:
                     *helpers.prepend_flag("--tx-out", txouts),
                 ]
             )
-        assert re.search(r"Missing: *\(--tx-in TX-IN", str(excinfo.value))
+        err_str = str(excinfo.value)
+        assert re.search(r"Missing: *\(--tx-in TX[_-]IN", err_str), err_str
 
     @allure.link(helpers.get_vcs_link())
     @pytest.mark.skipif(
@@ -1571,7 +1572,8 @@ class TestNegative:
                     *helpers.prepend_flag("--tx-out", txouts),
                 ]
             )
-        assert re.search(r"Missing: *\(--tx-in TX-IN", str(excinfo.value))
+        err_str = str(excinfo.value)
+        assert re.search(r"Missing: *\(--tx-in TX[_-]IN", err_str), err_str
 
     @allure.link(helpers.get_vcs_link())
     @common.SKIPIF_BUILD_UNUSABLE

--- a/cardano_node_tests/tests/tests_plutus_v2/test_spend_ref_inputs_build.py
+++ b/cardano_node_tests/tests/tests_plutus_v2/test_spend_ref_inputs_build.py
@@ -658,7 +658,7 @@ class TestNegativeReadonlyReferenceInputs:
     ):
         """Test using a read-only reference input without spending any UTxO.
 
-        Expect failure
+        Expect failure.
         """
         temp_template = common.get_test_id(cluster)
         reference_input_amount = 2_000_000
@@ -688,4 +688,4 @@ class TestNegativeReadonlyReferenceInputs:
                 ]
             )
         err_str = str(excinfo.value)
-        assert "Missing: (--tx-in TX-IN)" in err_str, err_str
+        assert re.search(r"Missing: *\(--tx-in TX[_-]IN", err_str), err_str

--- a/cardano_node_tests/tests/tests_plutus_v2/test_spend_ref_inputs_raw.py
+++ b/cardano_node_tests/tests/tests_plutus_v2/test_spend_ref_inputs_raw.py
@@ -521,7 +521,7 @@ class TestNegativeReadonlyReferenceInputs:
     ):
         """Test using a read-only reference input without spending any UTxO.
 
-        Expect failure
+        Expect failure.
         """
         temp_template = common.get_test_id(cluster)
         reference_input_amount = 2_000_000
@@ -551,4 +551,4 @@ class TestNegativeReadonlyReferenceInputs:
                 ]
             )
         err_str = str(excinfo.value)
-        assert "Missing: (--tx-in TX-IN)" in err_str, err_str
+        assert re.search(r"Missing: *\(--tx-in TX[_-]IN", err_str), err_str


### PR DESCRIPTION
Updated regex patterns in test assertions to handle variations in "TX-IN" formatting (e.g., "TX-IN" or "TX_IN"). This ensures better test compatibility between cardano-cli revisions.