### PR TITLE
fix(pools): use get_pool_state instead of get_pool_params

### DIFF
--- a/cardano_node_tests/tests/test_pools.py
+++ b/cardano_node_tests/tests/test_pools.py
@@ -761,7 +761,7 @@ class TestStakePool:
         # and will insert an error on the specific table
         # https://github.com/IntersectMBO/cardano-db-sync/blob/master/doc/pool-offchain-data.md
         if configuration.HAS_DBSYNC:
-            pool_params = cluster.g_query.get_pool_params(
+            pool_params = cluster.g_query.get_pool_state(
                 stake_pool_id=pool_creation_out.stake_pool_id
             ).pool_params
 


### PR DESCRIPTION
Replace deprecated usage of `get_pool_params` with `get_pool_state`.