### PR TITLE
refactor(tests): replace pytest.fail with pytest.xfail

### DIFF
--- a/cardano_node_tests/tests/test_governance.py
+++ b/cardano_node_tests/tests/test_governance.py
@@ -36,7 +36,7 @@ class TestPoll:
     @pytest.fixture(scope="class")
     def governance_poll_available(self) -> None:
         if not clusterlib_utils.cli_has("compatible babbage governance create-poll"):
-            pytest.fail(
+            pytest.xfail(
                 "The `cardano-cli compatible babbage governance` poll commands are not available."
             )
 


### PR DESCRIPTION
Updated the `governance_poll_available` fixture to use `pytest.xfail` instead of `pytest.fail` for better handling of unavailable poll commands. This ensures tests are marked as expected failures rather than hard failures.