### PR TITLE
Faketime work

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,12 @@ The preferred way is via `runner/runc.sh`, which builds a container image and ru
 ./runner/runc.sh ./runner/regression.sh
 ```
 
+Run with clock skew on one pool node:
+
+```sh
+./runner/runc.sh -- TIME_DRIFT_POOL=1 TIME_DRIFT_SPEC='+0 x1.008' ./runner/regression.sh
+```
+
 Run a specific test:
 
 ```sh
@@ -167,6 +173,9 @@ You can fine-tune test runs using these environment variables:
 | `TX_CENTRIFUGE_REV`| `tx-centrifuge` version (default: `bench/leios-11.0.1`) |
 | `PYTEST_ARGS`      | Extra options passed to pytest.                         |
 | `TEST_THREADS`     | Number of pytest workers (default: `20`).               |
+| `TIME_DRIFT_POOL`  | Pool (1-3) for libfaketime clock skew; unset = off.     |
+| `TIME_DRIFT_SPEC`  | libfaketime `FAKETIME` string, e.g. `+0 x1.008`.        |
+| `LIBFAKETIME_PATH` | Override path to `libfaketimeMT.so.1`.                  |
 
 ### 💡 Usage Examples
 
@@ -230,25 +239,6 @@ make start-cluster
 The default cluster variant is `local_fast`. Override with `TESTNET_VARIANT=<variant>`, e.g. `make cluster-scripts TESTNET_VARIANT=local_slow`.
 
 Keys and configs are stored under `/var/tmp/cardonnay-of-$USER/state-cluster0`.
-
-#### Time-Drift Resilience Testing (local only)
-
-Inject a gradual clock skew into a single pool node to observe network resilience.
-`libfaketime` is included automatically in the Nix dev shell.
-
-**Environment variables:**
-
-| Variable | Description |
-| --- | --- |
-| `TIME_DRIFT_POOL` | Which pool gets the skewed clock (1, 2, or 3); unset = no drift. |
-| `TIME_DRIFT_SPEC` | `libfaketime` `FAKETIME` string; `+0` = no offset at startup, `x<rate>` = clock speed multiplier. |
-| `LIBFAKETIME_PATH` | Override the `.so` path if not in the default location. |
-
-**Example:**
-
-```sh
-./runner/runc.sh -- TIME_DRIFT_POOL=1 TIME_DRIFT_SPEC='+0 x1.008' make start-cluster
-```
 
 ### Run Individual Tests
 

--- a/README.md
+++ b/README.md
@@ -231,6 +231,25 @@ The default cluster variant is `local_fast`. Override with `TESTNET_VARIANT=<var
 
 Keys and configs are stored under `/var/tmp/cardonnay-of-$USER/state-cluster0`.
 
+#### Time-Drift Resilience Testing (local only)
+
+Inject a gradual clock skew into a single pool node to observe network resilience.
+`libfaketime` is included automatically in the Nix dev shell.
+
+**Environment variables:**
+
+| Variable | Description |
+| --- | --- |
+| `TIME_DRIFT_POOL` | Which pool gets the skewed clock (1, 2, or 3); unset = no drift. |
+| `TIME_DRIFT_SPEC` | `libfaketime` `FAKETIME` string; `+0` = no offset at startup, `x<rate>` = clock speed multiplier. |
+| `LIBFAKETIME_PATH` | Override the `.so` path if not in the default location. |
+
+**Example:**
+
+```sh
+TIME_DRIFT_POOL=1 TIME_DRIFT_SPEC='+0 x1.008' make start-cluster
+```
+
 ### Run Individual Tests
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -37,6 +37,12 @@ The preferred way is via `runner/runc.sh`, which builds a container image and ru
 ./runner/runc.sh ./runner/regression.sh
 ```
 
