### PR TITLE
feat(tests): improve negative redeemer fuzzing coverage

### DIFF
--- a/cardano_node_tests/tests/tests_plutus/test_spend_negative_build.py
+++ b/cardano_node_tests/tests/tests_plutus/test_spend_negative_build.py
@@ -550,6 +550,8 @@ class TestNegativeRedeemer:
 
     MIN_INT_VAL = -common.MAX_UINT64
     AMOUNT = 800_000
+    KNOWN_FIELDS = ("int", "bytes", "string", "list", "map")
+    NONINT_FIELDS = ("bytes", "string", "list", "map")
 
     @pytest.fixture
     def fund_script_guessing_game_v1(
@@ -1189,7 +1191,12 @@ class TestNegativeRedeemer:
         assert "JSON object expected. Unexpected value" in err_str, err_str
 
     @allure.link(helpers.get_vcs_link())
-    @hypothesis.given(redeemer_type=st.text())
+    @hypothesis.given(
+        redeemer_type=st.one_of(
+            st.sampled_from(NONINT_FIELDS),
+            st.text(),
+        )
+    )
     @common.hypothesis_settings(max_examples=200)
     @common.PARAM_PLUTUS_VERSION
     @pytest.mark.smoke
@@ -1206,6 +1213,8 @@ class TestNegativeRedeemer:
 
         Expect failure.
         """
+        hypothesis.assume(redeemer_type != "int")
+
         temp_template = f"{common.get_test_id(cluster)}_{common.unique_time_str()}"
 
         fund_script_guessing_game = (
@@ -1244,10 +1253,19 @@ class TestNegativeRedeemer:
             'Expected a single field named "int", "bytes", "string", "list" or "map".' in err_str
             # See node commit ac662d8e46554c1ed02d485bfdd69e7ec04d8613
             or 'Expected a single field named "int", "bytes", "list" or "map".' in err_str
+            or (
+                redeemer_type in self.KNOWN_FIELDS
+                and "JSON schema error within the script data" in err_str
+            )
         ), err_str
 
     @allure.link(helpers.get_vcs_link())
-    @hypothesis.given(redeemer_type=st.text())
+    @hypothesis.given(
+        redeemer_type=st.one_of(
+            st.sampled_from(NONINT_FIELDS),
+            st.text(),
+        )
+    )
     @common.hypothesis_settings(max_examples=200)
     @common.PARAM_PLUTUS_VERSION
     @pytest.mark.smoke
@@ -1264,6 +1282,8 @@ class TestNegativeRedeemer:
 
         Expect failure.
         """
+        hypothesis.assume(redeemer_type != "int")
+
         temp_template = f"{common.get_test_id(cluster)}_{common.unique_time_str()}"
 
         fund_script_guessing_game = (
@@ -1302,4 +1322,8 @@ class TestNegativeRedeemer:
             'Expected a single field named "int", "bytes", "string", "list" or "map".' in err_str
             # See node commit ac662d8e46554c1ed02d485bfdd69e7ec04d8613
             or 'Expected a single field named "int", "bytes", "list" or "map".' in err_str
+            or (
+                redeemer_type in self.KNOWN_FIELDS
+                and "JSON schema error within the script data" in err_str
+            )
         ), err_str

--- a/cardano_node_tests/tests/tests_plutus/test_spend_negative_raw.py
+++ b/cardano_node_tests/tests/tests_plutus/test_spend_negative_raw.py
@@ -694,6 +694,8 @@ class TestNegativeRedeemer:
 
     MIN_INT_VAL = -common.MAX_UINT64
     AMOUNT = 2_000_000
+    KNOWN_FIELDS = ("int", "bytes", "string", "list", "map")
+    NONINT_FIELDS = ("bytes", "string", "list", "map")
 
     def _fund_script_guessing_game(
         self,
@@ -1460,7 +1462,12 @@ class TestNegativeRedeemer:
         assert "Invalid JSON format" in err, err
 
     @allure.link(helpers.get_vcs_link())
-    @hypothesis.given(redeemer_type=st.text())
+    @hypothesis.given(
+        redeemer_type=st.one_of(
+            st.sampled_from(NONINT_FIELDS),
+            st.text(),
+        )
+    )
     @common.hypothesis_settings(max_examples=200)
     @common.PARAM_PLUTUS_VERSION
     @pytest.mark.smoke
@@ -1477,6 +1484,8 @@ class TestNegativeRedeemer:
 
         Expect failure.
         """
+        hypothesis.assume(redeemer_type != "int")
+
         temp_template = f"{common.get_test_id(cluster)}_{common.unique_time_str()}"
 
         fund_script_guessing_game = (
@@ -1503,10 +1512,19 @@ class TestNegativeRedeemer:
             'Expected a single field named "int", "bytes", "string", "list" or "map".' in err
             # See node commit ac662d8e46554c1ed02d485bfdd69e7ec04d8613
             or 'Expected a single field named "int", "bytes", "list" or "map".' in err
+            or (
+                redeemer_type in self.KNOWN_FIELDS
+                and "JSON schema error within the script data" in err
+            )
         ), err
 
     @allure.link(helpers.get_vcs_link())
-    @hypothesis.given(redeemer_type=st.text())
+    @hypothesis.given(
+        redeemer_type=st.one_of(
+            st.sampled_from(NONINT_FIELDS),
+            st.text(),
+        )
+    )
     @common.hypothesis_settings(max_examples=200)
     @common.PARAM_PLUTUS_VERSION
     @pytest.mark.smoke
@@ -1523,6 +1541,8 @@ class TestNegativeRedeemer:
 
         Expect failure.
         """
+        hypothesis.assume(redeemer_type != "int")
+
         temp_template = f"{common.get_test_id(cluster)}_{common.unique_time_str()}"
 
         fund_script_guessing_game = (
@@ -1549,4 +1569,8 @@ class TestNegativeRedeemer:
             'Expected a single field named "int", "bytes", "string", "list" or "map".' in err
             # See node commit ac662d8e46554c1ed02d485bfdd69e7ec04d8613
             or 'Expected a single field named "int", "bytes", "list" or "map".' in err
+            or (
+                redeemer_type in self.KNOWN_FIELDS
+                and "JSON schema error within the script data" in err
+            )
         ), err


### PR DESCRIPTION
Expand hypothesis strategies in negative redeemer tests to sample from known non-int fields and arbitrary text, increasing coverage of invalid redeemer types. Add explicit assumption to skip "int" type. Update assertions to handle new error message variants for known fields.