### PR TITLE
chore(ci): update cardano-node to 10.4.1 in nightly upgrade

### DIFF
--- a/.github/env_nightly_upgrade
+++ b/.github/env_nightly_upgrade
@@ -1,2 +1,2 @@
-BASE_TAR_URL=https://github.com/IntersectMBO/cardano-node/releases/download/10.3.1/cardano-node-10.3.1-linux.tar.gz
+BASE_TAR_URL=https://github.com/IntersectMBO/cardano-node/releases/download/10.4.1/cardano-node-10.4.1-linux.tar.gz
 CI_BYRON_CLUSTER=true


### PR DESCRIPTION
Bump the BASE_TAR_URL in .github/env_nightly_upgrade to use the cardano-node 10.4.1 release instead of 10.3.1. This ensures nightly upgrade workflows test against the latest mainnet node release.