### PR TITLE
refactor(ci): rename PATH_APPEND to PATH_PREPEND

### DIFF
--- a/.github/regression.sh
+++ b/.github/regression.sh
@@ -15,7 +15,7 @@ REPODIR="$(readlink -m "${0%/*}/..")"
 cd "$REPODIR"
 
 export WORKDIR="$REPODIR/run_workdir"
-export PATH_APPEND="${PWD}/.bin"
+export PATH_PREPEND="${PWD}/.bin"
 
 # shellcheck disable=SC1090,SC1091
 . .github/stop_cluster_instances.sh
@@ -169,7 +169,7 @@ _cleanup_testnet_on_interrupt() {
   # shellcheck disable=SC2016
   nix develop --accept-flake-config .#venv --command bash -c '
     . .github/setup_venv.sh
-    export PATH="$PATH_APPEND":"$PATH"
+    export PATH="$PATH_PREPEND":"$PATH"
     export CARDANO_NODE_SOCKET_PATH="$CARDANO_NODE_SOCKET_PATH_CI"
     cleanup_dir="${_PYTEST_CURRENT}/../cleanup-${_PYTEST_CURRENT##*/}-script"
     mkdir "$cleanup_dir"
@@ -223,7 +223,7 @@ nix develop --accept-flake-config .#venv --command bash -c '
   echo "::group::🧪 Testrun"
   printf "start: %(%H:%M:%S)T\n" -1
   df -h .
-  export PATH="$PATH_APPEND":"$PATH"
+  export PATH="$PATH_PREPEND":"$PATH"
   export CARDANO_NODE_SOCKET_PATH="$CARDANO_NODE_SOCKET_PATH_CI"
   retval=0
   make "${MAKE_TARGET:-"tests"}" || retval="$?"

--- a/.github/source_cardano_cli.sh
+++ b/.github/source_cardano_cli.sh
@@ -16,9 +16,9 @@ nix build \
   -o cardano-cli-build || exit 1
 [ -e cardano-cli-build/bin/cardano-cli ] || exit 1
 
-# Add `cardano-cli` to PATH_APPEND
-PATH_APPEND="${PATH_APPEND:+"${PATH_APPEND}:"}$(readlink -m cardano-cli-build/bin)"
-export PATH_APPEND
+# Add `cardano-cli` to PATH_PREPEND
+PATH_PREPEND="${PATH_PREPEND:+"${PATH_PREPEND}:"}$(readlink -m cardano-cli-build/bin)"
+export PATH_PREPEND
 
 cd "$_origpwd" || exit 1
 unset _origpwd

--- a/.github/source_dbsync.sh
+++ b/.github/source_dbsync.sh
@@ -121,12 +121,12 @@ if [ ! -e db-sync-node/bin/cardano-db-sync ]; then
   exit 1
 fi
 
-# Add `cardano-db-sync` and `cardano-smash-server` to PATH_APPEND
-PATH_APPEND="${PATH_APPEND:+"${PATH_APPEND}:"}$(readlink -m db-sync-node/bin)"
+# Add `cardano-db-sync` and `cardano-smash-server` to PATH_PREPEND
+PATH_PREPEND="${PATH_PREPEND:+"${PATH_PREPEND}:"}$(readlink -m db-sync-node/bin)"
 if [ -e smash-server/bin/cardano-smash-server ]; then
-  PATH_APPEND="${PATH_APPEND:+"${PATH_APPEND}:"}$(readlink -m smash-server/bin)"
+  PATH_PREPEND="${PATH_PREPEND:+"${PATH_PREPEND}:"}$(readlink -m smash-server/bin)"
 fi
-export PATH_APPEND
+export PATH_PREPEND
 
 export DBSYNC_SCHEMA_DIR="$PWD/schema"
 

--- a/.github/source_plutus_apps.sh
+++ b/.github/source_plutus_apps.sh
@@ -16,9 +16,9 @@ nix build \
   -o create-script-context-build || exit 1
 [ -e create-script-context-build/bin/create-script-context ] || exit 1
 
-# Add `create-script-context` to PATH_APPEND
-PATH_APPEND="${PATH_APPEND:+"${PATH_APPEND}:"}$(readlink -m create-script-context-build/bin)"
-export PATH_APPEND
+# Add `create-script-context` to PATH_PREPEND
+PATH_PREPEND="${PATH_PREPEND:+"${PATH_PREPEND}:"}$(readlink -m create-script-context-build/bin)"
+export PATH_PREPEND
 
 cd "$_origpwd" || exit 1
 unset _origpwd


### PR DESCRIPTION
Renamed the environment variable PATH_APPEND to PATH_PREPEND in all CI scripts to better reflect its usage as a path prefix. Updated all references and export statements accordingly for consistency and clarity. No functional changes introduced.