### PR TITLE
docs(readme): update sync instruction and node version

### DIFF
--- a/testnets_bootstrap_template/README.md
+++ b/testnets_bootstrap_template/README.md
@@ -51,7 +51,7 @@ Running the db-sync
     ./run-cardano-dbsync
     ```
 
-* Wait until the db-syn is synced
+* Wait until the db-sync is fully synced
 
 Running tests
 -------------
@@ -64,5 +64,5 @@ Note that the testing framework will start node and db-sync processes automatica
 * run the tests
 
     ```sh
-    NODE_REV=8.0.0 BOOTSTRAP_DIR=~/path/to/preview_bootstrap ./.github/regression.sh
+    NODE_REV=10.4.1 BOOTSTRAP_DIR=~/path/to/preview_bootstrap ./.github/regression.sh
     ```


### PR DESCRIPTION
Fixed typo. Updated the example NODE_REV in the test command from 8.0.0 to 10.4.1 to reflect the latest supported version.