### PR TITLE
feat(configuration): add cluster info metadata

### DIFF
--- a/cardano_node_tests/tests/conftest.py
+++ b/cardano_node_tests/tests/conftest.py
@@ -102,6 +102,11 @@ def pytest_configure(config: tp.Any) -> None:
     config.stash[metadata_key]["MIXED_P2P"] = str(configuration.MIXED_P2P)
     config.stash[metadata_key]["NUM_POOLS"] = str(configuration.NUM_POOLS)
     config.stash[metadata_key]["UTXO_BACKEND"] = configuration.UTXO_BACKEND
+    config.stash[metadata_key]["MAX_TESTS_PER_CLUSTER"] = configuration.MAX_TESTS_PER_CLUSTER
+    # If not explicitly specified, the `CLUSTERS_COUNT` is calculated based on number of xdist
+    # workers, which is not known yet by the time this fixture runs.
+    if os.environ.get("CLUSTERS_COUNT") is not None:
+        config.stash[metadata_key]["CLUSTERS_COUNT"] = configuration.CLUSTERS_COUNT
     if configuration.CONFIRM_BLOCKS_NUM:
         config.stash[metadata_key]["CONFIRM_BLOCKS_NUM"] = str(configuration.CONFIRM_BLOCKS_NUM)
     config.stash[metadata_key]["HAS_CC"] = str(configuration.HAS_CC)

--- a/cardano_node_tests/utils/configuration.py
+++ b/cardano_node_tests/utils/configuration.py
@@ -57,10 +57,11 @@ if COMMAND_ERA not in ("", "shelley", "allegra", "mary", "alonzo", "babbage", "c
     msg = f"Invalid COMMAND_ERA: {COMMAND_ERA}"
     raise RuntimeError(msg)
 
-CLUSTERS_COUNT = int(os.environ.get("CLUSTERS_COUNT") or 0)
-WORKERS_COUNT = int(os.environ.get("PYTEST_XDIST_WORKER_COUNT") or 1)
+XDIST_WORKERS_COUNT = int(os.environ.get("PYTEST_XDIST_WORKER_COUNT") or 0)
 MAX_TESTS_PER_CLUSTER = int(os.environ.get("MAX_TESTS_PER_CLUSTER") or 8)
-CLUSTERS_COUNT = int(CLUSTERS_COUNT or (min(WORKERS_COUNT, 9)))
+# If CLUSTERS_COUNT is not set, use the number of xdist workers or 1
+CLUSTERS_COUNT = int(os.environ.get("CLUSTERS_COUNT") or 0)
+CLUSTERS_COUNT = int(CLUSTERS_COUNT or (min(XDIST_WORKERS_COUNT, 9)) or 1)
 
 DEV_CLUSTER_RUNNING = bool(os.environ.get("DEV_CLUSTER_RUNNING"))
 FORBID_RESTART = bool(os.environ.get("FORBID_RESTART"))


### PR DESCRIPTION
Add `CLUSTERS_COUNT` and `MAX_TESTS_PER_CLUSTER` to pytest configuration stash for better test metadata tracking.