### PR TITLE
refactor: replace asserts with explicit exceptions

### DIFF
--- a/cardano_node_tests/cluster_management/cluster_getter.py
+++ b/cardano_node_tests/cluster_management/cluster_getter.py
@@ -724,8 +724,12 @@ class ClusterGetter:
                 ("singleton" tests).
             scriptsdir: Path to custom scripts for the cluster.
         """
-        assert not isinstance(lock_resources, str), "`lock_resources` can't be single string"
-        assert not isinstance(use_resources, str), "`use_resources` can't be single string"
+        if isinstance(lock_resources, str):
+            msg = "`lock_resources` cannot be a string"
+            raise TypeError(msg)
+        if isinstance(use_resources, str):
+            msg = "`use_resources` cannot be a string"
+            raise TypeError(msg)
 
         # Sanitize strings so they can be used in file names
         mark = resources.sanitize_res_name(mark)

--- a/cardano_node_tests/cluster_management/manager.py
+++ b/cardano_node_tests/cluster_management/manager.py
@@ -42,7 +42,9 @@ def _get_manager_fixture_line_str() -> str:
     """Get `filename#lineno` of current fixture, called from contextmanager."""
     # Get past `cache_fixture` and `contextmanager` to the fixture
     calling_frame = inspect.currentframe().f_back.f_back.f_back  # type: ignore
-    assert calling_frame
+    if not calling_frame:
+        msg = "Couldn't get the calling frame."
+        raise ValueError(msg)
     return helpers.get_line_str_from_frame(frame=calling_frame)
 
 
@@ -282,7 +284,7 @@ class ClusterManager:
     ) -> list[str]:
         if from_set is not None and isinstance(from_set, str):
             msg = "`from_set` cannot be a string"
-            raise AssertionError(msg)
+            raise TypeError(msg)
 
         resources = set(status_files.get_resources_from_path(paths=paths))
 
@@ -383,7 +385,7 @@ class ClusterManager:
         cluster_obj = self.cache.cluster_obj
         if not cluster_obj:
             msg = "`cluster_obj` not available, that cannot happen"
-            raise AssertionError(msg)
+            raise RuntimeError(msg)
         cluster_obj.cluster_id = self.cluster_instance_num
         cluster_obj._cluster_manager = self  # type: ignore
         self._initialized = True
@@ -408,8 +410,8 @@ class ClusterManager:
         # If you've ran into this issue, check that all the fixtures you use in the test are using
         # the same `cluster` fixture.
         if check_initialized and self._initialized:
-            msg = "manager is already initialized"
-            raise AssertionError(msg)
+            msg = "Manager is already initialized"
+            raise RuntimeError(msg)
 
         self.init(
             mark=mark,
@@ -421,5 +423,7 @@ class ClusterManager:
         )
 
         cluster_obj = self.cache.cluster_obj
-        assert cluster_obj
+        if not cluster_obj:
+            msg = "`cluster_obj` not available, that cannot happen"
+            raise RuntimeError(msg)
         return cluster_obj

--- a/cardano_node_tests/cluster_management/resources_management.py
+++ b/cardano_node_tests/cluster_management/resources_management.py
@@ -8,7 +8,9 @@ class BaseFilter:
     """Base class for resource filters."""
 
     def __init__(self, resources: tp.Iterable[str]) -> None:
-        assert not isinstance(resources, str), "`resources` can't be single string"
+        if isinstance(resources, str):
+            msg = "`resources` cannot be a string"
+            raise TypeError(msg)
         self.resources = resources
 
     def filter(self, unavailable: tp.Iterable[str], **kwargs: tp.Any) -> list[str]:
@@ -27,7 +29,9 @@ class OneOf(BaseFilter):
         unavailable: tp.Iterable[str],
         **kwargs: tp.Any,  # noqa: ARG002
     ) -> list[str]:
-        assert not isinstance(unavailable, str), "`unavailable` can't be single string"
+        if isinstance(unavailable, str):
+            msg = "`unavailable` cannot be a string"
+            raise TypeError(msg)
 
         usable = [r for r in self.resources if r not in unavailable]
         if not usable:


### PR DESCRIPTION
Refactored code to replace assert statements with explicit exception raising for better error handling and clarity. Changed inappropriate asserts to TypeError or RuntimeError where applicable, and improved error messages for invalid input types and unexpected states.