### PR TITLE
refactor(cluster): create governance_data dir together

### DIFF
--- a/cardano_node_tests/cluster_scripts/common/start-cluster-fast
+++ b/cardano_node_tests/cluster_scripts/common/start-cluster-fast
@@ -65,7 +65,7 @@ if [ -e "${SCRIPT_DIR}/shell_env" ]; then
 fi
 
 rm -rf "$STATE_CLUSTER"
-mkdir -p "$STATE_CLUSTER"/{shelley,webserver,db-sync,create_staked}
+mkdir -p "$STATE_CLUSTER"/{shelley,webserver,db-sync,create_staked,governance_data}
 cd "${STATE_CLUSTER}/.."
 
 cp "$SCRIPT_DIR"/cardano-node-* "$STATE_CLUSTER"
@@ -193,8 +193,6 @@ cardano_cli_log latest genesis create-staked \
   --gen-stake-delegs "$NUM_POOLS" \
   --supply-delegated "$DELEG_SUPPLY" \
   --start-time "$START_TIME_SHELLEY"
-
-mkdir -p "${STATE_CLUSTER}/governance_data"
 
 # Create committee keys
 if [ -z "${NO_CC:-""}" ]; then
@@ -459,7 +457,7 @@ EoF
     --out-file "${STATE_CLUSTER}/nodes/node-pool${i}/register.cert"
 done
 
-rm -rf "${STATE_CLUSTER}/shelley/create_staked"
+rm -rf "${STATE_CLUSTER}/create_staked"
 
 for i in $(seq 1 "$NUM_DREPS"); do
   # DRep keys

--- a/cardano_node_tests/cluster_scripts/conway_slow/start-cluster
+++ b/cardano_node_tests/cluster_scripts/conway_slow/start-cluster
@@ -63,7 +63,7 @@ if [ -e "${SCRIPT_DIR}/shell_env" ]; then
 fi
 
 rm -rf "$STATE_CLUSTER"
-mkdir -p "$STATE_CLUSTER"/{shelley,webserver,db-sync}
+mkdir -p "$STATE_CLUSTER"/{shelley,webserver,db-sync,governance_data}
 cd "${STATE_CLUSTER}/.."
 
 cp "$SCRIPT_DIR"/cardano-node-* "$STATE_CLUSTER"
@@ -198,8 +198,6 @@ jq -r '
   < "${STATE_CLUSTER}/shelley/genesis.json" > "${STATE_CLUSTER}/shelley/genesis.json_jq"
 cat "${STATE_CLUSTER}/shelley/genesis.json_jq" > "${STATE_CLUSTER}/shelley/genesis.json"
 rm -f "${STATE_CLUSTER}/shelley/genesis.json_jq"
-
-mkdir -p "${STATE_CLUSTER}/governance_data"
 
 # Create committee keys
 if [ -z "${NO_CC:-""}" ]; then


### PR DESCRIPTION
Previously, the governance_data directory was created separately after initial cluster setup. This change moves its creation into the main directory setup step, ensuring it is always present and avoiding redundant mkdir calls.