### PR TITLE
feat(tests): skip tests with legacy commands if CLI lacks support

### DIFF
--- a/cardano_node_tests/tests/tests_conway/test_pparam_update.py
+++ b/cardano_node_tests/tests/tests_conway/test_pparam_update.py
@@ -1406,11 +1406,17 @@ class TestPParamData:
 class TestLegacyProposals:
     """Tests for legacy update proposals in Conway."""
 
+    @pytest.fixture(scope="class")
+    def skip_on_missing_legacy(self) -> None:
+        if not clusterlib_utils.cli_has("legacy governance"):
+            pytest.skip("`legacy governance` commands are not available")
+
     @allure.link(helpers.get_vcs_link())
     @submit_utils.PARAM_SUBMIT_METHOD
     @pytest.mark.smoke
     def test_legacy_proposal_submit(
         self,
+        skip_on_missing_legacy: None,  # noqa: ARG002
         cluster: clusterlib.ClusterLib,
         payment_addr: clusterlib.AddressRecord,
         submit_method: str,
@@ -1419,6 +1425,8 @@ class TestLegacyProposals:
 
         Expect failure as the legacy update proposals are not supported in Conway.
         """
+        # TODO: convert to use
+        # `compatible babbage governance action create-protocol-parameters-update`
         temp_template = common.get_test_id(cluster)
 
         update_proposals = [

--- a/cardano_node_tests/tests/tests_conway/test_treasury_withdrawals.py
+++ b/cardano_node_tests/tests/tests_conway/test_treasury_withdrawals.py
@@ -719,9 +719,15 @@ class TestTreasuryWithdrawals:
 class TestMIRCerts:
     """Tests for MIR certificates."""
 
+    @pytest.fixture(scope="class")
+    def skip_on_missing_legacy(self) -> None:
+        if not clusterlib_utils.cli_has("legacy governance"):
+            pytest.skip("`legacy governance` commands are not available")
+
     @pytest.fixture
     def payment_addr(
         self,
+        skip_on_missing_legacy: None,  # noqa: ARG002
         cluster_manager: cluster_management.ClusterManager,
         cluster: clusterlib.ClusterLib,
     ) -> clusterlib.AddressRecord:
@@ -742,6 +748,7 @@ class TestMIRCerts:
     @pytest.mark.smoke
     def test_mir_certificates(
         self,
+        skip_on_missing_legacy: None,  # noqa: ARG002
         cluster: clusterlib.ClusterLib,
         payment_addr: clusterlib.AddressRecord,
         mir_cert: str,
@@ -754,6 +761,7 @@ class TestMIRCerts:
         * successfully build the Tx as Babbage Tx using `transaction build-raw`
         * try and fail to submit the Babbage Tx
         """
+        # TODO: convert to use `compatible babbage governance create-mir-certificate`
         temp_template = common.get_test_id(cluster)
         amount = 1_500_000
 


### PR DESCRIPTION
Add class-scoped pytest fixtures to skip tests that depend on legacy governance commands when the CLI does not support them. This prevents test failures in environments where legacy commands are unavailable.