### PR TITLE
fix(ci): handle missing report files in results script

### DIFF
--- a/.github/create_results.sh
+++ b/.github/create_results.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 
 tests_repo="$(readlink -m "${0%/*}/..")"
 reports_dir="$tests_repo/.reports"
-if [ "$(echo "$reports_dir"/*)" = "$reports_dir/*" ]; then
+if [ "$(echo "$reports_dir"/*.json)" = "$reports_dir/*.json" ]; then
   echo "No reports found in $reports_dir" >&2
   exit 1
 fi
@@ -14,7 +14,9 @@ allure_results_dir="$tests_repo/allure-results"
 
 rm -rf "${allure_results_dir:?}"
 mkdir -p "$allure_results_dir"
-mv "$reports_dir"/{*.json,*.txt,*.properties} "$allure_results_dir"
+mv "$reports_dir"/*.json "$allure_results_dir"
+mv "$reports_dir"/*.txt "$allure_results_dir" 2>/dev/null || :
+mv "$reports_dir"/*.properties "$allure_results_dir" 2>/dev/null || :
 
 echo "Creating results archive $results_tar"
 rm -f "$results_tar"


### PR DESCRIPTION
Update `.github/create_results.sh` to correctly check for the presence of JSON report files before proceeding. Separate `mv` commands for `.json`, `.txt`, and `.properties` files now handle missing files gracefully by redirecting errors to `/dev/null`. This prevents script failures when some optional report file types are absent.