### PR TITLE
feat(test): set fee_buffer=0 in tx build test

### DIFF
--- a/cardano_node_tests/tests/test_tx_basic.py
+++ b/cardano_node_tests/tests/test_tx_basic.py
@@ -294,6 +294,7 @@ class TestBasicTransactions:
                     tx_files=tx_files,
                     txouts=txouts,
                     change_address=src_address,
+                    fee_buffer=0,
                 )
             except clusterlib.CLIError as exc:
                 str_exc = str(exc)


### PR DESCRIPTION
We transfer all available funds, so there's no need to look for more inputs for fee buffer.