### PR TITLE
feat(cluster): add testnet.json metadata and status file

### DIFF
--- a/cardano_node_tests/cluster_scripts/common/start-cluster-fast
+++ b/cardano_node_tests/cluster_scripts/common/start-cluster-fast
@@ -1,15 +1,5 @@
 #!/usr/bin/env bash
 
-# controlling environment variables:
-# DBSYNC_REPO - will start and configure db-sync if the value is path to db-sync repository
-# SMASH - if set, will start and configure smash
-# ENABLE_LEGACY - if set, local cluster will use legacy networking
-# MIXED_P2P - if set, local cluster will use P2P for some nodes and legacy topology for others
-# UTXO_BACKEND - 'mem' or 'disk', default is 'mem' (or legacy) if unset
-# NO_CC - if set, will not create committee
-# PV9 - if set, will use protocol version 9
-# DRY_RUN - if set, will not start the cluster
-
 set -Eeuo pipefail
 trap 'echo "Error at line $LINENO"' ERR
 
@@ -19,6 +9,7 @@ STATE_CLUSTER="${SOCKET_PATH%/*}"
 STATE_CLUSTER_NAME="${STATE_CLUSTER##*/}"
 SUPERVISORD_SOCKET_PATH="${STATE_CLUSTER}/supervisord.sock"
 START_CLUSTER_LOG="${STATE_CLUSTER}/start-cluster.log"
+START_CLUSTER_STATUS="${STATE_CLUSTER}/status_started"
 
 INSTANCE_NUM="%%INSTANCE_NUM%%"
 if [[ "$SOCKET_PATH" != *"/state-cluster${INSTANCE_NUM}/"* ]]; then
@@ -54,7 +45,7 @@ DELEG_MAGIC_VALUE=3340000000000000
 DELEG_SUPPLY="$((POOL_PLEDGE * NUM_POOLS + DELEG_MAGIC_VALUE))"
 NONDELEG_SUPPLY="$(( (MAX_SUPPLY - DELEG_SUPPLY) * 8 / 10))"
 
-if [ -f "${STATE_CLUSTER}/supervisord.pid" ]; then
+if [ -e "$SUPERVISORD_SOCKET_PATH" ]; then
   echo "Cluster already running. Please run \`${STATE_CLUSTER}/stop-cluster\` first!" >&2
   exit 1
 fi
@@ -83,6 +74,7 @@ cp "${SCRIPT_DIR}/byron-params.json" "$STATE_CLUSTER"
 cp "${SCRIPT_DIR}/dbsync-config.yaml" "$STATE_CLUSTER"
 cp "${SCRIPT_DIR}/submit-api-config.json" "$STATE_CLUSTER"
 cp "${SCRIPT_DIR}/supervisor.conf" "$STATE_CLUSTER"
+cp "$SCRIPT_DIR/testnet.json" "$STATE_CLUSTER"
 cp "$SCRIPT_DIR"/*genesis*.spec.json "${STATE_CLUSTER}/create_staked/"
 
 if [ -n "${PV9:-""}" ]; then
@@ -716,4 +708,5 @@ if ! check_spend_success "${TXINS[@]}"; then
   exit 1
 fi
 
-echo "Cluster started"
+: > "$START_CLUSTER_STATUS"
+echo "Cluster started 🚀"

--- a/cardano_node_tests/cluster_scripts/conway_fast/testnet.json
+++ b/cardano_node_tests/cluster_scripts/conway_fast/testnet.json
@@ -1,0 +1,14 @@
+{
+    "name": "conway_fast",
+    "description": "Local testnet that starts directly in Conway era.",
+    "control_env": {
+        "DBSYNC_REPO": "will start and configure db-sync if the value is path to db-sync repository",
+        "SMASH": "if set, will start and configure smash",
+        "ENABLE_LEGACY": "if set, local cluster will use legacy networking",
+        "MIXED_P2P": "if set, local cluster will use P2P for some nodes and legacy topology for others",
+        "UTXO_BACKEND": "'mem' or 'disk', default is 'mem' (or legacy) if unset",
+        "NO_CC": "if set, will not create committee",
+        "PV9": "if set, will use protocol version 9",
+        "DRY_RUN": "if set, will not start the cluster"
+    }
+}

--- a/cardano_node_tests/cluster_scripts/conway_slow/start-cluster
+++ b/cardano_node_tests/cluster_scripts/conway_slow/start-cluster
@@ -1,15 +1,5 @@
 #!/usr/bin/env bash
 
-# controlling environment variables:
-# DBSYNC_REPO - will start and configure db-sync if the value is path to db-sync repository
-# SMASH - if set, will start and configure smash
-# ENABLE_LEGACY - if set, local cluster will use legacy networking
-# MIXED_P2P - if set, local cluster will use P2P for some nodes and legacy topology for others
-# UTXO_BACKEND - 'mem' or 'disk', default is 'mem' (or legacy) if unset
-# NO_CC - if set, will not create committee
-# PV9 - if set, will use protocol version 9
-# DRY_RUN - if set, will not start the cluster
-
 set -Eeuo pipefail
 trap 'echo "Error at line $LINENO"' ERR
 
@@ -18,7 +8,9 @@ SOCKET_PATH="$(readlink -m "$CARDANO_NODE_SOCKET_PATH")"
 STATE_CLUSTER="${SOCKET_PATH%/*}"
 STATE_CLUSTER_NAME="${STATE_CLUSTER##*/}"
 SUPERVISORD_SOCKET_PATH="${STATE_CLUSTER}/supervisord.sock"
