### PR TITLE
refactor(cluster): rename supervisord_stop to stop-cluster

### DIFF
--- a/.github/node_upgrade_pytest.sh
+++ b/.github/node_upgrade_pytest.sh
@@ -199,7 +199,7 @@ elif [ "$1" = "step2" ]; then
   # It is necessary to restart supervisord with new environment.
   "$STATE_CLUSTER/supervisorctl" stop all
   sleep 5
-  "$STATE_CLUSTER/supervisord_stop"
+  "$STATE_CLUSTER/stop-cluster"
   sleep 3
   "$STATE_CLUSTER/supervisord_start" || exit 6
   sleep 5

--- a/.github/stop_cluster_instances.sh
+++ b/.github/stop_cluster_instances.sh
@@ -6,6 +6,6 @@ stop_instances() {
   local workdir="${1:?}"
   for sc in "$workdir"/state-cluster*; do
     [ -d "$sc" ] || continue
-    "$sc/supervisord_stop" 2>/dev/null || :
+    "$sc/stop-cluster" 2>/dev/null || :
   done
 }

--- a/cardano_node_tests/cluster_scripts/common/start-cluster-fast
+++ b/cardano_node_tests/cluster_scripts/common/start-cluster-fast
@@ -55,7 +55,7 @@ DELEG_SUPPLY="$((POOL_PLEDGE * NUM_POOLS + DELEG_MAGIC_VALUE))"
 NONDELEG_SUPPLY="$(( (MAX_SUPPLY - DELEG_SUPPLY) * 8 / 10))"
 
 if [ -f "${STATE_CLUSTER}/supervisord.pid" ]; then
-  echo "Cluster already running. Please run \`${SCRIPT_DIR}/stop-cluster\` first!" >&2
+  echo "Cluster already running. Please run \`${STATE_CLUSTER}/stop-cluster\` first!" >&2
   exit 1
 fi
 
@@ -534,7 +534,7 @@ cd "\${SCRIPT_DIR}/.."
 supervisord --config "\${SCRIPT_DIR}/supervisor.conf"
 EoF
 
-cat > "${STATE_CLUSTER}/supervisord_stop" <<EoF
+cat > "${STATE_CLUSTER}/stop-cluster" <<EoF
 #!/usr/bin/env bash
 
 set -uo pipefail
@@ -567,7 +567,7 @@ rm -f "\$PID_FILE"
 echo "Cluster terminated!"
 EoF
 
-chmod u+x "$STATE_CLUSTER"/{supervisorctl*,supervisord_*}
+chmod u+x "$STATE_CLUSTER"/{supervisorctl*,supervisord_*,stop-cluster}
 
 if [ -n "${DRY_RUN:-""}" ]; then
   echo "Dry run, not starting cluster"

--- a/cardano_node_tests/cluster_scripts/conway_slow/start-cluster
+++ b/cardano_node_tests/cluster_scripts/conway_slow/start-cluster
@@ -49,7 +49,7 @@ if [ "$POOL_COST" -eq 0 ]; then
 fi
 
 if [ -f "${STATE_CLUSTER}/supervisord.pid" ]; then
-  echo "Cluster already running. Please run \`${SCRIPT_DIR}/stop-cluster\` first!" >&2
+  echo "Cluster already running. Please run \`${STATE_CLUSTER}/stop-cluster\` first!" >&2
   exit 1
 fi
 
@@ -612,7 +612,7 @@ cd "\${SCRIPT_DIR}/.."
 supervisord --config "\${SCRIPT_DIR}/supervisor.conf"
 EoF
 
-cat > "${STATE_CLUSTER}/supervisord_stop" <<EoF
+cat > "${STATE_CLUSTER}/stop-cluster" <<EoF
 #!/usr/bin/env bash
 
 set -uo pipefail
@@ -645,7 +645,7 @@ rm -f "\$PID_FILE"
 echo "Cluster terminated!"
 EoF
 
-chmod u+x "$STATE_CLUSTER"/{supervisorctl*,supervisord_*}
+chmod u+x "$STATE_CLUSTER"/{supervisorctl*,supervisord_*,stop-cluster}
 
 if [ -n "${DRY_RUN:-""}" ]; then
   echo "Dry run, not starting cluster"

