### PR TITLE
This PR refactors test_committee to align with the new build Method

### DIFF
--- a/cardano_node_tests/tests/tests_conway/test_committee.py
+++ b/cardano_node_tests/tests/tests_conway/test_committee.py
@@ -115,14 +115,14 @@ class TestCommittee:
 
     @allure.link(helpers.get_vcs_link())
     @submit_utils.PARAM_SUBMIT_METHOD
-    @common.PARAM_USE_BUILD_CMD
+    @common.PARAM_BUILD_METHOD_NO_EST
     @pytest.mark.testnets
     @pytest.mark.smoke
     def test_register_hot_key_no_cc_member(
         self,
         cluster: clusterlib.ClusterLib,
         pool_user: clusterlib.PoolUser,
-        use_build_cmd: bool,
+        build_method: str,
         submit_method: str,
     ):
         """Try to submit a Hot Credential Authorization certificate without being a CC member.
@@ -148,7 +148,7 @@ class TestCommittee:
                 name_template=f"{temp_template}_auth",
                 src_address=pool_user.payment.address,
                 submit_method=submit_method,
-                use_build_cmd=use_build_cmd,
+                build_method=build_method,
                 tx_files=tx_files_auth,
             )
         err_str = str(excinfo.value)
@@ -414,7 +414,7 @@ class TestCommittee:
 
     @allure.link(helpers.get_vcs_link())
     @submit_utils.PARAM_SUBMIT_METHOD
-    @common.PARAM_USE_BUILD_CMD
+    @common.PARAM_BUILD_METHOD_NO_EST
     @pytest.mark.parametrize("threshold_type", ("fraction", "decimal"))
     @pytest.mark.dbsync
     @pytest.mark.smoke
@@ -422,7 +422,7 @@ class TestCommittee:
         self,
         cluster: clusterlib.ClusterLib,
         pool_user: clusterlib.PoolUser,
-        use_build_cmd: bool,
+        build_method: str,
         submit_method: str,
         threshold_type: str,
     ):
@@ -489,7 +489,7 @@ class TestCommittee:
                     name_template=f"{temp_template}_bootstrap",
                     src_address=pool_user.payment.address,
                     submit_method=submit_method,
-                    use_build_cmd=use_build_cmd,
+                    build_method=build_method,
                     tx_files=tx_files,
                     deposit=deposit_amt,
                 )
@@ -505,7 +505,7 @@ class TestCommittee:
             name_template=temp_template,
             src_address=pool_user.payment.address,
             submit_method=submit_method,
-            use_build_cmd=use_build_cmd,
+            build_method=build_method,
             tx_files=tx_files,
             deposit=deposit_amt,
         )


### PR DESCRIPTION
This PR updates  Committee Action tests to align with the unified transaction building approach. The redundant `use_build_cmd` parameter is replaced by `build_method`, ensuring consistency across all certificate submission flows.

### **Key Changes**

* **Hot Key Registration Tests**

  * Updated `test_register_hot_key_no_cc_member` to pass `build_method` instead of `use_build_cmd`.

* **Committee Action Tests**

  * Updated `test_update_committee_action` and related committee tests.
  * Removed direct `use_build_cmd` handling and replaced with `build_method`.
  
  Test Run: https://github.com/IntersectMBO/cardano-node-tests/actions/runs/17410634762
