### PR TITLE
chore(ci): add script setup group to Nix smoke workflow

### DIFF
--- a/.github/workflows/nix_smoke.yaml
+++ b/.github/workflows/nix_smoke.yaml
@@ -25,4 +25,8 @@ jobs:
             substituters = https://cache.nixos.org https://cache.iog.io https://iohk.cachix.org
             allow-import-from-derivation = true
       - name: Run pytest in Nix
-        run: TEST_THREADS=0 PYTEST_ARGS="-k test_cli.py --skipall" ./.github/regression.sh
+        run: |
+          # env
+          echo "::group::Script setup"
+          TEST_THREADS=0 PYTEST_ARGS="-k test_cli.py --skipall" ./.github/regression.sh
+          echo "::endgroup::"


### PR DESCRIPTION
Wrap the regression script execution in a GitHub Actions group for improved log readability. This helps to visually separate the setup and execution steps in the workflow output, making debugging and review easier.