### PR TITLE
chore(ci): remove redundant directory listing in script

### DIFF
--- a/.github/node_upgrade.sh
+++ b/.github/node_upgrade.sh
@@ -177,10 +177,6 @@ if [ -n "${GITHUB_ACTIONS:-""}" ]; then
 
   # compress scheduling log
   xz "$SCHEDULING_LOG"
-
-  echo
-  echo "Dir content:"
-  ls -1a
 fi
 
 exit "$retval"


### PR DESCRIPTION
The directory listing command was unnecessary and has been removed to streamline the script. This change reduces noise in the output and improves script clarity.