### PR TITLE
fix(ci): close two failure-notification gaps

### DIFF
--- a/.github/workflows/regression_reusable.yaml
+++ b/.github/workflows/regression_reusable.yaml
@@ -133,6 +133,8 @@ jobs:
         if: success() || failure()
         run: |
           if [ -f deselected_tests.txt ]; then
+            # The testing step can die before it creates run_workdir.
+            mkdir -p run_workdir
             mv deselected_tests.txt run_workdir/
           fi
       - name: Load failure-analysis prompt
@@ -163,11 +165,19 @@ jobs:
           prompt: ${{ env.ANALYSIS_PROMPT }}
       - name: Read failure analysis into env
         id: read-analysis
-        if: (success() || failure()) && steps.testing-step.outcome != 'success' && env.HAS_OAUTH_TOKEN == 'true'
+        # No `env.HAS_OAUTH_TOKEN` condition here - without the token, this step still has to
+        # set the FAILURE_ANALYSIS placeholder that the mail body renders.
+        if: (success() || failure()) && steps.testing-step.outcome != 'success'
         env:
           EXECUTION_FILE: ${{ steps.analyze-failures.outputs.execution_file }}
           ANALYZE_OUTCOME: ${{ steps.analyze-failures.outcome }}
         run: |
+          if [ "$HAS_OAUTH_TOKEN" != "true" ]; then
+            echo "FAILURE_ANALYSIS=(AI failure analysis not configured - the CLAUDE_CODE_OAUTH_TOKEN secret is not set)" >> "$GITHUB_ENV"
+            echo "::notice::AI failure analysis skipped - the CLAUDE_CODE_OAUTH_TOKEN secret is not set."
+            exit 0
+          fi
+
           # When the analyze step did not finish cleanly (e.g. ran out of
           # turns mid-write), the analysis file may be a partial draft - mark
           # it as such everywhere it is surfaced.

--- a/.github/workflows/upgrade_reusable.yaml
+++ b/.github/workflows/upgrade_reusable.yaml
@@ -111,11 +111,19 @@ jobs:
           prompt: ${{ env.ANALYSIS_PROMPT }}
       - name: Read failure analysis into env
         id: read-analysis
-        if: (success() || failure()) && steps.testing-step.outcome != 'success' && env.HAS_OAUTH_TOKEN == 'true'
+        # No `env.HAS_OAUTH_TOKEN` condition here - without the token, this step still has to
+        # set the FAILURE_ANALYSIS placeholder that the mail body renders.
+        if: (success() || failure()) && steps.testing-step.outcome != 'success'
         env:
           EXECUTION_FILE: ${{ steps.analyze-failures.outputs.execution_file }}
           ANALYZE_OUTCOME: ${{ steps.analyze-failures.outcome }}
         run: |
+          if [ "$HAS_OAUTH_TOKEN" != "true" ]; then
+            echo "FAILURE_ANALYSIS=(AI failure analysis not configured - the CLAUDE_CODE_OAUTH_TOKEN secret is not set)" >> "$GITHUB_ENV"
+            echo "::notice::AI failure analysis skipped - the CLAUDE_CODE_OAUTH_TOKEN secret is not set."
+            exit 0
+          fi
+
           # When the analyze step did not finish cleanly (e.g. ran out of
           # turns mid-write), the analysis file may be a partial draft - mark
           # it as such everywhere it is surfaced.


### PR DESCRIPTION
- The 'Move deselected_tests.txt artifact' step fails when the testing step dies before creating run_workdir (nix setup or workdir lock failures). Create the directory first, same as the failure-analysis steps already do.
- The failure mail does not require the CLAUDE_CODE_OAUTH_TOKEN secret, but the step that sets FAILURE_ANALYSIS did - without the token the mail rendered an empty string where the analysis belongs. Run the step regardless and set an explicit placeholder when the token is not configured.