### PR TITLE
refactor(common): move and deprecate PARAM_USE_BUILD_CMD

### DIFF
--- a/cardano_node_tests/tests/common.py
+++ b/cardano_node_tests/tests/common.py
@@ -91,14 +91,6 @@ SKIPIF_ON_LOCAL = pytest.mark.skipif(
 
 
 # Common parametrization
-PARAM_USE_BUILD_CMD = pytest.mark.parametrize(
-    "use_build_cmd",
-    (
-        False,
-        pytest.param(True, marks=SKIPIF_BUILD_UNUSABLE),
-    ),
-    ids=(clusterlib_utils.BuildMethods.BUILD_RAW, clusterlib_utils.BuildMethods.BUILD),
-)
 
 PARAM_BUILD_METHOD = pytest.mark.parametrize(
     "build_method",
@@ -115,6 +107,16 @@ PARAM_OFFLINE_BUILD_METHOD = pytest.mark.parametrize(
         clusterlib_utils.BuildMethods.BUILD_RAW,
         clusterlib_utils.BuildMethods.BUILD_EST,
     ),
+)
+
+# Deprecated. Use `PARAM_BUILD_METHOD` instead.
+PARAM_USE_BUILD_CMD = pytest.mark.parametrize(
+    "use_build_cmd",
+    (
+        False,
+        pytest.param(True, marks=SKIPIF_BUILD_UNUSABLE),
+    ),
+    ids=(clusterlib_utils.BuildMethods.BUILD_RAW, clusterlib_utils.BuildMethods.BUILD),
 )
 
 PARAM_PLUTUS_VERSION = pytest.mark.parametrize(


### PR DESCRIPTION
Moved the definition of PARAM_USE_BUILD_CMD below PARAM_OFFLINE_BUILD_METHOD and marked it as deprecated in favor of PARAM_BUILD_METHOD. This clarifies preferred usage and improves code organization. No functional changes made.