### PR TITLE
chore(pre-commit): reorganize config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,10 +13,19 @@ repos:
     language_version: python3
   - id: debug-statements
     language_version: python3
+- repo: local
+  hooks:
+  - id: pyrefly
+    name: pyrefly
+    entry: pyrefly
+    args: [ check, --remove-unused-ignores ]
+    pass_filenames: false
+    language: system
+    types: [python]
 - repo: https://github.com/charliermarsh/ruff-pre-commit
   rev: v0.12.1
   hooks:
-    - id: ruff
+    - id: ruff-check
       args: [ --fix ]
     - id: ruff-format
 - repo: https://github.com/shellcheck-py/shellcheck-py
@@ -32,21 +41,14 @@ repos:
   hooks:
   - id: rstcheck
     additional_dependencies: [sphinx, toml]
+- repo: https://github.com/python-poetry/poetry
+  rev: 2.1.3
+  hooks:
+    - id: poetry-check
 - repo: local
   hooks:
-  - id: pyrefly
-    name: pyrefly
-    entry: pyrefly
-    args: [ check, --remove-unused-ignores ]
-    pass_filenames: false
-    language: system
-    types: [python]
   - id: mypy
     name: mypy
     entry: mypy
     language: system
     types: [python]
-- repo: https://github.com/python-poetry/poetry
-  rev: 2.1.3
-  hooks:
-    - id: poetry-check


### PR DESCRIPTION
Move pyrefly hook before ruff formatter, because pyrefly can modify the code.