### PR TITLE
refactor: use usefixtures marker in tests

### DIFF
--- a/cardano_node_tests/tests/test_env_network_id.py
+++ b/cardano_node_tests/tests/test_env_network_id.py
@@ -116,10 +116,9 @@ class TestNetworkIdEnv:
     @allure.link(helpers.get_vcs_link())
     @pytest.mark.smoke
     @pytest.mark.testnets
+    @pytest.mark.usefixtures("skip_on_no_env", "set_network_id_env")
     def test_query_protocol_state(
         self,
-        skip_on_no_env: None,  # noqa: ARG002
-        set_network_id_env: None,  # noqa: ARG002
         cluster: clusterlib.ClusterLib,
     ):
         """Query protocol state using CARDANO_NODE_NETWORK_ID environment variable.
@@ -140,10 +139,9 @@ class TestNetworkIdEnv:
     @allure.link(helpers.get_vcs_link())
     @pytest.mark.smoke
     @pytest.mark.testnets
+    @pytest.mark.usefixtures("skip_on_no_env", "set_network_id_env")
     def test_query_stake_distribution(
         self,
-        skip_on_no_env: None,  # noqa: ARG002
-        set_network_id_env: None,  # noqa: ARG002
         cluster: clusterlib.ClusterLib,
     ):
         """Query stake distribution using CARDANO_NODE_NETWORK_ID environment variable.
@@ -164,10 +162,9 @@ class TestNetworkIdEnv:
     @allure.link(helpers.get_vcs_link())
     @pytest.mark.smoke
     @pytest.mark.testnets
+    @pytest.mark.usefixtures("skip_on_no_env", "set_network_id_env")
     def test_query_protocol_params(
         self,
-        skip_on_no_env: None,  # noqa: ARG002
-        set_network_id_env: None,  # noqa: ARG002
         cluster: clusterlib.ClusterLib,
     ):
         """Query protocol parameters using CARDANO_NODE_NETWORK_ID environment variable.
@@ -188,10 +185,9 @@ class TestNetworkIdEnv:
     @allure.link(helpers.get_vcs_link())
     @pytest.mark.smoke
     @pytest.mark.testnets
+    @pytest.mark.usefixtures("skip_on_no_env", "set_network_id_env")
     def test_query_pool_state(
         self,
-        skip_on_no_env: None,  # noqa: ARG002
-        set_network_id_env: None,  # noqa: ARG002
         cluster: clusterlib.ClusterLib,
     ):
         """Query pool state using CARDANO_NODE_NETWORK_ID environment variable.
@@ -210,10 +206,9 @@ class TestNetworkIdEnv:
     @allure.link(helpers.get_vcs_link())
     @pytest.mark.smoke
     @pytest.mark.testnets
