### PR TITLE
feat(common): increase random string length in test ID

### DIFF
--- a/cardano_node_tests/tests/common.py
+++ b/cardano_node_tests/tests/common.py
@@ -171,7 +171,7 @@ def get_test_id(cluster_obj: clusterlib.ClusterLib) -> str:
     Log the test ID into cluster manager log file.
     """
     curr_test = pytest_utils.get_current_test()
-    rand_str = clusterlib.get_rand_str(3)
+    rand_str = clusterlib.get_rand_str(6)
     test_id = (
         f"{curr_test.test_function}{curr_test.test_params}_ci{cluster_obj.cluster_id}_{rand_str}"
     )


### PR DESCRIPTION
Updated the random string length from 3 to 6 characters in the `get_test_id` function to enhance uniqueness of generated test IDs. This change ensures better differentiation between test runs.