### PR TITLE
fix(imports): improve pyright compatibility for helpers and smash

### DIFF
--- a/cardano_node_tests/utils/helpers.py
+++ b/cardano_node_tests/utils/helpers.py
@@ -1,5 +1,4 @@
 import argparse
-import collections
 import contextlib
 import datetime
 import functools
@@ -17,6 +16,7 @@ import string
 import subprocess
 import types as tt
 import typing as tp
+from collections import abc
 
 import cardano_node_tests.utils.types as ttypes
 
@@ -291,9 +291,10 @@ def tool_has(command: str) -> bool:
 
 def flatten(
     iterable: tp.Iterable,
-    ltypes: type[tp.Iterable[tp.Any]] = collections.abc.Iterable,  # pyright: ignore [reportAttributeAccessIssue]
+    ltypes: type[tp.Iterable] | None = None,
 ) -> tp.Generator:
     """Flatten an irregular (arbitrarily nested) iterable of iterables."""
+    ltypes = ltypes if ltypes is not None else abc.Iterable
     remainder = iter(iterable)
     while True:
         try:

--- a/cardano_node_tests/utils/smash_utils.py
+++ b/cardano_node_tests/utils/smash_utils.py
@@ -6,6 +6,7 @@ import shutil
 import typing as tp
 
 import requests
+from requests import auth as rauth
 
 from cardano_node_tests.utils import cluster_nodes
 from cardano_node_tests.utils import dbsync_queries
@@ -55,11 +56,11 @@ class SmashClient:
         self.base_url = f"http://localhost:{self.port}"
         self.auth = self._get_auth()
 
-    def _get_auth(self) -> requests.auth.HTTPBasicAuth | None:  # pyright: ignore [reportAttributeAccessIssue]
+    def _get_auth(self) -> rauth.HTTPBasicAuth | None:
         """Get Basic Auth credentials if configured."""
         admin = os.environ.get("SMASH_ADMIN", "admin")
         password = os.environ.get("SMASH_PASSWORD", "password")
-        return requests.auth.HTTPBasicAuth(admin, password) if admin and password else None  # pyright: ignore [reportAttributeAccessIssue]
+        return rauth.HTTPBasicAuth(admin, password) if admin and password else None
 
     def get_pool_metadata(self, pool_id: str, pool_meta_hash: str) -> PoolMetadata:
         """Fetch stake pool metadata from SMASH, returning a `PoolMetadata`."""


### PR DESCRIPTION
Refactored imports in helpers.py and smash_utils.py to use explicit collections.abc and requests.auth imports. This resolves pyright attribute access issues and improves type hinting compatibility.