+Run with clock skew on one pool node:
+
+```sh
+./runner/runc.sh -- TIME_DRIFT_POOL=1 TIME_DRIFT_SPEC='+0 x1.008' ./runner/regression.sh
+```
+
 Run a specific test:
 
 ```sh
@@ -180,6 +186,9 @@ You can fine-tune test runs using these environment variables:
 | `TX_FIREHOSE_REV`   | `tx-firehose` version (default: `leios-prototype`).      |
 | `PYTEST_ARGS`       | Extra options passed to pytest.                          |
 | `TEST_THREADS`      | Number of pytest workers (default: `20`).                |
+| `TIME_DRIFT_POOL`   | Pool (1-3) for libfaketime clock skew; unset = off.      |
+| `TIME_DRIFT_SPEC`   | libfaketime `FAKETIME` string, e.g. `+0 x1.008`.         |
+| `LIBFAKETIME_PATH`  | Override path to `libfaketimeMT.so.1`.                   |
 
 ### 💡 Usage Examples
 

--- a/README.md
+++ b/README.md
@@ -247,7 +247,7 @@ Inject a gradual clock skew into a single pool node to observe network resilienc
 **Example:**
 
 ```sh
-TIME_DRIFT_POOL=1 TIME_DRIFT_SPEC='+0 x1.008' make start-cluster
+./runner/runc.sh -- TIME_DRIFT_POOL=1 TIME_DRIFT_SPEC='+0 x1.008' make start-cluster
 ```
 
 ### Run Individual Tests

--- a/cardano_node_tests/utils/cluster_scripts.py
+++ b/cardano_node_tests/utils/cluster_scripts.py
@@ -99,9 +99,10 @@ fi
 def _inject_time_drift_hook(content: str, pool_num: int) -> str:
     """Inject a conditional clock-skew bash block into pool wrapper scripts.
 
-    Replaces the pre-run setup placeholder in the cardonnay template. Activated
-    only when TIME_DRIFT_POOL=<pool_num> and TIME_DRIFT_SPEC are set at cluster
-    start time. Default-off: unset env vars leave behaviour unchanged.
+    Appends after the pre-run setup placeholder in the cardonnay template, leaving
+    the placeholder itself intact. Activated only when TIME_DRIFT_POOL=<pool_num>
+    and TIME_DRIFT_SPEC are set at cluster start time. Default-off: unset env vars
+    leave behaviour unchanged.
 
     Raises:
         ValueError: When the pre-run setup placeholder is absent from the template.
@@ -112,7 +113,7 @@ def _inject_time_drift_hook(content: str, pool_num: int) -> str:
         raise ValueError(msg)
 
     hook = _TIME_DRIFT_HOOK.replace("%%POOL_NUM%%", str(pool_num))
-    return content.replace(marker, hook.rstrip("\n"), 1)
+    return content.replace(marker, f"{marker}\n{hook.rstrip(chr(10))}", 1)
 
 
 class CustomCardonnayScripts(cardonnay_local.LocalScripts):

--- a/cardano_node_tests/utils/cluster_scripts.py
+++ b/cardano_node_tests/utils/cluster_scripts.py
@@ -97,21 +97,22 @@ fi
 
 
 def _inject_time_drift_hook(content: str, pool_num: int) -> str:
-    """Inject a conditional clock-skew bash block before exec in pool wrapper scripts.
+    """Inject a conditional clock-skew bash block into pool wrapper scripts.
 
-    Activated only when TIME_DRIFT_POOL=<pool_num> and TIME_DRIFT_SPEC are set at
-    cluster start time. Default-off: unset env vars leave behaviour unchanged.
+    Replaces the pre-run setup placeholder in the cardonnay template. Activated
+    only when TIME_DRIFT_POOL=<pool_num> and TIME_DRIFT_SPEC are set at cluster
+    start time. Default-off: unset env vars leave behaviour unchanged.
 
     Raises:
-        ValueError: When the expected exec marker is absent from the template.
+        ValueError: When the pre-run setup placeholder is absent from the template.
     """
-    marker = "exec cardano-node run"
+    marker = "# --- Placeholder for any pre-run setup ---"
     if marker not in content:
-        msg = f"Cannot inject TIME_DRIFT hook: '{marker}' not found in pool{pool_num} wrapper."
+        msg = f"TIME_DRIFT hook: pre-run placeholder missing in pool{pool_num} wrapper."
         raise ValueError(msg)
 
     hook = _TIME_DRIFT_HOOK.replace("%%POOL_NUM%%", str(pool_num))
-    return content.replace(marker, f"{hook}{marker}", 1)
+    return content.replace(marker, hook.rstrip("\n"), 1)
 
 
 class CustomCardonnayScripts(cardonnay_local.LocalScripts):

--- a/cardano_node_tests/utils/cluster_scripts.py
+++ b/cardano_node_tests/utils/cluster_scripts.py
@@ -74,6 +74,46 @@ def get_testnet_variant_scriptdir2(*, testnet_variant: str) -> pl.Path:
     return scriptdir
 
 
+_TIME_DRIFT_HOOK = """\
+# TIME_DRIFT: activate clock skew on this pool when TIME_DRIFT_POOL=%%POOL_NUM%%
+if [[ -n "${TIME_DRIFT_POOL:-}" && -n "${TIME_DRIFT_SPEC:-}" \\
+      && "${TIME_DRIFT_POOL}" == "%%POOL_NUM%%" ]]; then
+  _ft_so="${LIBFAKETIME_PATH:-/usr/lib/x86_64-linux-gnu/faketime/libfaketimeMT.so.1}"
+  if [[ ! -f "$_ft_so" ]]; then
+    _ft_bin="$(command -v faketime 2>/dev/null || true)"
+    if [[ -n "$_ft_bin" ]]; then
+      _ft_so="$(dirname "$(dirname "$_ft_bin")")/lib/faketime/libfaketimeMT.so.1"
+    fi
+  fi
+  if [[ ! -f "$_ft_so" ]]; then
+    echo "[faketime] ERROR: libfaketimeMT.so.1 not found" >&2
+    exit 1
+  fi
+  export LD_PRELOAD="${LD_PRELOAD:+${LD_PRELOAD}:}$_ft_so"
+  export FAKETIME="${TIME_DRIFT_SPEC}"
+  echo "[faketime] pool%%POOL_NUM%%: LD_PRELOAD=$LD_PRELOAD FAKETIME=$FAKETIME" >&2
+fi
+"""
+
+
+def _inject_time_drift_hook(content: str, pool_num: int) -> str:
+    """Inject a conditional clock-skew bash block before exec in pool wrapper scripts.
+
+    Activated only when TIME_DRIFT_POOL=<pool_num> and TIME_DRIFT_SPEC are set at
+    cluster start time. Default-off: unset env vars leave behaviour unchanged.
+
+    Raises:
+        ValueError: When the expected exec marker is absent from the template.
+    """
+    marker = "exec cardano-node run"
+    if marker not in content:
+        msg = f"Cannot inject TIME_DRIFT hook: '{marker}' not found in pool{pool_num} wrapper."
+        raise ValueError(msg)
+
+    hook = _TIME_DRIFT_HOOK.replace("%%POOL_NUM%%", str(pool_num))
+    return content.replace(marker, f"{hook}{marker}", 1)
+
+
 class CustomCardonnayScripts(cardonnay_local.LocalScripts):
     """Scripts for starting local cluster.
 
@@ -186,6 +226,9 @@ class CustomCardonnayScripts(cardonnay_local.LocalScripts):
                     template_file=indir / "template-cardano-node-pool",
                     node_rec=node_rec,
                     instance_num=instance_num,
+                )
+                supervisor_script_content = _inject_time_drift_hook(
+                    content=supervisor_script_content, pool_num=node_rec.num
                 )
                 supervisor_script.unlink(missing_ok=True)
                 supervisor_script.write_text(f"{supervisor_script_content}\n", encoding="utf-8")

--- a/cardano_node_tests/utils/cluster_scripts.py
+++ b/cardano_node_tests/utils/cluster_scripts.py
@@ -74,6 +74,46 @@ def get_testnet_variant_scriptdir2(*, testnet_variant: str) -> pl.Path:
     return scriptdir
 
 
+_TIME_DRIFT_HOOK = """\
+# TIME_DRIFT: activate clock skew on this pool when TIME_DRIFT_POOL=%%POOL_NUM%%
+if [[ -n "${TIME_DRIFT_POOL:-}" && -n "${TIME_DRIFT_SPEC:-}" \\
+      && "${TIME_DRIFT_POOL}" == "%%POOL_NUM%%" ]]; then
+  _ft_so="${LIBFAKETIME_PATH:-/usr/lib/x86_64-linux-gnu/faketime/libfaketimeMT.so.1}"
+  if [[ ! -f "$_ft_so" ]]; then
+    _ft_bin="$(command -v faketime 2>/dev/null || true)"
+    if [[ -n "$_ft_bin" ]]; then
+      _ft_so="$(dirname "$(dirname "$_ft_bin")")/lib/faketime/libfaketimeMT.so.1"
+    fi
+  fi
+  if [[ ! -f "$_ft_so" ]]; then
+    exit 1
+  fi
+  export LD_PRELOAD="${LD_PRELOAD:+${LD_PRELOAD}:}$_ft_so"
+  export FAKETIME="${TIME_DRIFT_SPEC}"
+fi
+"""
+
+
+def _inject_time_drift_hook(content: str, pool_num: int) -> str:
+    """Inject a conditional clock-skew bash block into pool wrapper scripts.
+
+    Appends after the pre-run setup placeholder in the cardonnay template, leaving
+    the placeholder itself intact. Activated only when TIME_DRIFT_POOL=<pool_num>
+    and TIME_DRIFT_SPEC are set at cluster start time. Default-off: unset env vars
+    leave behaviour unchanged.
+
+    Raises:
+        ValueError: When the pre-run setup placeholder is absent from the template.
+    """
+    marker = "# --- Placeholder for any pre-run setup ---"
+    if marker not in content:
+        msg = f"TIME_DRIFT hook: pre-run placeholder missing in pool{pool_num} wrapper."
+        raise ValueError(msg)
+
+    hook = _TIME_DRIFT_HOOK.replace("%%POOL_NUM%%", str(pool_num))
+    return content.replace(marker, f"{marker}\n{hook.rstrip(chr(10))}", 1)
+
+
 class CustomCardonnayScripts(cardonnay_local.LocalScripts):
     """Scripts for starting local cluster.
 
@@ -186,6 +226,9 @@ class CustomCardonnayScripts(cardonnay_local.LocalScripts):
                     template_file=indir / "template-cardano-node-pool",
                     node_rec=node_rec,
                     instance_num=instance_num,
+                )
+                supervisor_script_content = _inject_time_drift_hook(
+                    content=supervisor_script_content, pool_num=node_rec.num
                 )
                 supervisor_script.unlink(missing_ok=True)
                 supervisor_script.write_text(f"{supervisor_script_content}\n", encoding="utf-8")

--- a/flake.nix
+++ b/flake.nix
@@ -39,6 +39,7 @@
                 nodePkgs.cardano-submit-api
                 nodePkgs.bech32
                 nodePkgs.tx-generator
+                pkgs.libfaketime
                 pkgs.bashInteractive
               ];
             };

--- a/flake.nix
+++ b/flake.nix
@@ -46,6 +46,7 @@
                 nodePkgs.bech32
                 nodePkgs.tx-generator
                 centrifugePkgs.tx-centrifuge
+                pkgs.libfaketime
                 pkgs.bashInteractive
               ];
             };


### PR DESCRIPTION
Skew one pool's clock against the rest of the cluster, so time-drift can be
tested locally.

A hook is appended after cardonnay's pre-run placeholder in the generated
`cardano-node-poolN` wrapper. It preloads libfaketime only when
`TIME_DRIFT_POOL` names that pool, so the other pools are untouched.

`TIME_DRIFT_POOL`, `TIME_DRIFT_SPEC` and `LIBFAKETIME_PATH` are documented in
the README, with a `runner/runc.sh` example.

Note `flake.nix` adds `pkgs.libfaketime` to the dev shell. Say if you would
rather that came from the host, as with `check_dev_env.sh`.
