### PR TITLE
fix(cli): add periods to argparse help messages

### DIFF
--- a/cardano_node_tests/cardano_cli_coverage.py
+++ b/cardano_node_tests/cardano_cli_coverage.py
@@ -64,35 +64,35 @@ def get_args() -> argparse.Namespace:
         required=True,
         nargs="+",
         type=helpers.check_file_arg,
-        help="Path to coverage files",
+        help="Path to coverage files.",
     )
     parser.add_argument(
         "-o",
         "--output-file",
-        help="File where to save coverage results",
+        help="File where to save coverage results.",
     )
     parser.add_argument(
         "-u",
         "--uncovered-only",
         action="store_true",
-        help="Report only uncovered arguments",
+        help="Report only uncovered arguments.",
     )
     parser.add_argument(
         "-p",
         "--print-coverage",
         action="store_true",
-        help="Print coverage percentage",
+        help="Print coverage percentage.",
     )
     parser.add_argument(
         "-b",
         "--badge-icon-url",
         action="store_true",
-        help="Print badge icon URL",
+        help="Print badge icon URL.",
     )
     parser.add_argument(
         "--ignore-skips",
         action="store_true",
-        help="Include all commands and arguments, ignore list of items to skip",
+        help="Include all commands and arguments, ignore list of items to skip.",
     )
     return parser.parse_args()
 

--- a/cardano_node_tests/chang_us_coverage.py
+++ b/cardano_node_tests/chang_us_coverage.py
@@ -19,19 +19,19 @@ def get_args() -> argparse.Namespace:
         "-i",
         "--input-file",
         required=True,
-        help="File with coverage results",
+        help="File with coverage results.",
     )
     parser.add_argument(
         "-t",
         "--report-template",
         required=True,
-        help="File with report template",
+        help="File with report template.",
     )
     parser.add_argument(
         "-o",
         "--output-report",
         required=True,
-        help="Report file",
+        help="Report file.",
     )
     return parser.parse_args()
 

--- a/cardano_node_tests/defragment_utxos.py
+++ b/cardano_node_tests/defragment_utxos.py
@@ -22,14 +22,14 @@ def get_args() -> argparse.Namespace:
         "-a",
         "--address",
         required=True,
-        help="Address",
+        help="Address to defragment.",
     )
     parser.add_argument(
         "-s",
         "--skey-file",
         required=True,
         type=helpers.check_file_arg,
-        help="Path to skey file",
+        help="Path to skey file.",
     )
     return parser.parse_args()
 

--- a/cardano_node_tests/dump_requirements_coverage.py
+++ b/cardano_node_tests/dump_requirements_coverage.py
@@ -19,26 +19,26 @@ def get_args() -> argparse.Namespace:
         "-m",
         "--requirements-mapping",
         required=True,
-        help="JSON file with requirements mapping",
+        help="JSON file with requirements mapping.",
     )
     parser.add_argument(
         "-o",
         "--output-file",
         required=True,
-        help="File where to save coverage results",
+        help="File where to save coverage results.",
     )
     parser.add_argument(
         "-a",
         "--artifacts-base-dir",
         type=helpers.check_dir_arg,
-        help="Path to a directory with testing artifacts",
+        help="Path to a directory with testing artifacts.",
     )
     parser.add_argument(
         "-i",
         "--input-files",
         nargs="+",
         type=helpers.check_file_arg,
-        help="Path to coverage results to merge into a final result",
+        help="Path to coverage results to merge into a final result.",
     )
     return parser.parse_args()
 

--- a/cardano_node_tests/prepare_cluster_scripts.py
+++ b/cardano_node_tests/prepare_cluster_scripts.py
@@ -25,7 +25,7 @@ def get_args() -> argparse.Namespace:
     parser.add_argument(
         "-d",
         "--dest-dir",
-        help="Path to destination directory",
+        help="Path to destination directory.",
     )
     parser.add_argument(
         "-t",
@@ -37,7 +37,7 @@ def get_args() -> argparse.Namespace:
         "--instance-num",
         type=int,
         default=0,
-        help="Instance number in the sequence of cluster instances (default: 0)",
+        help="Instance number in the sequence of cluster instances (default: 0).",
     )
     parser.add_argument(
         "-l",
@@ -49,7 +49,7 @@ def get_args() -> argparse.Namespace:
         "-c",
         "--clean",
         action="store_true",
-        help="Delete the destination directory if it already exists (default: false)",
+        help="Delete the destination directory if it already exists (default: false).",
     )
     return parser.parse_args()
 

--- a/cardano_node_tests/split_topology.py
+++ b/cardano_node_tests/split_topology.py
@@ -21,7 +21,7 @@ def get_args() -> argparse.Namespace:
         "-d",
         "--dest-dir",
         required=True,
-        help="Path to destination directory",
+        help="Path to destination directory.",
     )
     parser.add_argument(
         "-i",
@@ -29,7 +29,7 @@ def get_args() -> argparse.Namespace:
         required=False,
         type=int,
         default=0,
-        help="Instance number in the sequence of cluster instances (default: 0)",
+        help="Instance number in the sequence of cluster instances (default: 0).",
     )
     parser.add_argument(
         "-o",
@@ -37,7 +37,7 @@ def get_args() -> argparse.Namespace:
         required=False,
         type=int,
         default=0,
-        help="Difference in number of nodes in cluster 1 vs cluster 2 (default: 0)",
+        help="Difference in number of nodes in cluster 1 vs cluster 2 (default: 0).",
     )
     return parser.parse_args()
 

--- a/cardano_node_tests/testnet_cleanup.py
+++ b/cardano_node_tests/testnet_cleanup.py
@@ -29,18 +29,18 @@ def get_args() -> argparse.Namespace:
         "--artifacts-base-dir",
         required=True,
         type=helpers.check_dir_arg,
-        help="Path to a directory with testing artifacts",
+        help="Path to a directory with testing artifacts.",
     )
     parser.add_argument(
         "-f",
         "--address",
-        help="Faucet address",
+        help="Faucet address.",
     )
     parser.add_argument(
         "-s",
         "--skey-file",
         type=helpers.check_file_arg,
-        help="Path to faucet skey file",
+        help="Path to faucet skey file.",
     )
     return parser.parse_args()
 

--- a/cardano_node_tests/testnet_cleanup_info.py
+++ b/cardano_node_tests/testnet_cleanup_info.py
@@ -23,14 +23,14 @@ def get_args() -> argparse.Namespace:
         "--artifacts-base-dir",
         required=True,
         type=helpers.check_dir_arg_keep,
-        help="Path to a directory with testing artifacts",
+        help="Path to a directory with testing artifacts.",
     )
     parser.add_argument(
         "-f",
         "--fee",
         action="store_true",
         required=False,
-        help="Print total fees of signed transactions",
+        help="Print total fees of signed transactions.",
     )
     return parser.parse_args()
 


### PR DESCRIPTION
Standardize argparse help messages by adding periods at the end of each help string in CLI scripts. This improves consistency and readability across the codebase.