### PR TITLE
Build method test treasure donation

### DIFF
--- a/cardano_node_tests/tests/tests_conway/test_committee.py
+++ b/cardano_node_tests/tests/tests_conway/test_committee.py
@@ -115,14 +115,14 @@ class TestCommittee:
 
     @allure.link(helpers.get_vcs_link())
     @submit_utils.PARAM_SUBMIT_METHOD
-    @common.PARAM_USE_BUILD_CMD
+    @common.PARAM_BUILD_METHOD_NO_EST
     @pytest.mark.testnets
     @pytest.mark.smoke
     def test_register_hot_key_no_cc_member(
         self,
         cluster: clusterlib.ClusterLib,
         pool_user: clusterlib.PoolUser,
-        use_build_cmd: bool,
+        build_method: str,
         submit_method: str,
     ):
         """Try to submit a Hot Credential Authorization certificate without being a CC member.
@@ -148,7 +148,7 @@ class TestCommittee:
                 name_template=f"{temp_template}_auth",
                 src_address=pool_user.payment.address,
                 submit_method=submit_method,
-                use_build_cmd=use_build_cmd,
+                build_method=build_method,
                 tx_files=tx_files_auth,
             )
         err_str = str(excinfo.value)
@@ -414,7 +414,7 @@ class TestCommittee:
 
     @allure.link(helpers.get_vcs_link())
     @submit_utils.PARAM_SUBMIT_METHOD
-    @common.PARAM_USE_BUILD_CMD
+    @common.PARAM_BUILD_METHOD_NO_EST
     @pytest.mark.parametrize("threshold_type", ("fraction", "decimal"))
     @pytest.mark.dbsync
     @pytest.mark.smoke
@@ -422,7 +422,7 @@ class TestCommittee:
         self,
         cluster: clusterlib.ClusterLib,
         pool_user: clusterlib.PoolUser,
-        use_build_cmd: bool,
+        build_method: str,
         submit_method: str,
         threshold_type: str,
     ):
@@ -489,7 +489,7 @@ class TestCommittee:
                     name_template=f"{temp_template}_bootstrap",
                     src_address=pool_user.payment.address,
                     submit_method=submit_method,
-                    use_build_cmd=use_build_cmd,
+                    build_method=build_method,
                     tx_files=tx_files,
                     deposit=deposit_amt,
                 )
@@ -505,7 +505,7 @@ class TestCommittee:
             name_template=temp_template,
             src_address=pool_user.payment.address,
             submit_method=submit_method,
-            use_build_cmd=use_build_cmd,
+            build_method=build_method,
             tx_files=tx_files,
             deposit=deposit_amt,
         )

--- a/cardano_node_tests/tests/tests_conway/test_committee.py
+++ b/cardano_node_tests/tests/tests_conway/test_committee.py
@@ -115,14 +115,14 @@ class TestCommittee:
 
     @allure.link(helpers.get_vcs_link())
     @submit_utils.PARAM_SUBMIT_METHOD
-    @common.PARAM_BUILD_METHOD_NO_EST
+    @common.PARAM_USE_BUILD_CMD
     @pytest.mark.testnets
     @pytest.mark.smoke
     def test_register_hot_key_no_cc_member(
         self,
         cluster: clusterlib.ClusterLib,
         pool_user: clusterlib.PoolUser,
-        build_method: str,
+        use_build_cmd: bool,
         submit_method: str,
     ):
         """Try to submit a Hot Credential Authorization certificate without being a CC member.
@@ -148,7 +148,7 @@ class TestCommittee:
                 name_template=f"{temp_template}_auth",
                 src_address=pool_user.payment.address,
                 submit_method=submit_method,
-                build_method=build_method,
+                use_build_cmd=use_build_cmd,
                 tx_files=tx_files_auth,
             )
         err_str = str(excinfo.value)
@@ -414,7 +414,7 @@ class TestCommittee:
 
     @allure.link(helpers.get_vcs_link())
     @submit_utils.PARAM_SUBMIT_METHOD
-    @common.PARAM_BUILD_METHOD_NO_EST
+    @common.PARAM_USE_BUILD_CMD
     @pytest.mark.parametrize("threshold_type", ("fraction", "decimal"))
     @pytest.mark.dbsync
     @pytest.mark.smoke
@@ -422,7 +422,7 @@ class TestCommittee:
         self,
         cluster: clusterlib.ClusterLib,
         pool_user: clusterlib.PoolUser,
-        build_method: str,
+        use_build_cmd: bool,
         submit_method: str,
         threshold_type: str,
     ):
@@ -489,7 +489,7 @@ class TestCommittee:
                     name_template=f"{temp_template}_bootstrap",
                     src_address=pool_user.payment.address,
                     submit_method=submit_method,
-                    build_method=build_method,
+                    use_build_cmd=use_build_cmd,
                     tx_files=tx_files,
                     deposit=deposit_amt,
                 )
@@ -505,7 +505,7 @@ class TestCommittee:
             name_template=temp_template,
             src_address=pool_user.payment.address,
             submit_method=submit_method,
-            build_method=build_method,
+            use_build_cmd=use_build_cmd,
             tx_files=tx_files,
             deposit=deposit_amt,
         )

--- a/cardano_node_tests/tests/tests_conway/test_treasury_donation.py
+++ b/cardano_node_tests/tests/tests_conway/test_treasury_donation.py
@@ -69,13 +69,13 @@ class TestTreasuryDonation:
 
     @allure.link(helpers.get_vcs_link())
     @submit_utils.PARAM_SUBMIT_METHOD
-    @common.PARAM_USE_BUILD_CMD
+    @common.PARAM_BUILD_METHOD_NO_EST
     @pytest.mark.smoke
     def test_transfer_treasury_donation(
         self,
         cluster_treasury: clusterlib.ClusterLib,
         payment_addr_treasury: clusterlib.AddressRecord,
-        use_build_cmd: bool,
+        build_method: str,
         submit_method: str,
     ):
         """Send funds from payment address to the treasury.
@@ -107,7 +107,7 @@ class TestTreasuryDonation:
             treasury_donation=amount,
             submit_method=submit_method,
             change_address=payment_addr_treasury.address,
-            use_build_cmd=use_build_cmd,
+            build_method=build_method,
             tx_files=tx_files,
         )
 


### PR DESCRIPTION
This PR updates the `test_transfer_treasury_donation` test to align with the ongoing transaction-building refactor. The `use_build_cmd` flag has been removed and replaced with the more explicit `build_method` parameter.

### **Key Changes**

* **`test_transfer_treasury_donation`**

  * Replaced `use_build_cmd` argument with `build_method`.
  * Ensures treasury donation transactions follow the same unified build logic used in other tests.

### **Benefits**

* Consistency across all transaction-related tests.
* Simplifies test logic by removing redundant boolean flag.
* Aligns treasury donation flow with the unified `build_and_submit_tx` interface.

Test RUN: https://github.com/IntersectMBO/cardano-node-tests/actions/runs/17414430310
