### PR TITLE
refactor: use Protocol and singledispatch

### DIFF
--- a/cardano_node_tests/cluster_management/cluster_getter.py
+++ b/cardano_node_tests/cluster_management/cluster_getter.py
@@ -854,7 +854,7 @@ class ClusterGetter:
         self,
         lock_resources: resources_management.ResourcesType,
         use_resources: resources_management.ResourcesType,
-    ) -> list[str | resources_management.BaseFilter]:
+    ) -> list[str | resources_management.ResourceFilter]:
         """Add `resources.Resources.CLUSTER` to `use_resources`.
 
         Filter out `lock_resources` from the list of `use_resources`.

--- a/cardano_node_tests/cluster_management/resources_management.py
+++ b/cardano_node_tests/cluster_management/resources_management.py
@@ -2,11 +2,11 @@
 
 Resources can be requested by name (string).
 
-It is also possible to use filters. A filter is a class that gets a list of all unavailable
+It is also possible to use filters. A filter is an object that gets a list of all unavailable
 resources and returns a list of resources that should be used. An example is `OneOf`, which returns
 one usable resource from a given list of resources. The unavailable resources passed to the filter
-include resources that are unavailable because they are locked, and also resources that were
-already selected by preceding filters in the same request.
+include resources that are locked, resources that were requested by name in the same request, and
+resources that were already selected by preceding filters in the same request.
 
 It is possible to use multiple `OneOf` filters in a single request. For example, using `OneOf`
 filter with the same set of resources twice will result in selecting two different resources from
@@ -17,31 +17,32 @@ import random
 import typing as tp
 
 
-class BaseFilter:
-    """Base class for resource filters."""
+class ResourceFilter(tp.Protocol):
+    """Protocol for resource filters."""
+
+    def filter(self, unavailable: tp.Iterable[str]) -> list[str]:
+        """Return resources to use, given the currently unavailable resources.
+
+        The `unavailable` resources include resources that are locked, resources that were
+        requested by name in the same request, and resources that were already selected by
+        preceding filters in the same request.
+
+        Returning an empty list means the request cannot be satisfied.
+        """
+        raise NotImplementedError
+
+
+class OneOf(ResourceFilter):
+    """Filter that returns one usable resource out of list of resources."""
 
     def __init__(self, resources: tp.Iterable[str]) -> None:
         if isinstance(resources, str):
             msg = "`resources` cannot be a string"
             raise TypeError(msg)
-        self.resources = resources
+        self.resources = tuple(resources)
 
-    def filter(self, unavailable: tp.Iterable[str], **kwargs: tp.Any) -> list[str]:
-        """Filter resources."""
-        raise NotImplementedError
-
-    def __repr__(self) -> str:
-        return f"{self.__class__.__name__}({self.resources})"
-
-
-class OneOf(BaseFilter):
-    """Filter that returns one usable resource out of list of resources."""
-
-    def filter(
-        self,
-        unavailable: tp.Iterable[str],
-        **kwargs: tp.Any,  # noqa: ARG002
-    ) -> list[str]:
+    def filter(self, unavailable: tp.Iterable[str]) -> list[str]:
+        """Return one randomly selected usable resource, or an empty list if none is usable."""
         if isinstance(unavailable, str):
             msg = "`unavailable` cannot be a string"
             raise TypeError(msg)
@@ -52,8 +53,11 @@ class OneOf(BaseFilter):
 
         return [random.choice(usable)]
 
+    def __repr__(self) -> str:
+        return f"{self.__class__.__name__}({self.resources})"
 
-ResourcesType = tp.Iterable[str | BaseFilter]
+
+ResourcesType = tp.Iterable[str | ResourceFilter]
 
 
 def get_resources(

--- a/cardano_node_tests/utils/governance_utils.py
+++ b/cardano_node_tests/utils/governance_utils.py
@@ -371,7 +371,181 @@ def get_cc_member_auth_record(
     )
 
 
-def check_action_view(  # noqa: C901
+def _prev_action_ref(
+    action_data: clusterlib.ActionConstitution
+    | clusterlib.ActionNoConfidence
+    | clusterlib.ActionUpdateCommittee,
+) -> dict[str, tp.Any] | None:
+    """Get reference to previous governance action for `governance action view` output."""
+    if action_data.prev_action_txid:
+        return {"govActionIx": action_data.prev_action_ix, "txId": action_data.prev_action_txid}
+    return None
+
+
+@functools.singledispatch
+def _get_gov_action(
+    action_data: ActionsAllT,
+    *,
+    cluster_obj: clusterlib.ClusterLib,
+    recv_addr_vkey_hash: str,
+) -> dict[str, tp.Any]:
+    """Get expected "governance action" record for `governance action view` output."""
+    msg = f"Not implemented for action `{action_data}`"
+    raise NotImplementedError(msg)
+
+
+@_get_gov_action.register
+def _get_gov_action_treasury(
+    action_data: clusterlib.ActionTreasuryWithdrawal,
+    *,
+    cluster_obj: clusterlib.ClusterLib,
+    recv_addr_vkey_hash: str,
+) -> dict[str, tp.Any]:
+    """Get expected "governance action" record for treasury withdrawal action."""
+    if not recv_addr_vkey_hash:
+        if action_data.funds_receiving_stake_vkey_file:
+            recv_addr_vkey_hash = cluster_obj.g_stake_address.get_stake_vkey_hash(
+                stake_vkey_file=action_data.funds_receiving_stake_vkey_file
+            )
+        elif action_data.funds_receiving_stake_vkey:
+            recv_addr_vkey_hash = cluster_obj.g_stake_address.get_stake_vkey_hash(
+                stake_vkey=action_data.funds_receiving_stake_vkey
+            )
+        elif action_data.funds_receiving_stake_key_hash:
+            recv_addr_vkey_hash = action_data.funds_receiving_stake_key_hash
+        else:
+            msg = "No funds receiving stake key was specified"
+            raise ValueError(msg)
+
+    return {
+        "contents": [
+            [
+                [
+                    {
+                        "credential": {"keyHash": recv_addr_vkey_hash},
+                        "network": "Testnet",
+                    },
+                    action_data.transfer_amt,
+                ],
+            ],
+            None,  # TODO 8.8: what is this?
+        ],
+        "tag": ActionTags.TREASURY_WITHDRAWALS.value,
+    }
+
+
+@_get_gov_action.register
+def _get_gov_action_info(
+    action_data: clusterlib.ActionInfo,  # noqa: ARG001
+    *,
+    cluster_obj: clusterlib.ClusterLib,  # noqa: ARG001
+    recv_addr_vkey_hash: str,  # noqa: ARG001
+) -> dict[str, tp.Any]:
+    """Get expected "governance action" record for info action."""
+    return {
+        "tag": ActionTags.INFO_ACTION.value,
+    }
+
+
+@_get_gov_action.register
+def _get_gov_action_constitution(
+    action_data: clusterlib.ActionConstitution,
+    *,
+    cluster_obj: clusterlib.ClusterLib,  # noqa: ARG001
+    recv_addr_vkey_hash: str,  # noqa: ARG001
+) -> dict[str, tp.Any]:
+    """Get expected "governance action" record for new constitution action."""
+    return {
+        "contents": [
+            _prev_action_ref(action_data),
+            {
+                "anchor": {
+                    "dataHash": action_data.constitution_hash,
+                    "url": action_data.constitution_url,
+                }
+            },
+        ],
+        "tag": ActionTags.NEW_CONSTITUTION.value,
+    }
+
+
+@_get_gov_action.register
+def _get_gov_action_committee(
+    action_data: clusterlib.ActionUpdateCommittee,
+    *,
+    cluster_obj: clusterlib.ClusterLib,
+    recv_addr_vkey_hash: str,  # noqa: ARG001
+) -> dict[str, tp.Any]:
+    """Get expected "governance action" record for update committee action."""
+
+    def _get_cvkey_hash(*, member: clusterlib.CCMember) -> str:
+        if member.cold_vkey_file:
+            cvkey_hash = cluster_obj.g_governance.committee.get_key_hash(
+                vkey_file=member.cold_vkey_file
+            )
+        elif member.cold_vkey:
+            cvkey_hash = cluster_obj.g_governance.committee.get_key_hash(vkey=member.cold_vkey)
+        elif member.cold_vkey_hash:
+            cvkey_hash = member.cold_vkey_hash
+        else:
+            msg = "No cold key was specified"
+            raise ValueError(msg)
+
+        return cvkey_hash
+
+    added_members = {}
+    for _m in action_data.add_cc_members:
+        cvkey_hash = _get_cvkey_hash(member=_m)
+        added_members[f"keyHash-{cvkey_hash}"] = _m.epoch
+
+    removed_members = [{"keyHash": _get_cvkey_hash(member=_m)} for _m in action_data.rem_cc_members]
+
+    return {
+        "contents": [
+            _prev_action_ref(action_data),
+            removed_members or [],
+            added_members,
+            float(action_data.threshold),
+        ],
+        "tag": ActionTags.UPDATE_COMMITTEE.value,
+    }
+
+
+@_get_gov_action.register
+def _get_gov_action_no_confidence(
+    action_data: clusterlib.ActionNoConfidence,
+    *,
+    cluster_obj: clusterlib.ClusterLib,  # noqa: ARG001
+    recv_addr_vkey_hash: str,  # noqa: ARG001
+) -> dict[str, tp.Any]:
+    """Get expected "governance action" record for no confidence action."""
+    return {
+        "contents": _prev_action_ref(action_data),
+        "tag": ActionTags.NO_CONFIDENCE.value,
+    }
+
+
+@_get_gov_action.register
+def _get_gov_action_hardfork(
+    action_data: clusterlib.ActionHardfork,
+    *,
+    cluster_obj: clusterlib.ClusterLib,  # noqa: ARG001
+    recv_addr_vkey_hash: str,  # noqa: ARG001
+) -> dict[str, tp.Any]:
+    """Get expected "governance action" record for hardfork action."""
+    return {
+        "contents": [
+            None,  # TODO 8.11: what is this?
+            {
+                "major": action_data.protocol_major_version,
+                "minor": action_data.protocol_minor_version,
+            },
+        ],
+        "tag": ActionTags.HARDFORK_INIT.value,
+    }
+
+
+def check_action_view(
     *,
     cluster_obj: clusterlib.ClusterLib,
     action_data: ActionsAllT,
@@ -394,119 +568,9 @@ def check_action_view(  # noqa: C901
             msg = "No return stake key was specified"
             raise ValueError(msg)
 
-    prev_action_txid = getattr(action_data, "prev_action_txid", None)
-    prev_action_ix = getattr(action_data, "prev_action_ix", None)
-
-    gov_action: dict[str, tp.Any]
-
-    if isinstance(action_data, clusterlib.ActionTreasuryWithdrawal):
-        if not recv_addr_vkey_hash:
-            if action_data.funds_receiving_stake_vkey_file:
-                recv_addr_vkey_hash = cluster_obj.g_stake_address.get_stake_vkey_hash(
-                    stake_vkey_file=action_data.funds_receiving_stake_vkey_file
-                )
-            elif action_data.funds_receiving_stake_vkey:
-                recv_addr_vkey_hash = cluster_obj.g_stake_address.get_stake_vkey_hash(
-                    stake_vkey=action_data.funds_receiving_stake_vkey
-                )
-            elif action_data.funds_receiving_stake_key_hash:
-                recv_addr_vkey_hash = action_data.funds_receiving_stake_key_hash
-            else:
-                msg = "No funds receiving stake key was specified"
-                raise ValueError(msg)
-
-        gov_action = {
-            "contents": [
-                [
-                    [
-                        {
-                            "credential": {"keyHash": recv_addr_vkey_hash},
-                            "network": "Testnet",
-                        },
-                        action_data.transfer_amt,
-                    ],
-                ],
-                None,  # TODO 8.8: what is this?
-            ],
-            "tag": ActionTags.TREASURY_WITHDRAWALS.value,
-        }
-    elif isinstance(action_data, clusterlib.ActionInfo):
-        gov_action = {
-            "tag": ActionTags.INFO_ACTION.value,
-        }
-    elif isinstance(action_data, clusterlib.ActionConstitution):
-        gov_action = {
-            "contents": [
-                {"govActionIx": prev_action_ix, "txId": prev_action_txid}
-                if prev_action_txid
-                else None,
-                {
-                    "anchor": {
-                        "dataHash": action_data.constitution_hash,
-                        "url": action_data.constitution_url,
-                    }
-                },
-            ],
-            "tag": ActionTags.NEW_CONSTITUTION.value,
-        }
-    elif isinstance(action_data, clusterlib.ActionUpdateCommittee):
-
-        def _get_cvkey_hash(*, member: clusterlib.CCMember) -> str:
-            if member.cold_vkey_file:
-                cvkey_hash = cluster_obj.g_governance.committee.get_key_hash(
-                    vkey_file=member.cold_vkey_file
-                )
-            elif member.cold_vkey:
-                cvkey_hash = cluster_obj.g_governance.committee.get_key_hash(vkey=member.cold_vkey)
-            elif member.cold_vkey_hash:
-                cvkey_hash = member.cold_vkey_hash
-            else:
-                msg = "No cold key was specified"
-                raise ValueError(msg)
-
-            return cvkey_hash
-
-        added_members = {}
-        for _m in action_data.add_cc_members:
-            cvkey_hash = _get_cvkey_hash(member=_m)
-            added_members[f"keyHash-{cvkey_hash}"] = _m.epoch
-
-        removed_members = [
-            {"keyHash": _get_cvkey_hash(member=_m)} for _m in action_data.rem_cc_members
-        ]
-
-        gov_action = {
-            "contents": [
-                {"govActionIx": prev_action_ix, "txId": prev_action_txid}
-                if prev_action_txid
-                else None,
-                removed_members or [],
-                added_members,
-                float(action_data.threshold),
-            ],
-            "tag": ActionTags.UPDATE_COMMITTEE.value,
-        }
-    elif isinstance(action_data, clusterlib.ActionNoConfidence):
-        gov_action = {
-            "contents": {"govActionIx": prev_action_ix, "txId": prev_action_txid}
-            if prev_action_txid
-            else None,
-            "tag": ActionTags.NO_CONFIDENCE.value,
-        }
-    elif isinstance(action_data, clusterlib.ActionHardfork):
-        gov_action = {
-            "contents": [
-                None,  # TODO 8.11: what is this?
-                {
-                    "major": action_data.protocol_major_version,
-                    "minor": action_data.protocol_minor_version,
-                },
-            ],
-            "tag": ActionTags.HARDFORK_INIT.value,
-        }
-    else:
-        msg = f"Not implemented for action `{action_data}`"
-        raise NotImplementedError(msg)
+    gov_action = _get_gov_action(
+        action_data, cluster_obj=cluster_obj, recv_addr_vkey_hash=recv_addr_vkey_hash
+    )
 
     expected_action_out = {
         "anchor": {
@@ -526,73 +590,86 @@ def check_action_view(  # noqa: C901
     assert action_view_out == expected_action_out, f"{action_view_out} != {expected_action_out}"
 
 
-def check_vote_view(  # noqa: C901
+@functools.singledispatch
+def _get_vote_key(vote_data: VotesAllT, *, cluster_obj: clusterlib.ClusterLib) -> str:
+    """Get vote key for `governance vote view` output."""
+    msg = f"Not implemented for vote `{vote_data}`"
+    raise NotImplementedError(msg)
+
+
+@_get_vote_key.register
+def _get_vote_key_cc(vote_data: clusterlib.VoteCC, *, cluster_obj: clusterlib.ClusterLib) -> str:
+    """Get vote key for Constitutional Committee vote."""
+    if vote_data.cc_hot_vkey_file:
+        cc_key_hash = cluster_obj.g_governance.committee.get_key_hash(
+            vkey_file=vote_data.cc_hot_vkey_file
+        )
+    elif vote_data.cc_hot_vkey:
+        cc_key_hash = cluster_obj.g_governance.committee.get_key_hash(vkey=vote_data.cc_hot_vkey)
+    elif vote_data.cc_hot_key_hash:
+        cc_key_hash = vote_data.cc_hot_key_hash
+    else:
+        msg = "No hot key was specified"
+        raise ValueError(msg)
+
+    return f"committee-keyHash-{cc_key_hash}"
+
+
+@_get_vote_key.register
+def _get_vote_key_drep(
+    vote_data: clusterlib.VoteDrep, *, cluster_obj: clusterlib.ClusterLib
+) -> str:
+    """Get vote key for DRep vote."""
+    if vote_data.drep_vkey_file:
+        drep_id = cluster_obj.g_governance.drep.get_id(
+            drep_vkey_file=vote_data.drep_vkey_file, out_format="hex"
+        )
+    elif vote_data.drep_vkey:
+        drep_id = cluster_obj.g_governance.drep.get_id(
+            drep_vkey=vote_data.drep_vkey, out_format="hex"
+        )
+    elif vote_data.drep_key_hash:
+        drep_id = vote_data.drep_key_hash
+    else:
+        msg = "No drep key was specified"
+        raise ValueError(msg)
+
+    if drep_id.startswith("drep1"):
+        drep_id = helpers.decode_bech32(bech32=drep_id)
+
+    return f"drep-keyHash-{drep_id}"
+
+
+@_get_vote_key.register
+def _get_vote_key_spo(vote_data: clusterlib.VoteSPO, *, cluster_obj: clusterlib.ClusterLib) -> str:
+    """Get vote key for SPO vote."""
+    if vote_data.cold_vkey_file:
+        pool_id = cluster_obj.g_stake_pool.get_stake_pool_id(
+            cold_vkey_file=vote_data.cold_vkey_file
+        )
+    elif vote_data.stake_pool_vkey:
+        pool_id = cluster_obj.g_stake_pool.get_stake_pool_id(
+            stake_pool_vkey=vote_data.stake_pool_vkey
+        )
+    elif vote_data.stake_pool_id:
+        pool_id = vote_data.stake_pool_id
+    else:
+        msg = "No stake pool key was specified"
+        raise ValueError(msg)
+
+    if pool_id.startswith("pool1"):
+        pool_id = helpers.decode_bech32(bech32=pool_id)
+
+    return f"stakepool-keyHash-{pool_id}"
+
+
+def check_vote_view(
     *,
     cluster_obj: clusterlib.ClusterLib,
     vote_data: VotesAllT,
 ) -> None:
     """Check `governance vote view` output."""
-    vote_key = ""
-
-    if isinstance(vote_data, clusterlib.VoteCC):
-        if vote_data.cc_hot_vkey_file:
-            cc_key_hash = cluster_obj.g_governance.committee.get_key_hash(
-                vkey_file=vote_data.cc_hot_vkey_file
-            )
-        elif vote_data.cc_hot_vkey:
-            cc_key_hash = cluster_obj.g_governance.committee.get_key_hash(
-                vkey=vote_data.cc_hot_vkey
-            )
-        elif vote_data.cc_hot_key_hash:
-            cc_key_hash = vote_data.cc_hot_key_hash
-        else:
-            msg = "No hot key was specified"
-            raise ValueError(msg)
-
-        vote_key = f"committee-keyHash-{cc_key_hash}"
-    elif isinstance(vote_data, clusterlib.VoteDrep):
-        if vote_data.drep_vkey_file:
-            drep_id = cluster_obj.g_governance.drep.get_id(
-                drep_vkey_file=vote_data.drep_vkey_file, out_format="hex"
-            )
-        elif vote_data.drep_vkey:
-            drep_id = cluster_obj.g_governance.drep.get_id(
-                drep_vkey=vote_data.drep_vkey, out_format="hex"
-            )
-        elif vote_data.drep_key_hash:
-            drep_id = vote_data.drep_key_hash
-        else:
-            msg = "No drep key was specified"
-            raise ValueError(msg)
-
-        if drep_id.startswith("drep1"):
-            drep_id = helpers.decode_bech32(bech32=drep_id)
-
-        vote_key = f"drep-keyHash-{drep_id}"
-    elif isinstance(vote_data, clusterlib.VoteSPO):
-        if vote_data.cold_vkey_file:
-            pool_id = cluster_obj.g_stake_pool.get_stake_pool_id(
-                cold_vkey_file=vote_data.cold_vkey_file
-            )
-        elif vote_data.stake_pool_vkey:
-            pool_id = cluster_obj.g_stake_pool.get_stake_pool_id(
-                stake_pool_vkey=vote_data.stake_pool_vkey
-            )
-        elif vote_data.stake_pool_id:
-            pool_id = vote_data.stake_pool_id
-        else:
-            msg = "No stake pool key was specified"
-            raise ValueError(msg)
-
-        if pool_id.startswith("pool1"):
-            pool_id = helpers.decode_bech32(bech32=pool_id)
-
-        vote_key = f"stakepool-keyHash-{pool_id}"
-    else:
-        msg = f"Not implemented for vote `{vote_data}`"
-        raise NotImplementedError(msg)
-
-    assert vote_key, "No vote key was specified"
+    vote_key = _get_vote_key(vote_data, cluster_obj=cluster_obj)
 
     anchor = (
         {"dataHash": vote_data.anchor_data_hash, "url": vote_data.anchor_url}


### PR DESCRIPTION
Prefer functional style over class inheritance:

- Replace the `BaseFilter` base class with a structural `ResourceFilter` protocol. `OneOf` stores resources as a tuple so one-shot iterators survive repeated `filter()` calls in the cluster getter retry loop.
- Split the isinstance chains in `check_action_view` and `check_vote_view` into `functools.singledispatch` handlers, removing the C901 suppressions. Behavior is unchanged, including the `NotImplementedError` fallback for unregistered action/vote types.