+    @pytest.mark.usefixtures("skip_on_no_env", "set_network_id_env")
     def test_query_stake_addr_info(
         self,
-        skip_on_no_env: None,  # noqa: ARG002
-        set_network_id_env: None,  # noqa: ARG002
         cluster: clusterlib.ClusterLib,
     ):
         """Query stake address info using CARDANO_NODE_NETWORK_ID environment variable.
@@ -233,10 +228,9 @@ class TestNetworkIdEnv:
     @common.SKIPIF_BUILD_UNUSABLE
     @pytest.mark.smoke
     @pytest.mark.testnets
+    @pytest.mark.usefixtures("skip_on_no_env", "set_network_id_env")
     def test_build_transfer_funds(
         self,
-        skip_on_no_env: None,  # noqa: ARG002
-        set_network_id_env: None,  # noqa: ARG002
         cluster: clusterlib.ClusterLib,
         payment_addrs: list[clusterlib.AddressRecord],
     ):
@@ -299,10 +293,9 @@ class TestNegativeNetworkIdEnv:
     @PARAM_ARG_SCENARIO
     @pytest.mark.smoke
     @pytest.mark.testnets
+    @pytest.mark.usefixtures("skip_on_no_env", "set_network_id_env")
     def test_neg_query_protocol_state(
         self,
-        skip_on_no_env: None,  # noqa: ARG002
-        set_network_id_env: None,  # noqa: ARG002
         cluster: clusterlib.ClusterLib,
         env_scenario: str,
         arg_scenario: str,
@@ -339,10 +332,9 @@ class TestNegativeNetworkIdEnv:
     @PARAM_ARG_SCENARIO
     @pytest.mark.smoke
     @pytest.mark.testnets
+    @pytest.mark.usefixtures("skip_on_no_env", "set_network_id_env")
     def test_neg_query_stake_distribution(
         self,
-        skip_on_no_env: None,  # noqa: ARG002
-        set_network_id_env: None,  # noqa: ARG002
         cluster: clusterlib.ClusterLib,
         env_scenario: str,
         arg_scenario: str,
@@ -378,10 +370,9 @@ class TestNegativeNetworkIdEnv:
     @PARAM_ARG_SCENARIO
     @pytest.mark.smoke
     @pytest.mark.testnets
+    @pytest.mark.usefixtures("skip_on_no_env", "set_network_id_env")
     def test_neg_query_protocol_params(
         self,
-        skip_on_no_env: None,  # noqa: ARG002
-        set_network_id_env: None,  # noqa: ARG002
         cluster: clusterlib.ClusterLib,
         env_scenario: str,
         arg_scenario: str,
@@ -417,10 +408,9 @@ class TestNegativeNetworkIdEnv:
     @PARAM_ARG_SCENARIO
     @pytest.mark.smoke
     @pytest.mark.testnets
+    @pytest.mark.usefixtures("skip_on_no_env", "set_network_id_env")
     def test_neg_query_pool_state(
         self,
-        skip_on_no_env: None,  # noqa: ARG002
-        set_network_id_env: None,  # noqa: ARG002
         cluster: clusterlib.ClusterLib,
         env_scenario: str,
         arg_scenario: str,
@@ -456,10 +446,9 @@ class TestNegativeNetworkIdEnv:
     @PARAM_ARG_SCENARIO
     @pytest.mark.smoke
     @pytest.mark.testnets
+    @pytest.mark.usefixtures("skip_on_no_env", "set_network_id_env")
     def test_neg_query_stake_addr_info(
         self,
-        skip_on_no_env: None,  # noqa: ARG002
-        set_network_id_env: None,  # noqa: ARG002
         cluster: clusterlib.ClusterLib,
         env_scenario: str,
         arg_scenario: str,
@@ -496,10 +485,9 @@ class TestNegativeNetworkIdEnv:
     @PARAM_ARG_SCENARIO
     @pytest.mark.smoke
     @pytest.mark.testnets
+    @pytest.mark.usefixtures("skip_on_no_env", "set_network_id_env")
     def test_neg_build_transfer_funds(
         self,
-        skip_on_no_env: None,  # noqa: ARG002
-        set_network_id_env: None,  # noqa: ARG002
         cluster: clusterlib.ClusterLib,
         payment_addrs: list[clusterlib.AddressRecord],
         env_scenario: str,

--- a/cardano_node_tests/tests/test_metrics.py
+++ b/cardano_node_tests/tests/test_metrics.py
@@ -103,10 +103,8 @@ class TestPrometheus:
     }
 
     @allure.link(helpers.get_vcs_link())
-    def test_available_metrics(
-        self,
-        wait_epochs,  # noqa: ARG002
-    ):
+    @pytest.mark.usefixtures("wait_epochs")
+    def test_available_metrics(self):
         """Test that list of available Prometheus metrics equals list of expected metrics.
 
         Test Prometheus metrics endpoint to verify all expected metrics are exposed and
@@ -138,10 +136,8 @@ class TestEKG:
     """EKG metrics tests."""
 
     @allure.link(helpers.get_vcs_link())
