### PR TITLE
fix(tests): update tx id error assertion for node 10.5.0+

### DIFF
--- a/cardano_node_tests/tests/test_tx_negative.py
+++ b/cardano_node_tests/tests/test_tx_negative.py
@@ -1337,7 +1337,8 @@ class TestNegative:
             use_build_cmd=True,
         )
         assert (
-            "Incorrect transaction id format" in err
+            "Unable to deserialise TxId" in err  # With node 10.5.0+
+            or "Incorrect transaction id format" in err
             or "Failed reading" in err
             or "expecting transaction id (hexadecimal)" in err
         )


### PR DESCRIPTION
Include "Unable to deserialise TxId" in error checks to support Cardano node 10.5.0+ error messages. Maintains compatibility with previous error formats for transaction id validation.