### PR TITLE
feat(cluster): enforce max tests per cluster instance

### DIFF
--- a/.github/regression.sh
+++ b/.github/regression.sh
@@ -70,6 +70,12 @@ elif [ "$TX_ERA" = "default" ]; then
   export TX_ERA=""
 fi
 
+# Decrease the number of tests per cluster if we are using the "disk" (LMDB) UTxO backend to avoid
+# having too many concurrent readers.
+if [ -z "${MAX_TESTS_PER_CLUSTER:-""}" ] && [ "${UTXO_BACKEND:-""}" = "disk" ]; then
+  export MAX_TESTS_PER_CLUSTER=5
+fi
+
 if [ -n "${BOOTSTRAP_DIR:-""}" ]; then
   :  # don't touch `SCRIPTS_DIRNAME` when running on testnet
 elif [ "${CI_BYRON_CLUSTER:-"false"}" != "false" ]; then

--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ Test execution can be configured using environment variables.
 * `PYTEST_ARGS` – specifies additional arguments for pytest (default: unset).
 * `MARKEXPR` – specifies marker expression for pytest (default: unset).
 * `TEST_THREADS` – specifies the number of pytest workers (default: 20).
+* `MAX_TESTS_PER_CLUSTER` - specifies the maximum number of tests that can be run on a single cluster instance (default: 8).
 * `CLUSTERS_COUNT` – number of cluster instances that will be started (default: 9).
 * `CLUSTER_ERA` – cluster era for Cardano node – used for selecting the correct cluster start script (default: conway).
 * `COMMAND_ERA` – era for cardano-cli commands – can be used for creating Shelley-era (Allegra-era, ...) transactions (default: unset).

--- a/cardano_node_tests/utils/configuration.py
+++ b/cardano_node_tests/utils/configuration.py
@@ -59,6 +59,7 @@ if COMMAND_ERA not in ("", "shelley", "allegra", "mary", "alonzo", "babbage", "c
 
 CLUSTERS_COUNT = int(os.environ.get("CLUSTERS_COUNT") or 0)
 WORKERS_COUNT = int(os.environ.get("PYTEST_XDIST_WORKER_COUNT") or 1)
+MAX_TESTS_PER_CLUSTER = int(os.environ.get("MAX_TESTS_PER_CLUSTER") or 8)
 CLUSTERS_COUNT = int(CLUSTERS_COUNT or (min(WORKERS_COUNT, 9)))
 
 DEV_CLUSTER_RUNNING = bool(os.environ.get("DEV_CLUSTER_RUNNING"))


### PR DESCRIPTION
- Added a check to ensure the number of running tests on a cluster instance does not exceed the configured maximum (`MAX_TESTS_PER_CLUSTER`).
- Introduced a new configuration variable `MAX_TESTS_PER_CLUSTER` with a default value of 10, which can be overridden via environment variables.
- Updated logic in `ClusterGetter` to handle cases where the limit is reached by introducing a delay and skipping further processing for the affected cluster instance.