### PR TITLE
chore(lint): enforce type annotations using ruff instead of in mypy

### DIFF
--- a/cardano_node_tests/cluster_management/resources_management.py
+++ b/cardano_node_tests/cluster_management/resources_management.py
@@ -7,7 +7,7 @@ import typing as tp
 class BaseFilter:
     """Base class for resource filters."""
 
-    def __init__(self, resources: tp.Iterable[str]):
+    def __init__(self, resources: tp.Iterable[str]) -> None:
         assert not isinstance(resources, str), "`resources` can't be single string"
         self.resources = resources
 

--- a/cardano_node_tests/utils/custom_clusterlib.py
+++ b/cardano_node_tests/utils/custom_clusterlib.py
@@ -66,7 +66,7 @@ class ClusterLib(clusterlib.ClusterLib):
         slots_offset: int | None = None,
         socket_path: clusterlib.FileType = "",
         command_era: str = consts.CommandEras.LATEST,
-    ):
+    ) -> None:
         super().__init__(
             state_dir=state_dir,
             slots_offset=slots_offset,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,11 +84,14 @@ line-length = 100
 line-length = 100
 
 [tool.ruff.lint]
-select = ["ARG", "B", "C4", "C90", "D", "DTZ", "E", "EM", "F", "FURB", "I001", "ISC", "N", "PERF", "PIE", "PL", "PLE", "PLR", "PLW", "PT", "PTH", "Q", "RET", "RSE", "RUF", "SIM", "TRY", "UP", "W", "YTT"]
-ignore = ["B905", "D10", "D203", "D212", "D213", "D214", "D215", "D404", "D405", "D406", "D407", "D408", "D409", "D410", "D411", "D413", "ISC001", "PLR0912", "PLR0913", "PLR0915", "PLR2004", "PT001", "PT007", "PT012", "PT018", "PT023", "PTH123", "RET504", "TRY002", "TRY301", "UP006", "UP007", "UP035"]
+select = ["ANN", "ARG", "B", "C4", "C90", "D", "DTZ", "E", "EM", "F", "FURB", "I001", "ISC", "N", "PERF", "PIE", "PL", "PLE", "PLR", "PLW", "PT", "PTH", "Q", "RET", "RSE", "RUF", "SIM", "TRY", "UP", "W", "YTT"]
+ignore = ["ANN401", "B905", "D10", "D203", "D212", "D213", "D214", "D215", "D404", "D405", "D406", "D407", "D408", "D409", "D410", "D411", "D413", "ISC001", "PLR0912", "PLR0913", "PLR0915", "PLR2004", "PT001", "PT007", "PT012", "PT018", "PT023", "PTH123", "RET504", "TRY002", "TRY301", "UP006", "UP007", "UP035"]
 
 [tool.ruff.lint.per-file-ignores]
 "cardano_node_tests/utils/model_ekg.py" = ["N815"]
+"cardano_node_tests/tests/**.py" = ["ANN"]
+"framework_tests/**.py" = ["ANN"]
+"src_docs/**.py" = ["ANN"]
 
 [tool.ruff.lint.isort]
 force-single-line = true
@@ -105,21 +108,8 @@ ignore_missing_imports = true
 follow_imports = "normal"
 no_implicit_optional = true
 allow_untyped_globals = false
-allow_untyped_defs = false
 warn_unused_configs = true
 warn_return_any = true
-
-[[tool.mypy.overrides]]
-module = "cardano_node_tests.tests.*"
-allow_untyped_defs = true
-
-[[tool.mypy.overrides]]
-module = "cardano_node_tests.*.conftest"
-allow_untyped_defs = false
-
-[[tool.mypy.overrides]]
-module = "framework_tests.*"
-allow_untyped_defs = true
 
 [tool.pytest.ini_options]
 log_cli = true


### PR DESCRIPTION
- Add "ANN" (type annotation) checks to ruff linting, except for test, framework, and docs files.
- Ignore ANN401 for ruff to allow untyped self/cls.
- Remove mypy per-file overrides for untyped defs in tests and framework.
- Add explicit return types to __init__ methods in resource and clusterlib.