### PR TITLE
fix(tests): make --skipall pass match the real run

### DIFF
--- a/cardano_node_tests/tests/conftest.py
+++ b/cardano_node_tests/tests/conftest.py
@@ -137,7 +137,7 @@ def pytest_configure(config: tp.Any) -> None:
         LOGGER.warning(" WARNING: Using `cardano-node` from custom path!")
 
 
-def _skip_all_tests(config: tp.Any, items: list) -> bool:
+def _skip_all_tests(config: tp.Any, items: list) -> None:
     """Skip all tests if specified on command line.
 
     Can be used for collecting all tests and having "skipped" result before running them for real.
@@ -145,25 +145,23 @@ def _skip_all_tests(config: tp.Any, items: list) -> bool:
     just tests that were not run yet.
     """
     if not config.getvalue("skipall"):
-        return False
+        return
 
-    marker = pytest.mark.skip(reason="collected, not run")
+    # A `skipif` marker, because pytest evaluates `skipif` markers before plain `skip` markers.
+    # A plain `skip` marker would lose to a `skipif` marker the test already has (e.g.
+    # `SKIPIF_BUILD_EST_1199`) and the test would be registered under that marker's reason
+    # instead of "collected, not run". Prepended (`append=False`) so it also takes precedence
+    # over the test's own `skipif` markers.
+    marker = pytest.mark.skipif(True, reason="collected, not run")
 
     for item in items:
-        item.add_marker(marker)
-
-    return True
+        item.add_marker(marker, append=False)
 
 
 @pytest.hookimpl(tryfirst=True)
-def pytest_collection_modifyitems(config: tp.Any, items: list) -> None:  # noqa: C901
-    # Prevent on slave nodes (xdist)
-    if hasattr(config, "slaveinput"):
-        return
-
-    if _skip_all_tests(config=config, items=items):
-        return
-
+def pytest_collection_modifyitems(config: tp.Any, items: list) -> None:
+    # This hook must also run on xdist worker nodes - with xdist, only the workers collect
+    # tests, and MARKEXPR filtering relies on the markers added here.
     skip_dbsync_marker = pytest.mark.skip(reason="db-sync not available")
 
     def _mark_needs_dbsync(item: tp.Any) -> None:
@@ -195,6 +193,12 @@ def pytest_collection_modifyitems(config: tp.Any, items: list) -> None:  # noqa:
     for item in items:
         _mark_needs_dbsync(item)
         _skip_disabled(item)
+
+    # This hook must never return before the dynamic markers above are added: MARKEXPR
+    # filtering runs in a later `pytest_collection_modifyitems` implementation and may rely
+    # on dynamically added markers such as `dbsync`, so the `--skipall` pass has to add them
+    # too in order to collect exactly the same set of tests as the real run.
+    _skip_all_tests(config=config, items=items)
 
 
 @pytest.hookimpl(tryfirst=True)

--- a/scripts/count_test_results.py
+++ b/scripts/count_test_results.py
@@ -12,9 +12,12 @@ Result files are grouped per test (by Allure `historyId`, which identifies a
 test together with its parameters), so tests with multiple result files are
 counted once. Multiple files per test are normal: the initial `--skipall`
 pass of `runner/run_tests.sh` registers every collected test with a
-"Skipped: collected, not run" result file, and tests skipped via `skipif`
-markers are recorded under their own skip reason even during that pass. The
-newest non-registration result of a test wins.
+"Skipped: collected, not run" result file, and the real testrun then adds a
+result file with the real status. The newest non-registration result of a
+test wins. (Result directories produced before the `--skipall` fix may also
+contain registration files carrying a test's own `skipif` or `skip` reason -
+those are treated as real results, which the newest-wins rule resolves
+correctly.)
 
 This is a standalone script so that AI failure analysis in CI can get the
 counts with a single allowlisted command - the CI allowlist permits only


### PR DESCRIPTION
The initial --skipall registration pass produced allure results that disagree with the real testrun, so the 'Skipped: collected, not run' marker count did not equal the number of collected tests:

- pytest evaluates skipif markers before plain skip markers, so tests with their own skipif (SKIPIF_BUILD_EST_1199, SKIPIF_WRONG_ERA, ...) were registered under that marker's reason and then produced a second, identical result file in the real run. Use a prepended skipif(True) marker instead - it is evaluated before all of the test's own markers, so every collected test is registered with the 'collected, not run' reason.
- The early return in pytest_collection_modifyitems skipped the dynamic marker additions (e.g. the dbsync marker), so a MARKEXPR relying on them selected different test sets in the skipall pass and the real run. Apply the skipall markers after the dynamic markers instead of returning early.

Also remove the dead xdist guard: 'slaveinput' was renamed to 'workerinput' in xdist 2.0, so the guard never fires - and it must not, since with xdist only the worker nodes collect tests and MARKEXPR filtering relies on the markers added by this hook. 'Fixing' the attribute name would have silently broken marker-based selection.

Update the count_test_results.py docstring that described the old registration behavior (pre-fix result directories are still handled correctly by the newest-wins rule).

Verified on a standalone reproduction: with the old behavior, 4 of 7 tests (class-level skipif, decorated skipif, param-level skipif, plain skip) were registered under their own reasons and '-m db' selected nothing during the skipall pass; with the new behavior all 7 register as 'collected, not run' and marker expression selection matches the real run exactly.