+# shellcheck disable=SC2034
 START_CLUSTER_LOG="${STATE_CLUSTER}/start-cluster.log"
+START_CLUSTER_STATUS="${STATE_CLUSTER}/status_started"
 
 INSTANCE_NUM="%%INSTANCE_NUM%%"
 if [[ "$SOCKET_PATH" != *"/state-cluster${INSTANCE_NUM}/"* ]]; then
@@ -41,14 +33,16 @@ FEE=5000000
 SECURITY_PARAM="$(jq '.securityParam' < "${SCRIPT_DIR}/genesis.spec.json")"
 NETWORK_MAGIC="$(jq '.networkMagic' < "${SCRIPT_DIR}/genesis.spec.json")"
 MAX_SUPPLY="$(jq '.maxLovelaceSupply' < "${SCRIPT_DIR}/genesis.spec.json")"
+# shellcheck disable=SC2034
 SLOT_LENGTH="$(jq '.slotLength' < "${SCRIPT_DIR}/genesis.spec.json")"
+# shellcheck disable=SC2034
 EPOCH_SEC="$(jq '.epochLength * .slotLength | ceil' < "${SCRIPT_DIR}/genesis.spec.json")"
 POOL_COST="$(jq '.protocolParams.minPoolCost' < "${SCRIPT_DIR}/genesis.spec.json")"
 if [ "$POOL_COST" -eq 0 ]; then
   POOL_COST=600
 fi
 
-if [ -f "${STATE_CLUSTER}/supervisord.pid" ]; then
+if [ -e "$SUPERVISORD_SOCKET_PATH" ]; then
   echo "Cluster already running. Please run \`${STATE_CLUSTER}/stop-cluster\` first!" >&2
   exit 1
 fi
@@ -78,6 +72,7 @@ cp "${SCRIPT_DIR}/byron-params.json" "$STATE_CLUSTER"
 cp "${SCRIPT_DIR}/dbsync-config.yaml" "$STATE_CLUSTER"
 cp "${SCRIPT_DIR}/submit-api-config.json" "$STATE_CLUSTER"
 cp "${SCRIPT_DIR}/supervisor.conf" "$STATE_CLUSTER"
