### PR TITLE
fix(tests): increase a guaranteed time in epoch

### DIFF
--- a/cardano_node_tests/tests/tests_conway/test_constitution.py
+++ b/cardano_node_tests/tests/tests_conway/test_constitution.py
@@ -408,7 +408,7 @@ class TestConstitution:
 
         # Make sure we have enough time to submit the votes in one epoch
         clusterlib_utils.wait_for_epoch_interval(
-            cluster_obj=cluster, start=5, stop=common.EPOCH_STOP_SEC_BUFFER
+            cluster_obj=cluster, start=5, stop=common.EPOCH_STOP_SEC_BUFFER - 20
         )
         init_epoch = cluster.g_query.get_epoch()
 


### PR DESCRIPTION
Increase a time in epoch in `wait_for_epoch_interval` by 20 seconds to ensure votes are submitted within the intended epoch window. This adjustment helps prevent timing issues during test execution.