### PR TITLE
This PR refactors test_delegation to align with the new build Method

### DIFF
--- a/cardano_node_tests/tests/test_delegation.py
+++ b/cardano_node_tests/tests/test_delegation.py
@@ -956,8 +956,8 @@ class TestDelegateAddr:
             signing_key_files=[user_payment.skey_file, user_registered.stake.skey_file],
         )
 
-        try:
-            tx_raw_output_deleg = clusterlib_utils.build_and_submit_tx(
+        def _build_and_submit() -> clusterlib.TxRawOutput:
+            return clusterlib_utils.build_and_submit_tx(
                 cluster_obj=cluster,
                 name_template=f"{temp_template}_deleg_dereg",
                 src_address=user_payment.address,
@@ -965,6 +965,9 @@ class TestDelegateAddr:
                 build_method=build_method,
                 witness_override=len(tx_files.signing_key_files),
             )
+
+        try:
+            tx_raw_output_deleg = common.match_blocker(func=_build_and_submit)
         except clusterlib.CLIError as exc:
             if "ValueNotConservedUTxO" in str(exc):
                 issues.cli_942.finish_test()


### PR DESCRIPTION
This PR simplifies and unifies the delegation transaction handling by removing redundant `use_build_cmd` branches and consolidating transaction creation into a single `clusterlib_utils.build_and_submit_tx` flow.

### **Key Changes**

* **`delegate_stake_addr`**

  * Removed conditional handling of `use_build_cmd` vs. `send_tx`.
  * Replaced both with `clusterlib_utils.build_and_submit_tx` for consistency.
  * Ensures returned `DelegationOut` uses `tx_output` instead of mixed outputs.
  * Balance validation updated to reference unified transaction output.

* **`test_delegation.py`**

  * Updated delegation tests (`delegate using pool_id`, `delegate using vkey`, `delegation + deregistration`, `unknown addr`, `deregistered addr`) to use `build_method` instead of `use_build_cmd`.
  * Simplified test logic by removing duplicated transaction signing/submission branches.
  * Maintained existing assertions on balance updates, stake key deposits, and delegation error handling.
  
  Regression RUN: https://github.com/IntersectMBO/cardano-node-tests/actions/runs/17407105869/job/49414294045
