### PR TITLE
fix(issue): check issue for build-estimate failure with no txouts

### DIFF
--- a/cardano_node_tests/tests/issues.py
+++ b/cardano_node_tests/tests/issues.py
@@ -109,6 +109,12 @@ cli_1023 = blockers.GH(
     fixed_in="10.3.0.1",  # Fixed in release following 10.3.0.0
     message="Plutus cost too low.",
 )
+cli_1199 = blockers.GH(
+    issue=1199,
+    repo="IntersectMBO/cardano-cli",
+    fixed_in="10.10.0.1",  # Fixed in release after 10.10.0.0
+    message="`build-estimate` fails to balance tx with no txouts.",
+)
 
 consensus_973 = blockers.GH(
     issue=973,

--- a/cardano_node_tests/tests/test_tx_basic.py
+++ b/cardano_node_tests/tests/test_tx_basic.py
@@ -494,12 +494,18 @@ class TestBasicTransactions:
         txouts = [clusterlib.TxOut(address=dst_address, amount=-1)]
         tx_files = clusterlib.TxFiles(signing_key_files=[payment_addrs_disposable[1].skey_file])
 
-        tx_raw_output = cluster.g_transaction.build_estimate_tx(
-            src_address=src_address,
-            tx_name=temp_template,
-            txouts=txouts,
-            tx_files=tx_files,
-        )
+        try:
+            tx_raw_output = cluster.g_transaction.build_estimate_tx(
+                src_address=src_address,
+                tx_name=temp_template,
+                txouts=txouts,
+                tx_files=tx_files,
+            )
+        except clusterlib.CLIError as exc:
+            if "balance of the transaction is negative" not in str(exc):
+                raise
+            issues.cli_1199.finish_test()
+
         out_file_signed = cluster.g_transaction.sign_tx(
             tx_body_file=tx_raw_output.out_file,
             signing_key_files=tx_files.signing_key_files,


### PR DESCRIPTION
Add handling for CLI error when `build-estimate` fails to balance a transaction with no txouts, referencing issue IntersectMBO/cardano-cli#1199.