### PR TITLE
feat(ci): improve dbsync index cleanup and smash build

### DIFF
--- a/.github/regression.sh
+++ b/.github/regression.sh
@@ -151,6 +151,11 @@ _cleanup() {
   if command -v stop_postgres >/dev/null 2>&1; then
     stop_postgres || :
   fi
+
+  # cleanup dbsync repo if modified
+  if command -v cleanup_dbsync_repo >/dev/null 2>&1; then
+    cleanup_dbsync_repo || :
+  fi
 }
 
 _cleanup_testnet_on_interrupt() {


### PR DESCRIPTION
Move DBSYNC_SKIP_INDEXES logic to after binary build to ensure binaries can be retrieved from the nix cache before schema files are removed. Introduce a cleanup_dbsync_repo function to restore the dbsync repo state after tests, and invoke it in the regression cleanup step. Add conditional build for cardano-smash-server when SMASH is enabled.