### PR TITLE
fix: guard all check_ functions on HAS_DBSYNC

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,6 +49,10 @@ Unit tests for the framework components are organized under:
    ./ai_run.sh make lint
    ```
 
+### Documentation
+
+When adding to `README.md`, keep it short, with no lengthy explanations. Instead of documenting every detail, the user-facing functionality (`make ...` targets, scripts in the runner, etc.) should handle incorrect usage itself and guide the user. Detailed guidance for AI agents belongs in `agent_docs/`.
+
 ---
 
 ## Running Tests

--- a/agent_docs/dbsync.md
+++ b/agent_docs/dbsync.md
@@ -1,0 +1,23 @@
+# db-sync Checks in Tests
+
+Many E2E tests can verify their results against cardano-db-sync in addition to node queries. Availability of db-sync is optional, and tests need to handle both cases.
+
+## Markers
+
+- `@pytest.mark.dbsync` - add to any test that performs optional db-sync checks (i.e. calls `dbsync_utils.check_...` functions). The test runs even when db-sync is not available; only the db-sync checks are skipped.
+- `@pytest.mark.needs_dbsync` - add to a test that depends on db-sync. The test is automatically skipped when db-sync is not available. The `dbsync` marker is added automatically to such tests, don't add it manually.
+
+## Writing the Checks
+
+Use the `check_...` functions from `cardano_node_tests/utils/dbsync_utils.py` (e.g. `dbsync_utils.check_tx`, `dbsync_utils.check_drep_registration`). They are the high-level interface to db-sync meant to be called directly from tests. Every `check_...` function checks db-sync availability and returns early (with `None`) when db-sync is not available, so a plain call is enough - don't wrap it in `if configuration.HAS_DBSYNC:`.
+
+```python
+tx_db_record = dbsync_utils.check_tx(cluster_obj=cluster, tx_raw_output=tx_output)
+if tx_db_record:
+    # additional assertions on the transaction record
+    ...
+```
+
+Keep db-sync related code in the test body to a minimum. If a test needs non-trivial db-sync logic, add a reusable `check_...` function to `dbsync_utils` instead. Every new `check_...` function must return early when db-sync is not available - either directly (start with `if not configuration.HAS_DBSYNC:`) or via a getter it calls first (as `check_tx` does via `get_tx`). Avoid calling lower-level building blocks (`dbsync_queries`, `get_...` helpers without the guard) from tests directly - prefer adding a `check_...` function. Some older tests call `dbsync_queries` directly, but only under the `needs_dbsync` marker or an explicit `if configuration.HAS_DBSYNC:` guard.
+
+See `_build_spend_locked_txin` in `cardano_node_tests/tests/tests_plutus/spend_build.py:370-375` for a real example (`check_tx` result tested with `if`, with `check_plutus_costs` nested inside).

--- a/agent_docs/new_e2e_tests.md
+++ b/agent_docs/new_e2e_tests.md
@@ -16,6 +16,20 @@ Cache expensive fixture resources (addresses, keys, scripts) to avoid recreation
 
 Reuse expensive setups (governance actions, etc.) across multiple scenarios using pytest-subtests. Open `agent_docs/subtests.md` and follow the instructions.
 
+## db-sync Checks
+
+When test results (transactions, registrations, governance actions) can be verified in db-sync, open `agent_docs/dbsync.md` and follow the instructions.
+
+## Pytest Markers
+
+Mark tests based on where they can run and how long they take:
+
+- `@pytest.mark.testnets` - add when the test can run on public testnets like Preview. The test cannot depend on crossing an epoch boundary - waiting for the next epoch would take too long there.
+- `@pytest.mark.long` - add when the test runs for a long time even on local testnets, typically because it crosses several epoch boundaries.
+- `@pytest.mark.smoke` - add when the test finishes under 1 minute. Smoke tests are selected for quick regression and upgrade testing runs, so unmarked fast tests silently drop out of those runs.
+
+The full list of markers is in `pyproject.toml`. For db-sync related markers, see `agent_docs/dbsync.md`. The `xdist_group` marker is described in `agent_docs/subtests.md`. The `xdist_split` marker spreads tests that lock the same scarce cluster resource across xdist workers - it is orthogonal to `long` (wallclock).
+
 ## Summary Checklist
 
 When writing a new E2E test, ensure:
@@ -25,5 +39,7 @@ When writing a new E2E test, ensure:
 - [ ] Test has comprehensive docstring with steps and expectations
 - [ ] Type hints are included for all parameters
 - [ ] `common.get_test_id(cluster)` is used for unique naming
+- [ ] Appropriate pytest markers are set (see Pytest Markers above)
+- [ ] db-sync checks are added where results are verifiable in db-sync (see `agent_docs/dbsync.md`)
 - [ ] Code follows Google Python Style Guide
 - [ ] Linters pass

--- a/cardano_node_tests/tests/test_pools.py
+++ b/cardano_node_tests/tests/test_pools.py
@@ -27,7 +27,6 @@ from cardano_node_tests.tests import common
 from cardano_node_tests.tests import issues
 from cardano_node_tests.utils import cluster_nodes
 from cardano_node_tests.utils import clusterlib_utils
-from cardano_node_tests.utils import configuration
 from cardano_node_tests.utils import dbsync_utils
 from cardano_node_tests.utils import helpers
 from cardano_node_tests.utils import locking
@@ -766,18 +765,17 @@ class TestStakePool:
         # Check `transaction view` command
         tx_view.check_tx_view(cluster_obj=cluster, tx_raw_output=pool_creation_out.tx_raw_output)
 
-        # Check dbsync `PoolOfflineData` table
-        if configuration.HAS_DBSYNC:
-            pool_params = cluster.g_query.get_pool_state(
-                stake_pool_id=pool_creation_out.stake_pool_id
-            ).pool_params
+        pool_params = cluster.g_query.get_pool_state(
+            stake_pool_id=pool_creation_out.stake_pool_id
+        ).pool_params
 
-            def _query_func():
-                dbsync_utils.check_pool_off_chain_data(
-                    ledger_pool_data=pool_params, pool_id=pool_creation_out.stake_pool_id
-                )
+        # Check dbsync `OffChainPoolData` table
+        def _query_func():
+            dbsync_utils.check_pool_off_chain_data(
+                ledger_pool_data=pool_params, pool_id=pool_creation_out.stake_pool_id
+            )
 
-            dbsync_utils.retry_query(query_func=_query_func, timeout=360)
+        dbsync_utils.retry_query(query_func=_query_func, timeout=360)
 
     @allure.link(helpers.get_vcs_link())
     @pytest.mark.testnets
@@ -852,24 +850,23 @@ class TestStakePool:
             build_method=clusterlib_utils.BuildMethods.BUILD_RAW,
         )
 
-        # Check dbsync `PoolOffChainFetchError` table
+        pool_params = cluster.g_query.get_pool_state(
+            stake_pool_id=pool_creation_out.stake_pool_id
+        ).pool_params
+
+        # Check dbsync `OffChainPoolFetchError` table
         # since the metadata url is invalid the dbsync dedicated thread will not fetch the data
         # and will insert an error on the specific table
         # https://github.com/IntersectMBO/cardano-db-sync/blob/master/doc/pool-offchain-data.md
-        if configuration.HAS_DBSYNC:
-            pool_params = cluster.g_query.get_pool_state(
-                stake_pool_id=pool_creation_out.stake_pool_id
-            ).pool_params
-
-            def _query_func():
-                dbsync_utils.check_pool_off_chain_fetch_error(
-                    ledger_pool_data=pool_params, pool_id=pool_creation_out.stake_pool_id
-                )
-
-            dbsync_utils.retry_query(query_func=_query_func, timeout=360)
-            smash_utils.check_smash_pool_errors(
-                pool_id=pool_creation_out.stake_pool_id, pool_metadata_hash=pool_metadata_hash
+        def _query_func():
+            dbsync_utils.check_pool_off_chain_fetch_error(
+                ledger_pool_data=pool_params, pool_id=pool_creation_out.stake_pool_id
             )
+
+        dbsync_utils.retry_query(query_func=_query_func, timeout=360)
+        smash_utils.check_smash_pool_errors(
+            pool_id=pool_creation_out.stake_pool_id, pool_metadata_hash=pool_metadata_hash
+        )
 
     @allure.link(helpers.get_vcs_link())
     @common.PARAM_BUILD_METHOD_NO_EST

--- a/cardano_node_tests/utils/dbsync_utils.py
+++ b/cardano_node_tests/utils/dbsync_utils.py
@@ -79,11 +79,15 @@ def get_address_reward(
 
 def check_address_reward(
     address: str, *, epoch_from: int = 0, epoch_to: int = 99999999
-) -> dbsync_types.RewardRecord:
+) -> dbsync_types.RewardRecord | None:
     """Check reward data for stake address in db-sync.
 
     The `epoch_from` and `epoch_to` are epochs where the reward can be spent.
+    Return None if db-sync is not available.
     """
+    if not configuration.HAS_DBSYNC:
+        return None
+
     reward = get_address_reward(address=address, epoch_from=epoch_from, epoch_to=epoch_to)
     if not reward:
         return reward
@@ -763,8 +767,14 @@ def check_pool_data(  # noqa: C901
 
 def check_pool_off_chain_data(
     *, ledger_pool_data: dict, pool_id: str
-) -> dbsync_queries.PoolOffChainDataDBRow:
-    """Check comparison for pool off chain data between ledger and db-sync."""
+) -> dbsync_queries.PoolOffChainDataDBRow | None:
+    """Check comparison for pool off chain data between ledger and db-sync.
+
+    Return None if db-sync is not available.
+    """
+    if not configuration.HAS_DBSYNC:
+        return None
+
     db_pool_off_chain_data = list(dbsync_queries.query_off_chain_pool_data(pool_id_bech32=pool_id))
     if not db_pool_off_chain_data:
         msg = f"no off chain data for pool {pool_id}"
@@ -784,8 +794,14 @@ def check_pool_off_chain_data(
 
 def check_pool_off_chain_fetch_error(
     *, ledger_pool_data: dict, pool_id: str
-) -> dbsync_queries.PoolOffChainFetchErrorDBRow:
-    """Check expected error on `PoolOffChainFetchError`."""
+) -> dbsync_queries.PoolOffChainFetchErrorDBRow | None:
+    """Check expected error on `OffChainPoolFetchError`.
+
+    Return None if db-sync is not available.
+    """
+    if not configuration.HAS_DBSYNC:
+        return None
+
     db_pool_off_chain_fetch_error = list(
         dbsync_queries.query_off_chain_pool_fetch_error(pool_id_bech32=pool_id)
     )
@@ -811,7 +827,13 @@ def check_pool_off_chain_fetch_error(
 def check_plutus_cost(
     *, redeemer_record: dbsync_types.RedeemerRecord, cost_record: dict[str, tp.Any]
 ) -> None:
-    """Compare cost of Plutus script with data from db-sync."""
+    """Compare cost of Plutus script with data from db-sync.
+
+    The check is a no-op when db-sync is not available.
+    """
+    if not configuration.HAS_DBSYNC:
+        return
+
     errors = []
     if redeemer_record.unit_steps != cost_record["executionUnits"]["steps"]:
         errors.append(
@@ -833,7 +855,13 @@ def check_plutus_cost(
 def check_plutus_costs(
     *, redeemer_records: list[dbsync_types.RedeemerRecord], cost_records: list[dict[str, tp.Any]]
 ) -> None:
-    """Compare cost of multiple Plutus scripts with data from db-sync."""
+    """Compare cost of multiple Plutus scripts with data from db-sync.
+
+    The check is a no-op when db-sync is not available.
+    """
+    if not configuration.HAS_DBSYNC:
+        return
+
     # Sort records first by total cost, second by hash
     sorted_costs = sorted(
         cost_records,
@@ -1807,6 +1835,8 @@ def check_column_condition(
 ) -> None:
     """Validate that all/none rows meet a column condition atomically.
 
+    The check is a no-op when db-sync is not available.
+
     Args:
         table: Table to check
         column: Column to validate
@@ -1814,6 +1844,9 @@ def check_column_condition(
         expected_count: Require exactly this many matches (default: all must match)
         lock_timeout: Max wait for table lock
     """
+    if not configuration.HAS_DBSYNC:
+        return
+
     with dbsync_queries.db_transaction():
         # Get count of rows meeting condition
         matching_count = dbsync_queries.query_rows_count(

--- a/cardano_node_tests/utils/smash_utils.py
+++ b/cardano_node_tests/utils/smash_utils.py
@@ -8,6 +8,7 @@ import typing as tp
 from requests import auth as rauth
 
 from cardano_node_tests.utils import cluster_nodes
+from cardano_node_tests.utils import configuration
 from cardano_node_tests.utils import dbsync_queries
 from cardano_node_tests.utils import http_client
 
@@ -151,6 +152,8 @@ class SmashManager:
 
 def is_smash_running() -> bool:
     """Check if `cardano-smash-server` service is running."""
+    if not configuration.HAS_SMASH:
+        return False
     if not shutil.which("cardano-smash-server"):
         return False
     return cluster_nodes.services_status(service_names=["smash"])[0].status == "RUNNING"


### PR DESCRIPTION
All `check_...` functions in `dbsync_utils` are the high-level interface to db-sync meant to be called directly from tests, but six of them (`check_address_reward`, `check_pool_off_chain_data`, `check_pool_off_chain_fetch_error`, `check_plutus_cost`, `check_plutus_costs`, `check_column_condition`) were missing the `HAS_DBSYNC` guard and would fail when db-sync is not available. All of them now return early, so tests no longer need to wrap the calls in `if configuration.HAS_DBSYNC:`. The now redundant wrappers were removed from `test_pools.py`, and `is_smash_running` returns early when smash is not configured.

Also add AI agent documentation for the above: `agent_docs/dbsync.md` describes the db-sync markers and the pattern of calling `check_...` functions unguarded, and `agent_docs/new_e2e_tests.md` newly documents the `testnets`, `long` and `smoke` markers. AGENTS.md instructs to keep README.md brief and let user-facing tooling handle incorrect usage.