### PR TITLE
refactor: use enum for epoch state action type

### DIFF
--- a/cardano_node_tests/tests/tests_conway/test_committee.py
+++ b/cardano_node_tests/tests/tests_conway/test_committee.py
@@ -1317,10 +1317,12 @@ class TestCommittee:
         # Check epoch state in dbsync
         reqc.db025_01.start(url=helpers.get_vcs_link())
         dbsync_utils.check_epoch_state(
-            epoch_no=enact_epoch, txid=action_add_txid, change_type="committee"
+            epoch_no=enact_epoch,
+            txid=action_add_txid,
+            action_type=dbsync_utils.ActionTypes.COMMITTEE,
         )
         dbsync_utils.check_epoch_state(
-            epoch_no=rem_epoch, txid=action_rem_txid, change_type="committee"
+            epoch_no=rem_epoch, txid=action_rem_txid, action_type=dbsync_utils.ActionTypes.COMMITTEE
         )
         reqc.db025_01.success()
 

--- a/cardano_node_tests/tests/tests_conway/test_constitution.py
+++ b/cardano_node_tests/tests/tests_conway/test_constitution.py
@@ -589,9 +589,11 @@ class TestConstitution:
             assert constitution_db[0].gov_action_type == "NewConstitution"
             reqc.db012.success()
 
-        # Check epoch state in dbsync
-        reqc.db025_02.start(url=helpers.get_vcs_link())
-        dbsync_utils.check_epoch_state(
-            epoch_no=cluster.g_query.get_epoch(), txid=action_txid, change_type="constitution"
-        )
-        reqc.db025_02.success()
+            # Check epoch state in dbsync
+            reqc.db025_02.start(url=helpers.get_vcs_link())
+            dbsync_utils.check_epoch_state(
+                epoch_no=cluster.g_query.get_epoch(),
+                txid=action_txid,
+                action_type=dbsync_utils.ActionTypes.CONSTITUTION,
+            )
+            reqc.db025_02.success()


### PR DESCRIPTION
Refactored dbsync_utils.check_epoch_state to use ActionTypes enum instead of string literals for action type. Updated all usages in committee and constitution tests. Added ActionTypes enum to dbsync_utils for clarity and type safety. Improved error handling for unsupported action types.