-    def test_available_metrics(
-        self,
-        wait_epochs,  # noqa: ARG002
-    ):
+    @pytest.mark.usefixtures("wait_epochs")
+    def test_available_metrics(self):
         """Test that available EKG metrics matches the expected schema.
 
         Test EKG (Event-driven Key-value) metrics endpoint to verify metrics conform to

--- a/cardano_node_tests/tests/test_mir_certs.py
+++ b/cardano_node_tests/tests/test_mir_certs.py
@@ -114,9 +114,9 @@ class TestMIRCerts:
 
     @allure.link(helpers.get_vcs_link())
     @pytest.mark.dbsync
+    @pytest.mark.usefixtures("skip_on_hf_shortcut")
     def test_transfer_to_treasury(
         self,
-        skip_on_hf_shortcut: None,  # noqa: ARG002
         cluster_manager: cluster_management.ClusterManager,
         cluster_pots: clusterlib.ClusterLib,
         pool_users: list[clusterlib.PoolUser],
@@ -196,9 +196,9 @@ class TestMIRCerts:
     @allure.link(helpers.get_vcs_link())
     @pytest.mark.dbsync
     @common.SKIPIF_BUILD_UNUSABLE
+    @pytest.mark.usefixtures("skip_on_hf_shortcut")
     def test_build_transfer_to_treasury(
         self,
-        skip_on_hf_shortcut: None,  # noqa: ARG002
         cluster_manager: cluster_management.ClusterManager,
         cluster_pots: clusterlib.ClusterLib,
         pool_users: list[clusterlib.PoolUser],
@@ -284,9 +284,9 @@ class TestMIRCerts:
 
     @allure.link(helpers.get_vcs_link())
     @pytest.mark.dbsync
+    @pytest.mark.usefixtures("skip_on_hf_shortcut")
     def test_transfer_to_reserves(
         self,
-        skip_on_hf_shortcut: None,  # noqa: ARG002
         cluster_manager: cluster_management.ClusterManager,
         cluster_pots: clusterlib.ClusterLib,
         pool_users: list[clusterlib.PoolUser],
@@ -366,9 +366,9 @@ class TestMIRCerts:
     @allure.link(helpers.get_vcs_link())
     @pytest.mark.dbsync
     @common.SKIPIF_BUILD_UNUSABLE
+    @pytest.mark.usefixtures("skip_on_hf_shortcut")
     def test_build_transfer_to_reserves(
         self,
-        skip_on_hf_shortcut: None,  # noqa: ARG002
         cluster_manager: cluster_management.ClusterManager,
         cluster_pots: clusterlib.ClusterLib,
         pool_users: list[clusterlib.PoolUser],
@@ -455,9 +455,9 @@ class TestMIRCerts:
     @allure.link(helpers.get_vcs_link())
     @pytest.mark.dbsync
     @pytest.mark.parametrize("fund_src", (RESERVES, TREASURY))
+    @pytest.mark.usefixtures("skip_on_hf_shortcut")
     def test_pay_stake_addr_from(
         self,
-        skip_on_hf_shortcut: None,  # noqa: ARG002
         cluster_manager: cluster_management.ClusterManager,
         cluster_pots: clusterlib.ClusterLib,
         registered_users: list[clusterlib.PoolUser],
@@ -546,9 +546,9 @@ class TestMIRCerts:
     @pytest.mark.dbsync
     @common.SKIPIF_BUILD_UNUSABLE
     @pytest.mark.parametrize("fund_src", (RESERVES, TREASURY))
+    @pytest.mark.usefixtures("skip_on_hf_shortcut")
     def test_build_pay_stake_addr_from(
         self,
-        skip_on_hf_shortcut: None,  # noqa: ARG002
         cluster_manager: cluster_management.ClusterManager,
         cluster_pots: clusterlib.ClusterLib,
         registered_users: list[clusterlib.PoolUser],
@@ -643,9 +643,9 @@ class TestMIRCerts:
 
     @allure.link(helpers.get_vcs_link())
     @pytest.mark.dbsync
+    @pytest.mark.usefixtures("skip_on_hf_shortcut")
     def test_pay_stake_addr_from_both(
         self,
-        skip_on_hf_shortcut: None,  # noqa: ARG002
         cluster_manager: cluster_management.ClusterManager,
         cluster_pots: clusterlib.ClusterLib,
         registered_users: list[clusterlib.PoolUser],
@@ -775,9 +775,9 @@ class TestMIRCerts:
 
     @allure.link(helpers.get_vcs_link())
     @pytest.mark.dbsync
+    @pytest.mark.usefixtures("skip_on_hf_shortcut")
     def test_pay_multi_stake_addrs(
         self,
-        skip_on_hf_shortcut: None,  # noqa: ARG002
         cluster_manager: cluster_management.ClusterManager,
         cluster_pots: clusterlib.ClusterLib,
         registered_users: list[clusterlib.PoolUser],
@@ -920,9 +920,9 @@ class TestMIRCerts:
     @pytest.mark.dbsync
     @pytest.mark.parametrize("addr_history", ("addr_known", "addr_unknown"))
     @pytest.mark.parametrize("fund_src", (RESERVES, TREASURY))
+    @pytest.mark.usefixtures("skip_on_hf_shortcut")
     def test_pay_unregistered_stake_addr_from(  # noqa: C901
         self,
-        skip_on_hf_shortcut: None,  # noqa: ARG002
         cluster_manager: cluster_management.ClusterManager,
         cluster_pots: clusterlib.ClusterLib,
         pool_users: list[clusterlib.PoolUser],

--- a/cardano_node_tests/tests/test_socket_path.py
+++ b/cardano_node_tests/tests/test_socket_path.py
@@ -110,9 +110,9 @@ class TestSocketPath:
     @PARAM_ENV_SCENARIO
     @pytest.mark.smoke
     @pytest.mark.testnets
+    @pytest.mark.usefixtures("set_socket_path")
     def test_query_protocol_state(
         self,
-        set_socket_path: None,  # noqa: ARG002
         cluster: clusterlib.ClusterLib,
         env_scenario: str,
     ):
@@ -139,9 +139,9 @@ class TestSocketPath:
     @PARAM_ENV_SCENARIO
     @pytest.mark.smoke
     @pytest.mark.testnets
+    @pytest.mark.usefixtures("set_socket_path")
     def test_query_stake_distribution(
         self,
-        set_socket_path: None,  # noqa: ARG002
         cluster: clusterlib.ClusterLib,
         env_scenario: str,
     ):
@@ -168,9 +168,9 @@ class TestSocketPath:
     @PARAM_ENV_SCENARIO
     @pytest.mark.smoke
     @pytest.mark.testnets
+    @pytest.mark.usefixtures("set_socket_path")
     def test_query_protocol_params(
         self,
-        set_socket_path: None,  # noqa: ARG002
         cluster: clusterlib.ClusterLib,
         env_scenario: str,
     ):
@@ -197,9 +197,9 @@ class TestSocketPath:
     @PARAM_ENV_SCENARIO
     @pytest.mark.smoke
     @pytest.mark.testnets
+    @pytest.mark.usefixtures("set_socket_path")
     def test_query_pool_state(
         self,
-        set_socket_path: None,  # noqa: ARG002
         cluster: clusterlib.ClusterLib,
         env_scenario: str,
     ):
@@ -224,9 +224,9 @@ class TestSocketPath:
     @PARAM_ENV_SCENARIO
     @pytest.mark.smoke
     @pytest.mark.testnets
+    @pytest.mark.usefixtures("set_socket_path")
     def test_query_stake_addr_info(
         self,
-        set_socket_path: None,  # noqa: ARG002
         cluster: clusterlib.ClusterLib,
         env_scenario: str,
     ):
@@ -252,9 +252,9 @@ class TestSocketPath:
     @PARAM_ENV_SCENARIO
     @pytest.mark.smoke
     @pytest.mark.testnets
+    @pytest.mark.usefixtures("set_socket_path")
     def test_build_transfer_funds(
         self,
-        set_socket_path: None,  # noqa: ARG002
         cluster: clusterlib.ClusterLib,
         payment_addrs: list[clusterlib.AddressRecord],
         env_scenario: str,
@@ -317,9 +317,9 @@ class TestNegativeSocketPath:
     @allure.link(helpers.get_vcs_link())
     @PARAM_ENV_SCENARIO
     @PARAM_SOCKET_SCENARIO
+    @pytest.mark.usefixtures("set_socket_path")
     def test_neg_query_protocol_state(
         self,
-        set_socket_path: None,  # noqa: ARG002
         cluster: clusterlib.ClusterLib,
         env_scenario: str,
         socket_scenario: str,
@@ -353,9 +353,9 @@ class TestNegativeSocketPath:
     @allure.link(helpers.get_vcs_link())
     @PARAM_ENV_SCENARIO
     @PARAM_SOCKET_SCENARIO
+    @pytest.mark.usefixtures("set_socket_path")
     def test_neg_query_stake_distribution(
         self,
-        set_socket_path: None,  # noqa: ARG002
         cluster: clusterlib.ClusterLib,
         env_scenario: str,
         socket_scenario: str,
@@ -389,9 +389,9 @@ class TestNegativeSocketPath:
     @allure.link(helpers.get_vcs_link())
     @PARAM_ENV_SCENARIO
     @PARAM_SOCKET_SCENARIO
+    @pytest.mark.usefixtures("set_socket_path")
     def test_neg_query_protocol_params(
         self,
-        set_socket_path: None,  # noqa: ARG002
         cluster: clusterlib.ClusterLib,
         env_scenario: str,
         socket_scenario: str,
@@ -425,9 +425,9 @@ class TestNegativeSocketPath:
     @allure.link(helpers.get_vcs_link())
     @PARAM_ENV_SCENARIO
     @PARAM_SOCKET_SCENARIO
+    @pytest.mark.usefixtures("set_socket_path")
     def test_neg_query_pool_state(
         self,
-        set_socket_path: None,  # noqa: ARG002
         cluster: clusterlib.ClusterLib,
         env_scenario: str,
         socket_scenario: str,
@@ -461,9 +461,9 @@ class TestNegativeSocketPath:
     @allure.link(helpers.get_vcs_link())
     @PARAM_ENV_SCENARIO
     @PARAM_SOCKET_SCENARIO
+    @pytest.mark.usefixtures("set_socket_path")
     def test_neg_query_stake_addr_info(
         self,
-        set_socket_path: None,  # noqa: ARG002
         cluster: clusterlib.ClusterLib,
         env_scenario: str,
         socket_scenario: str,
@@ -498,9 +498,9 @@ class TestNegativeSocketPath:
     @common.SKIPIF_BUILD_UNUSABLE
     @PARAM_ENV_SCENARIO
     @PARAM_SOCKET_SCENARIO
+    @pytest.mark.usefixtures("set_socket_path")
     def test_neg_build_transfer_funds(
         self,
-        set_socket_path: None,  # noqa: ARG002
         cluster: clusterlib.ClusterLib,
         payment_addrs: list[clusterlib.AddressRecord],
         env_scenario: str,


### PR DESCRIPTION
Convert unused None-returning fixture parameters (annotated with `# noqa: ARG002`) in test method signatures to
`@pytest.mark.usefixtures` markers. Affects 35 tests in test_env_network_id.py, test_socket_path.py, test_mir_certs.py and test_metrics.py.

Fixture-signature dependencies (`# noqa: ARG001`) are kept as parameters, since usefixtures markers have no effect on fixtures. Fixture setup order is unchanged: the converted fixtures declare their own dependencies.