--- a/cardano_node_tests/cluster_scripts/testnets/start-cluster
+++ b/cardano_node_tests/cluster_scripts/testnets/start-cluster
@@ -18,7 +18,7 @@ if [[ "$SOCKET_PATH" != *"/state-cluster${INSTANCE_NUM}/"* ]]; then
 fi
 
 if [ -f "$STATE_CLUSTER/supervisord.pid" ]; then
-  echo "Cluster already running. Please run \`$SCRIPT_DIR/stop-cluster\` first!" >&2
+  echo "Cluster already running. Please run \`${STATE_CLUSTER}/stop-cluster\` first!" >&2
   exit 1
 fi
 
@@ -134,7 +134,7 @@ cd "\$SCRIPT_DIR/.."
 supervisord --config "\$SCRIPT_DIR/supervisor.conf"
 EoF
 
-cat > "$STATE_CLUSTER/supervisord_stop" <<EoF
+cat > "$STATE_CLUSTER/stop-cluster" <<EoF
 #!/usr/bin/env bash
 
 set -uo pipefail
@@ -167,7 +167,7 @@ rm -f "\$PID_FILE"
 echo "Cluster terminated!"
 EoF
 
-chmod u+x "$STATE_CLUSTER"/{supervisorctl*,supervisord_*}
+chmod u+x "$STATE_CLUSTER"/{supervisorctl*,supervisord_*,stop-cluster}
 
 # copy db
 cp -r "$TESTNET_DIR/relay1-db" "$STATE_CLUSTER/db-relay1"
@@ -228,4 +228,4 @@ faucet_init_balance="$(get_address_balance \
   --address "$(<"$STATE_CLUSTER/shelley/faucet.addr")")"
 echo "Faucet initial balance: $faucet_init_balance" >> "$START_CLUSTER_LOG"
 
-echo "Cluster started. Run \`$SCRIPT_DIR/stop-cluster\` to stop"
+echo "Cluster started"

--- a/cardano_node_tests/utils/cluster_scripts.py
+++ b/cardano_node_tests/utils/cluster_scripts.py
@@ -1,6 +1,6 @@
 """Functionality for cluster scripts (starting and stopping clusters).
 
-* copying scripts and their configuration, so it can be atered by tests
+* copying scripts and their configuration, so it can be altered by tests
 * setup of scripts and their configuration for starting of multiple cluster instances
 """
 
@@ -18,7 +18,7 @@ from cardano_node_tests.utils import configuration
 from cardano_node_tests.utils import helpers
 
 LOCAL_HOSTNAME = "node.local.gd"
-STOP_SCRIPT = "supervisord_stop"
+STOP_SCRIPT = "stop-cluster"
 
 
 @dataclasses.dataclass(frozen=True, order=True)

--- a/scripts/restart_dev_cluster.sh
+++ b/scripts/restart_dev_cluster.sh
@@ -11,13 +11,13 @@ if [ -z "${DEV_CLUSTER_RUNNING:-}" ]; then
   exit 1
 fi
 
-# check if "supervisord_stop" file exists in STATE_CLUSTER dir
-if [ ! -f "${STATE_CLUSTER}/supervisord_stop" ]; then
-  echo "Cannot find '${STATE_CLUSTER}/supervisord_stop', exiting."
+# check if "stop-cluster" file exists in STATE_CLUSTER dir
+if [ ! -f "${STATE_CLUSTER}/stop-cluster" ]; then
+  echo "Cannot find '${STATE_CLUSTER}/stop-cluster', exiting."
   exit 1
 fi
 
-"$STATE_CLUSTER/supervisord_stop"
+"$STATE_CLUSTER/stop-cluster"
 sleep 2
 
 "$STATE_CLUSTER/supervisord_start"


### PR DESCRIPTION
Renamed the cluster stop script from `supervisord_stop` to `stop-cluster` across all relevant scripts and references. This improves naming clarity and consistency with other cluster management scripts. Updated all usages, checks, and permissions to use the new script name. No functional changes to cluster start/stop logic.