### PR TITLE
fix(log): ignore serialization format error globally

### DIFF
--- a/cardano_node_tests/tests/test_node_upgrade.py
+++ b/cardano_node_tests/tests/test_node_upgrade.py
@@ -93,13 +93,6 @@ class TestSetup:
         """Ignore selected errors in log right after node upgrade."""
         common.get_test_id(cluster_singleton)
 
-        logfiles.add_ignore_rule(
-            files_glob="*.stdout",
-            regex="ChainDB:Error:.* Invalid snapshot DiskSnapshot .*DeserialiseFailure "
-            ".* expected change in the serialization format",
-            ignore_file_id=worker_id,
-        )
-
         # The error should be present only when upgrading pre UTxO-HD release.
         # The UTxO-HD was added in 10.4.1, so when we are upgrading from 10.4.1+ release to
         # 10.5.0+ release, the error should not be there.

--- a/cardano_node_tests/utils/logfiles.py
+++ b/cardano_node_tests/utils/logfiles.py
@@ -59,6 +59,7 @@ ERRORS_IGNORED = [
     "DiffusionError thread killed",
     # TODO: connection to other node before the other node is started
     r"AcquireConnectionError Network\.Socket\.connect",
+    "expected change in the serialization format",
 ]
 # Already removed from the list above:
 # * Workaround for node issue https://github.com/IntersectMBO/cardano-node/issues/4369


### PR DESCRIPTION
Move the "expected change in the serialization format" error from a test-specific ignore rule to the global ERRORS_IGNORED list in logfiles.py. This ensures the error is ignored consistently across all tests, simplifying maintenance and reducing duplication.