+cp "$SCRIPT_DIR/testnet.json" "$STATE_CLUSTER"
 cp "$SCRIPT_DIR"/*genesis*.spec.json "${STATE_CLUSTER}/shelley/"
 
 if [ -n "${PV9:-""}" ]; then
@@ -1428,4 +1423,5 @@ if [ -z "${PV9:-""}" ]; then
   [ "$PROTOCOL_VERSION" = 10 ] || { echo "Unexpected protocol version '$PROTOCOL_VERSION' on line $LINENO" >&2; exit 1; }  # assert
 fi
 
-echo "Cluster started"
+: > "$START_CLUSTER_STATUS"
+echo "Cluster started 🚀"

--- a/cardano_node_tests/cluster_scripts/conway_slow/testnet.json
+++ b/cardano_node_tests/cluster_scripts/conway_slow/testnet.json
@@ -1,0 +1,14 @@
+{
+    "name": "conway_slow",
+    "description": "Local testnet that starts in Byron era and hard-forks through all the protocol versions until it gets to Conway.",
+    "control_env": {
+        "DBSYNC_REPO": "will start and configure db-sync if the value is path to db-sync repository",
+        "SMASH": "if set, will start and configure smash",
+        "ENABLE_LEGACY": "if set, local cluster will use legacy networking",
+        "MIXED_P2P": "if set, local cluster will use P2P for some nodes and legacy topology for others",
+        "UTXO_BACKEND": "'mem' or 'disk', default is 'mem' (or legacy) if unset",
+        "NO_CC": "if set, will not create committee",
+        "PV9": "if set, will use protocol version 9",
+        "DRY_RUN": "if set, will not start the cluster"
+    }
+}

--- a/cardano_node_tests/cluster_scripts/mainnet_fast/testnet.json
+++ b/cardano_node_tests/cluster_scripts/mainnet_fast/testnet.json
@@ -1,0 +1,14 @@
+{
+    "name": "mainnet_fast",
+    "description": "Local testnet that starts directly in Conway era and has the same epoch length as Mainnet.",
+    "control_env": {
+        "DBSYNC_REPO": "will start and configure db-sync if the value is path to db-sync repository",
+        "SMASH": "if set, will start and configure smash",
+        "ENABLE_LEGACY": "if set, local cluster will use legacy networking",
+        "MIXED_P2P": "if set, local cluster will use P2P for some nodes and legacy topology for others",
+        "UTXO_BACKEND": "'mem' or 'disk', default is 'mem' (or legacy) if unset",
+        "NO_CC": "if set, will not create committee",
+        "PV9": "if set, will use protocol version 9",
+        "DRY_RUN": "if set, will not start the cluster"
+    }
+}

--- a/cardano_node_tests/cluster_scripts/testnets/start-cluster
+++ b/cardano_node_tests/cluster_scripts/testnets/start-cluster
@@ -10,6 +10,7 @@ STATE_CLUSTER="${SOCKET_PATH%/*}"
 STATE_CLUSTER_NAME="${STATE_CLUSTER##*/}"
 SUPERVISORD_SOCKET_PATH="${STATE_CLUSTER}/supervisord.sock"
 START_CLUSTER_LOG="${STATE_CLUSTER}/start-cluster.log"
+START_CLUSTER_STATUS="${STATE_CLUSTER}/status_started"
 
 INSTANCE_NUM="%%INSTANCE_NUM%%"
 if [[ "$SOCKET_PATH" != *"/state-cluster${INSTANCE_NUM}/"* ]]; then
@@ -17,7 +18,7 @@ if [[ "$SOCKET_PATH" != *"/state-cluster${INSTANCE_NUM}/"* ]]; then
   exit 1
 fi
 
-if [ -f "$STATE_CLUSTER/supervisord.pid" ]; then
+if [ -e "$SUPERVISORD_SOCKET_PATH" ]; then
   echo "Cluster already running. Please run \`${STATE_CLUSTER}/stop-cluster\` first!" >&2
   exit 1
 fi
@@ -52,6 +53,7 @@ cp "$TESTNET_DIR"/shelley/faucet.* "$STATE_CLUSTER/shelley"
 cp "$SCRIPT_DIR"/cardano-node-* "$STATE_CLUSTER"
 cp "$SCRIPT_DIR/run-cardano-submit-api" "$STATE_CLUSTER"
 cp "$SCRIPT_DIR/supervisor.conf" "$STATE_CLUSTER"
+cp "$SCRIPT_DIR/testnet.json" "$STATE_CLUSTER"
 cp "$TESTNET_CONF_DIR/topology-relay1.json" "$STATE_CLUSTER"
 cp "$TESTNET_CONF_DIR"/genesis-*.json "$STATE_CLUSTER"
 ln -rs "$STATE_CLUSTER/genesis-byron.json" "$STATE_CLUSTER/byron/genesis.json"
@@ -228,4 +230,5 @@ faucet_init_balance="$(get_address_balance \
   --address "$(<"$STATE_CLUSTER/shelley/faucet.addr")")"
 echo "Faucet initial balance: $faucet_init_balance" >> "$START_CLUSTER_LOG"
 
-echo "Cluster started"
+: > "$START_CLUSTER_STATUS"
+echo "Cluster started 🚀"

--- a/cardano_node_tests/cluster_scripts/testnets/testnet.json
+++ b/cardano_node_tests/cluster_scripts/testnets/testnet.json
@@ -1,0 +1,7 @@
+{
+    "name": "testnets",
+    "description": "Setup for long-running testnets like Preview.",
+    "control_env": {
+        "DBSYNC_REPO": "will start and configure db-sync if the value is path to db-sync repository"
+    }
+}


### PR DESCRIPTION
Add `testnet.json` metadata files to each cluster script directory to describe the testnet setup and supported environment variables. Update cluster startup scripts to copy `testnet.json` to the state directory and create a `status_started` file as a marker when the cluster starts. Replace legacy PID file checks with socket existence checks for improved robustness. Also, update cluster start messages with a rocket emoji for clarity.