### PR TITLE
fix(tests): tolerate new cardano-cli 'Missing:' spacing

### DIFF
--- a/cardano_node_tests/tests/test_env_network_id.py
+++ b/cardano_node_tests/tests/test_env_network_id.py
@@ -2,6 +2,7 @@
 
 import logging
 import os
+import re
 import time
 import typing as tp
 
@@ -16,7 +17,7 @@ from cardano_node_tests.utils import logfiles
 
 LOGGER = logging.getLogger(__name__)
 
-MISSING_ARG_ERR = "Missing: (--mainnet | --testnet-magic NATURAL)"
+MISSING_ARG_ERR = r"Missing: +\(--mainnet \| --testnet-magic NATURAL\)"
 
 POOL_ID = "pool1dlyzfcl25qwjjmpmp47dulwmp2fej8tw4qcezcnkdlsjkak5n89"
 STAKE_ADDR = "stake_test1uzy5myemjnne3gr0jp7yhtznxx2lvx4qgv730jktsu46v5gaw7rmt"
@@ -55,11 +56,11 @@ def _setup_scenarios(
 
 def _assert_expected_err(env_scenario: str, arg_scenario: str, err_msg: str) -> None:
     """Check expected error message based on scenarios."""
-    expected_err = "HandshakeError (Refused NodeToClient"
+    expected_err = re.escape("HandshakeError (Refused NodeToClient")
     if arg_scenario == "arg_missing" and env_scenario == "env_missing":
         expected_err = MISSING_ARG_ERR
 
-    assert expected_err in err_msg, f"{expected_err} not in {err_msg}"
+    assert re.search(expected_err, err_msg), f"`{expected_err}` not found in `{err_msg}`"
 
 
 @pytest.fixture
@@ -71,7 +72,7 @@ def skip_on_no_env(
     try:
         cluster.g_query.get_tip()
     except clusterlib.CLIError as exc:
-        if MISSING_ARG_ERR in str(exc):
+        if re.search(MISSING_ARG_ERR, str(exc)):
             pytest.skip("Env variable `CARDANO_NODE_NETWORK_ID` is not available")
         raise
 

--- a/cardano_node_tests/tests/test_socket_path.py
+++ b/cardano_node_tests/tests/test_socket_path.py
@@ -2,6 +2,7 @@
 
 import logging
 import os
+import re
 import typing as tp
 
 import allure
@@ -54,15 +55,17 @@ def _setup_scenarios(
 
 def _assert_expected_err(env_scenario: str, socket_scenario: str, err_msg: str) -> None:
     """Check expected error message based on scenarios."""
-    expected_err = ["Network.Socket.connect:"]
+    expected_err = [re.escape("Network.Socket.connect:")]
     if socket_scenario == "socket_path_missing" and env_scenario == "env_missing":
         expected_err = [
-            "Missing: --socket-path SOCKET_PATH",
+            r"Missing: +--socket-path SOCKET_PATH",
             # TODO: In 8.0.0-untested the error message is different:
-            "Error while looking up environment variable: CARDANO_NODE_SOCKET_PATH",
+            re.escape("Error while looking up environment variable: CARDANO_NODE_SOCKET_PATH"),
         ]
 
-    assert any(msg in err_msg for msg in expected_err), f"{expected_err} not in {err_msg}"
+    assert any(re.search(msg, err_msg) for msg in expected_err), (
+        f"{expected_err} not found in `{err_msg}`"
+    )
 
 
 @pytest.fixture

--- a/cardano_node_tests/tests/test_tx_negative.py
+++ b/cardano_node_tests/tests/test_tx_negative.py
@@ -1545,9 +1545,9 @@ class TestNegative:
 
         with common.allow_unstable_error_messages():
             assert (
-                "fee must be specified" in err_str
+                re.search(r"Missing:.* --fee LOVELACE", err_str)  # node >= 8.12.0
+                or "fee must be specified" in err_str
                 or "Implicit transaction fee not supported" in err_str
-                or "Missing: --fee LOVELACE" in err_str  # node >= 8.12.0
             ), err_str
 
     @allure.link(helpers.get_vcs_link())


### PR DESCRIPTION
The cardano-cli optparse error output now pads 'Missing:' with variable whitespace (e.g. 'Missing:  --socket-path SOCKET_PATH') and can render empty alternation groups inline
('Missing:  ( )      (  )   --fee LOVELACE').

Replace exact substring assertions with regex matching in test_env_network_id, test_socket_path and test_missing_fee so both old and new formats match.