### PR TITLE
feat: move artifacts copying to shell launchers

### DIFF
--- a/.source.dev
+++ b/.source.dev
@@ -53,7 +53,7 @@ fi
 
 # Set Cardano Node socket path and other environment variables
 export CARDANO_NODE_SOCKET_PATH="/var/tmp/cardonnay-of-${USER}/state-cluster${INSTANCE_NUM}/bft1.socket"
-export DEV_CLUSTER_RUNNING=true FORBID_RESTART=true NO_ARTIFACTS=true CLUSTERS_COUNT=1
+export DEV_CLUSTER_RUNNING=true FORBID_RESTART=true CLUSTERS_COUNT=1
 unset BOOTSTRAP_DIR
 
 mkdir -p "${CARDANO_NODE_SOCKET_PATH%/*}"

--- a/cardano_node_tests/tests/conftest.py
+++ b/cardano_node_tests/tests/conftest.py
@@ -51,13 +51,6 @@ def pytest_addoption(parser: tp.Any) -> None:
         help="Path to directory for storing coverage info",
     )
     parser.addoption(
-        artifacts.ARTIFACTS_BASE_DIR_ARG,
-        action="store",
-        type=helpers.check_dir_arg,
-        default="",
-        help="Path to directory for storing artifacts",
-    )
-    parser.addoption(
         "--skipall",
         action="store_true",
         default=False,
@@ -324,20 +317,19 @@ def testenv_setup_teardown(worker_id: str, request: FixtureRequest) -> tp.Genera
             _testnet_cleanup(pytest_root_tmp=pytest_root_tmp)
 
             if configuration.DEV_CLUSTER_RUNNING:
-                # Save cluster artifacts
-                artifacts_base_dir = request.config.getoption(artifacts.ARTIFACTS_BASE_DIR_ARG)
-                if artifacts_base_dir:
+                # Save cluster artifacts only when requested - it is not desirable to
+                # save them on every pytest invocation on a dev cluster
+                if configuration.FORCE_SAVE_CLUSTER_ARTIFACTS:
                     state_dir = cluster_nodes.get_cluster_env().state_dir
                     artifacts.save_cluster_artifacts(save_dir=pytest_root_tmp, state_dir=state_dir)
+                else:
+                    LOGGER.info("Not saving cluster artifacts of the dev cluster.")
             elif configuration.KEEP_CLUSTERS_RUNNING:
                 # Keep cluster instances running. Stopping them would need to be handled manually.
                 _save_all_cluster_instances_artifacts(cluster_manager_obj=cluster_manager_obj)
             else:
                 _save_all_cluster_instances_artifacts(cluster_manager_obj=cluster_manager_obj)
                 _stop_all_cluster_instances(cluster_manager_obj=cluster_manager_obj)
-
-            # Copy collected artifacts to dir specified by `--artifacts-base-dir`
-            artifacts.copy_artifacts(pytest_tmp_dir=pytest_root_tmp, pytest_config=request.config)
 
 
 @pytest.fixture(scope="session", autouse=True)

--- a/cardano_node_tests/utils/artifacts.py
+++ b/cardano_node_tests/utils/artifacts.py
@@ -13,7 +13,6 @@ from cardano_node_tests.utils import helpers
 LOGGER = logging.getLogger(__name__)
 
 CLI_COVERAGE_ARG = "--cli-coverage-dir"
-ARTIFACTS_BASE_DIR_ARG = "--artifacts-base-dir"
 CLUSTER_INSTANCE_ID_FILENAME = "cluster_instance_id.log"
 
 
@@ -135,20 +134,3 @@ def save_cluster_artifacts(*, save_dir: pl.Path, state_dir: pl.Path) -> None:
         # stay best-effort even when the setup I/O (reading the cluster instance id,
         # creating the destination dir) fails, not just the per-file copies.
         LOGGER.exception(f"Failed to save cluster artifacts from '{state_dir}'.")
-
-
-def copy_artifacts(*, pytest_tmp_dir: pl.Path, pytest_config: Config) -> None:
-    """Copy collected tests and cluster artifacts to artifacts dir."""
-    artifacts_base_dir = pytest_config.getoption(ARTIFACTS_BASE_DIR_ARG)
-    if not artifacts_base_dir:
-        return
-
-    artifacts_dir = pl.Path(artifacts_base_dir)
-
-    pytest_tmp_dir = pytest_tmp_dir.resolve()
-    if not pytest_tmp_dir.is_dir():
-        return
-
-    destdir = artifacts_dir / f"{pytest_tmp_dir.name}-{helpers.get_rand_str(8)}"
-    shutil.copytree(pytest_tmp_dir, destdir, symlinks=True)
-    LOGGER.info(f"Collected artifacts copied to '{destdir}'.")

--- a/cardano_node_tests/utils/configuration.py
+++ b/cardano_node_tests/utils/configuration.py
@@ -61,6 +61,12 @@ CLUSTERS_COUNT = CLUSTERS_COUNT or min(XDIST_WORKERS_COUNT, DEFAULT_MAX_CLUSTERS
 DEV_CLUSTER_RUNNING = helpers.is_truthy_env_var("DEV_CLUSTER_RUNNING")
 FORBID_RESTART = helpers.is_truthy_env_var("FORBID_RESTART")
 
+# Save cluster artifacts also when running on a dev cluster (has effect only together
+# with DEV_CLUSTER_RUNNING). By default the artifacts are not saved there, as a dev
+# cluster serves many pytest invocations and saving the artifacts (all the cluster logs
+# and configs) on each one is expensive. Set e.g. during node upgrade testing.
+FORCE_SAVE_CLUSTER_ARTIFACTS = helpers.is_truthy_env_var("FORCE_SAVE_CLUSTER_ARTIFACTS")
+
 BOOTSTRAP_DIR = helpers.get_env_path("BOOTSTRAP_DIR")
 if BOOTSTRAP_DIR and not (BOOTSTRAP_DIR / "genesis-shelley.json").exists():
     __msg = (

--- a/runner/copy_artifacts.sh
+++ b/runner/copy_artifacts.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [ "$#" -lt 1 ] || [ "$#" -gt 2 ]; then
+  echo "Usage: $0 <artifacts_dir> [newer_than_file]" >&2
+  exit 1
+fi
+
+artifacts_dir="$1"
+newer_than="${2:-}"
+
+# Report a problem with collecting the artifacts. The testrun artifacts are essential
+# for debugging failures, so on GitHub Actions the message is also emitted as a warning
+# annotation that is visible in the run summary.
+warn() {
+  echo "$1" >&2
+  if [ -n "${GITHUB_ACTIONS:-}" ]; then
+    echo "::warning::$1"
+  fi
+}
+
+# The `pytest-current` symlink points to the numbered pytest temp dir of the most
+# recent pytest run. It must be resolved right after the run finishes, before another
+# pytest invocation repoints it. Assumes pytest ran with its default basetemp under
+# the current temp dir (pytest resolves the temp dir the same way as Python's
+# `tempfile.gettempdir()`).
+tmp_root="${TMPDIR:-${TEMP:-${TMP:-/tmp}}}"
+pytest_current="${tmp_root}/pytest-of-${LOGNAME:-${USER:-$(id -un)}}/pytest-current"
+if [ ! -L "$pytest_current" ]; then
+  warn "Pytest temp dir symlink '$pytest_current' not found"
+  exit 1
+fi
+pytest_tmp="$(readlink -f "$pytest_current")"
+if [ ! -d "$pytest_tmp" ]; then
+  warn "Pytest temp dir '$pytest_tmp' not found"
+  exit 1
+fi
+
+# The guard must fail closed - `test -nt` would be true (and the copy allowed) if the
+# reference file didn't exist.
+if [ -n "$newer_than" ] && [ ! -e "$newer_than" ]; then
+  warn "Reference file '$newer_than' not found, not copying"
+  exit 1
+fi
+
+# When a pytest run dies before it creates its temp dir, the symlink still points
+# to the temp dir of a previous invocation. Refuse to copy a temp dir that predates
+# the given reference file, so a stale dir of an earlier run is not copied.
+if [ -n "$newer_than" ] && [ ! "$pytest_tmp" -nt "$newer_than" ]; then
+  warn "Pytest temp dir '$pytest_tmp' predates '$newer_than', not copying"
+  exit 1
+fi
+
+mkdir -p "$artifacts_dir" || { warn "Cannot create $artifacts_dir"; exit 1; }
+
+# Copy to a hidden staging dir and rename it when the copy is finished, so consumers
+# of the artifacts dir cannot see the tree while it is still being copied. The `mktemp`
+# suffix also keeps repeated copies of a same-numbered pytest temp dir from clashing.
+staging_dir="$(mktemp -d "${artifacts_dir}/.$(basename "$pytest_tmp")-XXXXXXXX")"
+copy_rc=0
+cp -a "$pytest_tmp/." "$staging_dir" || copy_rc="$?"
+
+if [ "$copy_rc" -ne 0 ] && [ -z "$(ls -A "$staging_dir")" ]; then
+  # Nothing was copied. Don't publish the empty dir - it would defeat the
+  # "no artifacts found" detection of the artifacts dir consumers.
+  rm -rf "$staging_dir"
+  warn "Failed to copy '$pytest_tmp'"
+  exit 1
+fi
+
+staging_name="$(basename "$staging_dir")"
+destdir="${artifacts_dir}/${staging_name#.}"
+mv "$staging_dir" "$destdir"
+
+if [ "$copy_rc" -ne 0 ]; then
+  # A partial copy is better than no artifacts at all
+  warn "Some content of '$pytest_tmp' was not copied to '$destdir'"
+  exit 1
+fi
+echo "Collected artifacts copied to '$destdir'."

--- a/runner/grep_errors.sh
+++ b/runner/grep_errors.sh
@@ -9,4 +9,8 @@ artifacts_dir="$1"
 output_file="$2"
 
 cd "$artifacts_dir" || { echo "Cannot switch to $artifacts_dir" >&2; exit 1; }
-grep -r --include "*.stdout" --include "*.stderr" -Ei ":error:|failed|failure" . > "$output_file" || :
+# Hidden dirs are skipped - a hidden dir can be a leftover staging dir of an
+# interrupted `copy_artifacts.sh` run, holding an incomplete copy of the artifacts.
+# The `.?*` glob (unlike `.*`) doesn't match the `.` start dir, that GNU grep would
+# otherwise exclude as well.
+grep -r --exclude-dir=".?*" --include "*.stdout" --include "*.stderr" -Ei ":error:|failed|failure" . > "$output_file" || :

--- a/runner/node_upgrade_pytest.sh
+++ b/runner/node_upgrade_pytest.sh
@@ -81,16 +81,20 @@ if [ "$1" = "step1" ]; then
   # run smoke tests
   printf "STEP1 tests: %(%H:%M:%S)T\n" -1
   retval=0
-  pytest \
+  pytest_stamp="$(mktemp)" || exit 6
+  FORCE_SAVE_CLUSTER_ARTIFACTS=true pytest \
     cardano_node_tests \
     -n "$TEST_THREADS" \
     -m "smoke or upgrade_step1" \
-    --artifacts-base-dir="$ARTIFACTS_DIR" \
     --cli-coverage-dir="$COVERAGE_DIR" \
     --alluredir="$reports_dir" \
     --html="$WORKDIR/testrun-report-step1.html" \
     --self-contained-html \
     || retval="$?"
+
+  # copy artifacts collected in the pytest temp dir
+  ./runner/copy_artifacts.sh "$ARTIFACTS_DIR" "$pytest_stamp" || :
+  rm -f "$pytest_stamp"
 
   # stop local cluster if tests failed unexpectedly
   [ "$retval" -le 1 ] || "$cluster_scripts_dir/stop-cluster"
@@ -239,16 +243,20 @@ elif [ "$1" = "step2" ]; then
   # run smoke tests
   printf "STEP2 tests: %(%H:%M:%S)T\n" -1
   retval=0
-  pytest \
+  pytest_stamp="$(mktemp)" || exit 6
+  FORCE_SAVE_CLUSTER_ARTIFACTS=true pytest \
     cardano_node_tests \
     -n "$TEST_THREADS" \
     -m "smoke or upgrade_step2" \
-    --artifacts-base-dir="$ARTIFACTS_DIR" \
     --cli-coverage-dir="$COVERAGE_DIR" \
     --alluredir="$reports_dir" \
     --html="$WORKDIR/testrun-report-step2.html" \
     --self-contained-html \
     ||retval="$?"
+
+  # copy artifacts collected in the pytest temp dir
+  ./runner/copy_artifacts.sh "$ARTIFACTS_DIR" "$pytest_stamp" || :
+  rm -f "$pytest_stamp"
 
   # stop local cluster if tests failed unexpectedly
   [ "$retval" -le 1 ] || "$cluster_scripts_dir/stop-cluster"
@@ -396,16 +404,20 @@ elif [ "$1" = "step3" ]; then
   # Run smoke tests
   printf "STEP3 tests: %(%H:%M:%S)T\n" -1
   retval=0
-  pytest \
+  pytest_stamp="$(mktemp)" || exit 6
+  FORCE_SAVE_CLUSTER_ARTIFACTS=true pytest \
     cardano_node_tests \
     -n "$TEST_THREADS" \
     -m "smoke or upgrade_step3" \
-    --artifacts-base-dir="$ARTIFACTS_DIR" \
     --cli-coverage-dir="$COVERAGE_DIR" \
     --alluredir="$reports_dir" \
     --html="$WORKDIR/testrun-report-step3.html" \
     --self-contained-html \
     ||retval="$?"
+
+  # copy artifacts collected in the pytest temp dir
+  ./runner/copy_artifacts.sh "$ARTIFACTS_DIR" "$pytest_stamp" || :
+  rm -f "$pytest_stamp"
 
   # create results archive for step3
   ./runner/create_results.sh "$reports_dir" "$WORKDIR" allure-results-step3

--- a/runner/regression.sh
+++ b/runner/regression.sh
@@ -399,12 +399,16 @@ nix develop --accept-flake-config .#testenv --command bash -c '
   assert_cmds_available "${_req_cmds[@]}" || exit 3
 
   retval=0
+  pytest_stamp="$(mktemp)" || exit 3
   ./runner/run_tests.sh "${RUN_TARGET:-"tests"}" || retval="$?"
   df -h .
   echo "::endgroup::"  # end group for "Testrun"
 
   echo "::group::Collect artifacts & teardown cluster"
   printf "start: %(%H:%M:%S)T\n" -1
+  # copy artifacts collected in the pytest temp dir
+  ./runner/copy_artifacts.sh "$ARTIFACTS_DIR" "$pytest_stamp" || :
+  rm -f "$pytest_stamp"
   ./runner/cli_coverage.sh "$COVERAGE_DIR" "${WORKDIR}/cli_coverage.json" || :
   ./runner/reqs_coverage.sh "$ARTIFACTS_DIR" "${WORKDIR}/requirements_coverage.json" || :
   exit "$retval"

--- a/runner/run_tests.sh
+++ b/runner/run_tests.sh
@@ -10,11 +10,9 @@
 #
 # Env vars:
 #   TESTS_DIR: directory with tests to run (default: cardano_node_tests/)
-#   ARTIFACTS_DIR: directory to save artifacts into (default: run_workdir/artifacts)
 #   COVERAGE_DIR: directory to save CLI coverage data into (default: run_workdir/cli_coverage)
 #   REPORTS_DIR: directory to save Allure test reports into (default: run_workdir/reports)
 #   MARKEXPR: pytest mark expression to filter tests, without the `-m` flag
-#   NO_ARTIFACTS: if set to true, do not save artifacts
 #   PYTEST_ARGS: additional args to pass to pytest
 #   CI_ARGS: additional args to pass to pytest (for CI runs)
 #   TEST_THREADS: number of pytest workers (defaults vary per target)
@@ -26,20 +24,14 @@
 # Notes:
 # - If PYTEST_ARGS is provided, we disable cleanup and the initial "skip all" pass.
 # - If DESELECT_FROM_FILE is provided, we disable the initial "skip all" pass.
-# - If NO_ARTIFACTS is not set, we save artifacts under ARTIFACTS_DIR.
 # - HTML/JUnit reports are generated only when PYTEST_ARGS is unset.
 
 set -Eeuo pipefail
 
 # Defaults
 TESTS_DIR="${TESTS_DIR:-cardano_node_tests/}"
-ARTIFACTS_DIR="${ARTIFACTS_DIR:-run_workdir/artifacts}"
 COVERAGE_DIR="${COVERAGE_DIR:-run_workdir/cli_coverage}"
 REPORTS_DIR="${REPORTS_DIR:-run_workdir/reports}"
-
-_top_dir="$(cd "$(dirname "$0")/.." && pwd)" || { echo "Cannot determine top dir, exiting." >&2; exit 1; }
-# shellcheck disable=SC1091
-. "$_top_dir/scripts/common.sh"
 
 # Helpers
 usage() {
@@ -68,7 +60,7 @@ run_pytest() {
 }
 
 ensure_dirs() {
-  mkdir -p "$ARTIFACTS_DIR" "$COVERAGE_DIR" "$REPORTS_DIR"
+  mkdir -p "$COVERAGE_DIR" "$REPORTS_DIR"
 }
 
 # Set common env vars that affect test runs.
@@ -102,14 +94,6 @@ compute_common_args() {
     markexpr_arr=( -m "$MARKEXPR" )
   else
     markexpr_arr=()
-  fi
-
-  # It may not be always necessary to save artifacts, e.g. when running tests on local cluster
-  # on local machine.
-  if is_truthy "${NO_ARTIFACTS:-}"; then
-    artifacts_arr=()
-  else
-    artifacts_arr=( "--artifacts-base-dir=$ARTIFACTS_DIR" )
   fi
 
   # Test run report args only when PYTEST_ARGS is unset.
@@ -152,7 +136,6 @@ run_real_tests() {
     "${markexpr_arr[@]}" \
     "${deselect_from_file_arr[@]}" \
     -n "${TEST_THREADS}" \
-    "${artifacts_arr[@]}" \
     --cli-coverage-dir="$COVERAGE_DIR" \
     --alluredir="$REPORTS_DIR" \
     "${testrun_report_arr[@]}" \

--- a/runner/status_dbs.sh
+++ b/runner/status_dbs.sh
@@ -15,17 +15,21 @@ mkdir -p "$output_dir" || { echo "Cannot create $output_dir" >&2; exit 1; }
 # The status database was copied from the pytest temp dir to the artifacts dir together
 # with the other testing artifacts. Copy the database of each pytest run to the output
 # dir. The output databases are numbered in the run order (e.g. one per node upgrade
-# step) - the `pytest-N` component of the artifacts subdir names cannot be used directly,
-# as the number comes from pytest's numbered basetemp counter that is shared by all
-# pytest invocations in a testrun, including those that don't collect artifacts.
-# Copy also the WAL sidecar, which is present when database connections were still open
-# during artifacts collection - without it the database copy would miss the
-# not-yet-checkpointed writes. The `-shm` file is skipped on purpose, it is transient
-# and not needed for an offline copy.
+# step). The run order is derived from the database modification times (preserved by
+# the copy to the artifacts dir) - the `pytest-N` component of the artifacts subdir
+# names cannot be used, as pytest's numbered basetemp counter is per temp root and is
+# shared by all pytest invocations that use the root, including invocations whose
+# artifacts are not collected. The mtime ordering holds no matter how the launcher
+# distributes the pytest invocations over temp roots.
+# Copy also the WAL sidecar. As artifacts are copied only after pytest exits, the WAL
+# is normally checkpointed into the database and the sidecar removed. It can still be
+# left behind when the run was killed - copy it in that case, otherwise the database
+# copy would miss the not-yet-checkpointed writes. The `-shm` file is skipped on
+# purpose, it is transient and not needed for an offline copy.
 found=0
 num=0
 while read -r db; do
-  # Skip the unexpanded pattern when the glob didn't match anything
+  # The file could disappear before it is copied
   [ -f "$db" ] || continue
   num=$((num + 1))
   cp "$db" "${output_dir}/cm-status-${num}.db" \
@@ -35,7 +39,12 @@ while read -r db; do
     cp "${db}-wal" "${output_dir}/cm-status-${num}.db-wal" \
       || echo "Failed to copy ${db}-wal" >&2
   fi
-done < <(printf '%s\n' "$artifacts_dir"/pytest-*/cm-status.db | sort -V)
+done < <(
+  # Hidden dirs are excluded explicitly - a hidden dir can be a leftover staging dir
+  # of an interrupted `copy_artifacts.sh` run
+  find "$artifacts_dir" -mindepth 2 -maxdepth 2 ! -path '*/.*' \
+    -path '*/pytest-*/cm-status.db' -printf '%T@ %p\n' | sort -n | cut -d' ' -f2-
+)
 
 if [ "$found" -eq 0 ]; then
   echo "No status database copied from $artifacts_dir" >&2

--- a/runner/status_dbs.sh
+++ b/runner/status_dbs.sh
@@ -28,7 +28,7 @@ mkdir -p "$output_dir" || { echo "Cannot create $output_dir" >&2; exit 1; }
 # purpose, it is transient and not needed for an offline copy.
 found=0
 num=0
-while read -r db; do
+while IFS= read -r db; do
   # The file could disappear before it is copied
   [ -f "$db" ] || continue
   num=$((num + 1))
@@ -43,7 +43,7 @@ done < <(
   # Hidden dirs are excluded explicitly - a hidden dir can be a leftover staging dir
   # of an interrupted `copy_artifacts.sh` run
   find "$artifacts_dir" -mindepth 2 -maxdepth 2 ! -path '*/.*' \
-    -path '*/pytest-*/cm-status.db' -printf '%T@ %p\n' | sort -n | cut -d' ' -f2-
+    -path '*/pytest-*/cm-status.db' -printf '%T@\t%p\n' | sort -n | cut -f2-
 )
 
 if [ "$found" -eq 0 ]; then

--- a/scripts/setup_test_env.sh
+++ b/scripts/setup_test_env.sh
@@ -69,7 +69,6 @@ export CARDANO_NODE_SOCKET_PATH="$WORKDIR/state-cluster0/bft1.socket"
 export TMPDIR="$WORKDIR/tmp"
 export DEV_CLUSTER_RUNNING=true
 export FORBID_RESTART=true
-export NO_ARTIFACTS=true
 export CLUSTERS_COUNT=1
 export COMMAND_ERA="${COMMAND_ERA:-}"
 export PROTOCOL_VERSION="${PROTOCOL_VERSION:-}"


### PR DESCRIPTION
Full test runs are launched only through the CI shell launchers, so copying of the collected artifacts doesn't need to happen inside the pytest session anymore. Remove the `--artifacts-base-dir` pytest option together with the Python-side copying, and copy the pytest temp dir to the artifacts dir in the CI scripts instead, after pytest exits. This way the artifacts are collected also when the pytest process is killed, e.g. on session timeout.

The new runner/copy_artifacts.sh resolves the `pytest-current` symlink, refuses to copy a temp dir that predates the current pytest run, and copies through a hidden staging dir so that consumers of the artifacts dir cannot see a partially copied tree.

Saving of cluster artifacts on a dev cluster is expensive and now opt-in via the new FORCE_SAVE_CLUSTER_ARTIFACTS env variable, set only for the node upgrade testing steps that need it. The NO_ARTIFACTS env variable is no longer needed and was removed.

The status databases are now numbered by their modification time, as the pytest temp dir numbers cannot be relied on for run ordering.