### PR TITLE
fix: stale db-sync table names and dead else

### DIFF
--- a/cardano_node_tests/utils/dbsync_utils.py
+++ b/cardano_node_tests/utils/dbsync_utils.py
@@ -1902,9 +1902,8 @@ def check_epoch_state(*, epoch_no: int, txid: str, action_type: ActionTypes) -> 
         es_constitution_id = epoch_state_data[0].constitution_id
         tx_constitution_id = dbsync_constitution_info.id
         assert es_constitution_id == tx_constitution_id, (
-            f"Committee id mismatch between epoch_state {es_constitution_id} "
-            f"and committee table {tx_constitution_id}."
+            f"Constitution id mismatch between epoch_state {es_constitution_id} "
+            f"and constitution table {tx_constitution_id}."
         )
     else:
-        msg = f"Unsupported action type for epoch state check: {action_type.value}"
-        raise ValueError(msg)
+        tp.assert_never(action_type)

--- a/doc/smash/smash_tests_and_debugging_examples.md
+++ b/doc/smash/smash_tests_and_debugging_examples.md
@@ -570,12 +570,12 @@ For hash `f2b553839dee1ad1d16127179d4378a0c06a1fddce83409ad4b6f10b65bad395`, the
 
 It seems that for this pool, 4 metadata references have been registered (from **pool_metadata_ref** table), but 3 of them failed and only one succeeded.
 
-The **pool_offline_data** table shows different metadata - the one that matches the record with `id=290` in **pool_metadata_ref**
+The **off_chain_pool_data** table (previously called **pool_offline_data**) shows different metadata - the one that matches the record with `id=290` in **pool_metadata_ref**
 (homepage <https://llcj.com/> differs from JSON presented above <https://git.io/JUNOy>)
 
 
 ```sql
-select id, pool_id, json from pool_offline_data where pool_id=103;
+select id, pool_id, json from off_chain_pool_data where pool_id=103;
 ```
 
 | id  | pool_id | json


### PR DESCRIPTION
Use tp.assert_never for the exhaustiveness check in check_epoch_state instead of an unreachable else branch, so adding a new ActionTypes member fails type checking. Fix the copy-pasted "Committee id mismatch" wording in the constitution assert message.

Update the pool_offline_data table name to off_chain_pool_data (renamed in db-sync 13.2) in the SMASH debugging examples.