### PR TITLE
refactor: use enum for respin lifecycle state

### DIFF
--- a/cardano_node_tests/cluster_management/cluster_getter.py
+++ b/cardano_node_tests/cluster_management/cluster_getter.py
@@ -17,6 +17,7 @@ is found and all conditions for starting the test are met. This includes handlin
 """
 
 import dataclasses
+import enum
 import logging
 import os
 import pathlib as pl
@@ -74,6 +75,35 @@ else:
         """No need to sleep if tests are running on a single worker."""
 
 
+class _RespinState(enum.Enum):
+    """State of the cluster respin lifecycle on this worker.
+
+    The respinning worker moves through the states:
+
+    * NONE - no respin claimed by this worker.
+    * CLAIMED - this worker claimed the respin of the selected cluster instance
+      (`_init_respin`) and is pinned to it. The claim is armed once all other
+      conditions for the respin are met - usually later in the same iteration,
+      or on a later one when the instance must be re-evaluated first (e.g. the
+      mark's resources must be resolved again).
+    * ARMED - the actual `_respin` will run at the start of the next iteration,
+      outside of the global lock so other workers don't need to wait.
+    * RESPUN - `_respin` has finished (successfully or not). The state moves here
+      right after the `_respin` call, so the respin runs exactly once per claim
+      even when later conditions delay the cleanup. The respin status records are
+      cleaned up under the lock afterwards (`_cleanup_after_respin`), which
+      returns the state to NONE.
+
+    When the cluster instance dies, `_cleanup_dead_cluster` resets any state
+    directly back to NONE and the respin is abandoned.
+    """
+
+    NONE = enum.auto()
+    CLAIMED = enum.auto()
+    ARMED = enum.auto()
+    RESPUN = enum.auto()
+
+
 @dataclasses.dataclass
 class _ClusterGetStatus:
     """Intermediate status while trying to `get` suitable cluster instance."""
@@ -88,8 +118,7 @@ class _ClusterGetStatus:
     selected_instance: int = -1
     instance_num: int = -1
     sleep_delay: int = 0
-    respin_here: bool = False
-    respin_ready: bool = False
+    respin_state: _RespinState = _RespinState.NONE
     cluster_needs_respin: bool = False
     prio_here: bool = False
     tried_all_instances: bool = False
@@ -315,8 +344,10 @@ class ClusterGetter:
             return False
 
         if cluster_obj is None:
-            # Should never reach this
+            # Should never reach this. Mark the instance as dead anyway - the respin
+            # runs only once per claim, so nothing else would retry the failed start.
             self.log(f"c{self.cluster_instance_num}: failed to start cluster")
+            status_db.set_cluster_dead(instance_num=self.cluster_instance_num)
             return False
 
         # Generate ID for the new cluster instance so it is possible to match log entries with
@@ -571,9 +602,9 @@ class ClusterGetter:
         cget_status.prio_here = True
         self.log(f"setting 'prio' for '{cget_status.current_test}'")
 
-    def _respun_by_other_worker(self, cget_status: _ClusterGetStatus) -> bool:
+    def _being_respun_by_other_worker(self, cget_status: _ClusterGetStatus) -> bool:
         """Check if the cluster is currently being respun by worker other than this one."""
-        if cget_status.respin_here:
+        if cget_status.respin_state is not _RespinState.NONE:
             return False
 
         respin_in_progress = self.snap.list_respin_progress(instance_num=cget_status.instance_num)
@@ -589,7 +620,7 @@ class ClusterGetter:
             )
             return True
 
-        if cget_status.marked_running_my_anywhere and not cget_status.respin_here:
+        if cget_status.marked_running_my_anywhere and cget_status.respin_state is _RespinState.NONE:
             self.log(
                 f"c{cget_status.instance_num}: tests marked with my mark '{cget_status.mark}' "
                 "already running on other cluster instance, cannot start"
@@ -687,20 +718,22 @@ class ClusterGetter:
 
         return respin_after_mark
 
-    def _cleanup_dead_clusters(self, cget_status: _ClusterGetStatus) -> None:
+    def _cleanup_dead_cluster(self, cget_status: _ClusterGetStatus) -> None:
         """Cleanup if the selected cluster instance failed to start."""
-        # Move on to other cluster instance
+        # Move on to other cluster instance.
+        # Respin status records ("respin in progress", "respin needed") may stay
+        # behind on the dead instance. They are never read - dead instances are never
+        # revived and workers skip them before checking the respin records.
         cget_status.selected_instance = -1
-        cget_status.respin_here = False
-        cget_status.respin_ready = False
+        cget_status.respin_state = _RespinState.NONE
 
         # Remove status records that are checked by other workers
         self._rm_marks(instance_num=cget_status.instance_num)
 
     def _init_respin(self, cget_status: _ClusterGetStatus) -> bool:
         """Initialize respin of this cluster instance on this worker."""
-        # Respin already initialized
-        if cget_status.respin_here:
+        # Respin already claimed by this worker
+        if cget_status.respin_state is not _RespinState.NONE:
             return True
 
         if not (cget_status.cluster_needs_respin or self._test_needs_respin(cget_status)):
@@ -714,15 +747,16 @@ class ClusterGetter:
         self.log(f"c{cget_status.instance_num}: setting 'respin in progress'")
 
         # Cluster respin will be performed by this worker.
-        # By setting `respin_here`, we make sure this worker continue on this cluster instance
+        # By claiming the respin, we make sure this worker continues on this cluster instance
         # after respin is finished. It is important because the `scriptsdir` used for starting the
         # cluster instance might be specific for the test.
-        cget_status.respin_here = True
-        cget_status.selected_instance = cget_status.instance_num
-
+        # The durable record is created first, the in-memory state is updated only after
+        # that succeeded - same convention as in `_cleanup_after_respin`.
         status_db.create_respin_progress(
             instance_num=cget_status.instance_num, worker_id=self.worker_id
         )
+        cget_status.respin_state = _RespinState.CLAIMED
+        cget_status.selected_instance = cget_status.instance_num
 
         # Remove mark status records and marked resource records as these will not be
         # valid after respin
@@ -745,30 +779,37 @@ class ClusterGetter:
 
         return True
 
-    def _finish_respin(self, cget_status: _ClusterGetStatus) -> bool:
-        """On first call, setup cluster instance for respin. On second call, perform cleanup."""
-        if not cget_status.respin_here:
-            return True
+    def _arm_respin(self, cget_status: _ClusterGetStatus) -> None:
+        """Arm the claimed respin so `_respin` runs on the next iteration.
 
-        if cget_status.respin_ready:
-            # The cluster was already respined if we are here and `respin_ready` is still True.
-            # If that's the case, do cleanup.
-            cget_status.respin_ready = False
-            cget_status.respin_here = False
-
-            # Remove status records that are no longer valid after respin
-            status_db.rm_respin_progress(instance_num=cget_status.instance_num)
-            status_db.rm_respin_needed(instance_num=cget_status.instance_num)
-
-            return True
+        The actual `_respin` function will be called outside of global lock so other
+        workers don't need to wait.
+        """
+        if cget_status.respin_state is not _RespinState.CLAIMED:
+            msg = f"Cannot arm respin in the '{cget_status.respin_state.name}' state."
+            raise RuntimeError(msg)
 
         # NOTE: when `_respin` is called, the env variables needed for cluster start scripts need
         # to be already set (e.g. CARDANO_NODE_SOCKET_PATH)
         self.log(f"c{cget_status.instance_num}: ready to respin cluster")
-        # The actual `_respin` function will be called outside of global lock so other workers
-        # don't need to wait
-        cget_status.respin_ready = True
-        return False
+        cget_status.respin_state = _RespinState.ARMED
+
+    def _cleanup_after_respin(self, cget_status: _ClusterGetStatus) -> None:
+        """Clean up after the respin of this cluster instance was performed.
+
+        Must be called only in the RESPUN state, after `_respin` has run: the respin
+        status records are removed for the whole instance, so a premature call would
+        delete another worker's records and break the cross-worker coordination.
+        """
+        if cget_status.respin_state is not _RespinState.RESPUN:
+            msg = f"Cannot clean up after respin in the '{cget_status.respin_state.name}' state."
+            raise RuntimeError(msg)
+
+        # Remove status records that are no longer valid after respin
+        status_db.rm_respin_progress(instance_num=cget_status.instance_num)
+        status_db.rm_respin_needed(instance_num=cget_status.instance_num)
+
+        cget_status.respin_state = _RespinState.NONE
 
     def _init_marked_test(self, cget_status: _ClusterGetStatus) -> None:
         """Create status record for marked test."""
@@ -986,8 +1027,11 @@ class ClusterGetter:
                 msg = "Timeout (hard) while waiting to obtain cluster instance."
                 raise TimeoutError(msg)
 
-            if cget_status.respin_ready:
+            if cget_status.respin_state is _RespinState.ARMED:
                 self._respin(scriptsdir=scriptsdir)
+                # Move to RESPUN right away - re-entering this branch on a later
+                # iteration must not restart the cluster again
+                cget_status.respin_state = _RespinState.RESPUN
 
             # Sleep for a while to avoid too many checks in a short time
             _xdist_sleep(random.uniform(0.6, 1.2) * cget_status.sleep_delay)
@@ -1044,11 +1088,11 @@ class ClusterGetter:
 
                     # Cleanup cluster instance where attempt to start cluster failed repeatedly
                     if self.snap.is_cluster_dead(instance_num=instance_num):
-                        self._cleanup_dead_clusters(cget_status)
+                        self._cleanup_dead_cluster(cget_status)
                         continue
 
                     # Cluster respin planned or in progress, so no new tests can start
-                    if self._respun_by_other_worker(cget_status):
+                    if self._being_respun_by_other_worker(cget_status):
                         cget_status.sleep_delay = 5
                         continue
 
@@ -1137,9 +1181,15 @@ class ClusterGetter:
                     # don't try to prepare another cluster instance.
                     self._init_marked_test(cget_status)
 
-                    # If needed, finish respin related actions
-                    if not self._finish_respin(cget_status):
+                    # Arm the claimed respin and return to the top-level loop, where
+                    # `_respin` runs outside of the global lock
+                    if cget_status.respin_state is _RespinState.CLAIMED:
+                        self._arm_respin(cget_status)
                         continue
+
+                    # The respin was already performed, clean up the respin status records
+                    if cget_status.respin_state is _RespinState.RESPUN:
+                        self._cleanup_after_respin(cget_status)
 
                     # From this point on, all conditions needed to start the test are met
                     break

--- a/framework_tests/test_cluster_getter.py
+++ b/framework_tests/test_cluster_getter.py
@@ -160,21 +160,20 @@ def test_on_marked_test_stop_no_respin_promise():
 
 
 @pytest.mark.usefixtures("db_dir")
-def test_cleanup_dead_clusters_removes_marks():
+def test_cleanup_dead_cluster_removes_marks():
     """Check that dead cluster instance cleanup removes marks and marked resources."""
     getter = _get_cluster_getter()
     cget_status = _get_cget_status(instance_num=0)
     cget_status.selected_instance = 0
-    cget_status.respin_here = True
-    cget_status.respin_ready = True
+    # The state a worker is in when its respin attempt failed and killed the instance
+    cget_status.respin_state = cluster_getter._RespinState.RESPUN
 
     _populate_marked(instance_num=0, mark="markA")
 
-    getter._cleanup_dead_clusters(cget_status)
+    getter._cleanup_dead_cluster(cget_status)
 
     assert cget_status.selected_instance == -1
-    assert cget_status.respin_here is False
-    assert cget_status.respin_ready is False
+    assert cget_status.respin_state is cluster_getter._RespinState.NONE
     assert status_db.list_curr_mark(instance_num=0) == []
     assert status_db.get_resource_names(mode=status_db.MODE_LOCK, instance_num=0) == []
     assert status_db.get_resource_names(mode=status_db.MODE_USE, instance_num=0) == []
@@ -203,7 +202,7 @@ def test_init_respin_own_mark():
     assert getter._init_respin(cget_status) is False
 
     assert cget_status.marked_ready_rows == ()
-    assert cget_status.respin_here is True
+    assert cget_status.respin_state is cluster_getter._RespinState.CLAIMED
     assert cget_status.selected_instance == 0
     assert len(status_db.list_respin_progress(instance_num=0)) == 1
     # The respin stays scheduled even when the re-evaluation gets delayed
@@ -212,13 +211,20 @@ def test_init_respin_own_mark():
     assert status_db.get_resource_names(mode=status_db.MODE_LOCK, instance_num=0) == []
     assert status_db.get_resource_names(mode=status_db.MODE_USE, instance_num=0) == []
 
-    # The re-evaluation re-creates the mark's records; the second `_init_respin` call
-    # must short-circuit on `respin_here` and not wipe them again
+    # The re-evaluation re-creates the mark's records; later `_init_respin` calls
+    # must short-circuit on the owned respin and not wipe them again. The short-circuit
+    # must hold in every owning phase, incl. the post-respin re-entry.
     _populate_marked(instance_num=0, mark="markA")
-    assert getter._init_respin(cget_status) is True
-    assert len(status_db.list_curr_mark(instance_num=0)) == 1
-    assert status_db.get_resource_names(mode=status_db.MODE_LOCK, instance_num=0) != []
-    assert len(status_db.list_respin_progress(instance_num=0)) == 1
+    for own_state in (
+        cluster_getter._RespinState.CLAIMED,
+        cluster_getter._RespinState.ARMED,
+        cluster_getter._RespinState.RESPUN,
+    ):
+        cget_status.respin_state = own_state
+        assert getter._init_respin(cget_status) is True
+        assert len(status_db.list_curr_mark(instance_num=0)) == 1
+        assert status_db.get_resource_names(mode=status_db.MODE_LOCK, instance_num=0) != []
+        assert len(status_db.list_respin_progress(instance_num=0)) == 1
 
 
 @pytest.mark.usefixtures("db_dir")
@@ -240,8 +246,8 @@ def test_marked_select_instance_respinner_not_blocked():
     assert getter._marked_select_instance(cget_status) is False
 
     # The respinning worker proceeds as the first test of the mark
-    cget_status.respin_here = True
-    cget_status.selected_instance = 0  # `respin_here` always comes with the pinned instance
+    cget_status.respin_state = cluster_getter._RespinState.CLAIMED
+    cget_status.selected_instance = 0  # A claimed respin always comes with the pinned instance
     assert getter._marked_select_instance(cget_status) is True
 
 
@@ -262,7 +268,7 @@ def test_init_respin_tests_running():
 
     assert getter._init_respin(cget_status) is False
 
-    assert cget_status.respin_here is False
+    assert cget_status.respin_state is cluster_getter._RespinState.NONE
     assert status_db.list_respin_progress(instance_num=0) == []
     assert len(status_db.list_curr_mark(instance_num=0)) == 1
     assert status_db.get_resource_names(mode=status_db.MODE_LOCK, instance_num=0) != []
@@ -283,7 +289,7 @@ def test_init_respin_foreign_marks():
 
     assert getter._init_respin(cget_status) is True
 
-    assert cget_status.respin_here is True
+    assert cget_status.respin_state is cluster_getter._RespinState.CLAIMED
     assert status_db.list_curr_mark(instance_num=0) == []
     assert status_db.get_resource_names(mode=status_db.MODE_LOCK, instance_num=0) == []
 
@@ -713,20 +719,25 @@ class TestPrio:
 
 
 @pytest.mark.usefixtures("db_dir")
-def test_respun_by_other_worker():
+def test_being_respun_by_other_worker():
     """Check the detection of a respin done by another worker."""
     getter = _get_cluster_getter()
     cget_status = _get_cget_status(instance_num=0)
 
-    assert getter._respun_by_other_worker(cget_status) is False
+    assert getter._being_respun_by_other_worker(cget_status) is False
 
     status_db.create_respin_progress(instance_num=0, worker_id="gw1")
     getter.snap.refresh()
-    assert getter._respun_by_other_worker(cget_status) is True
+    assert getter._being_respun_by_other_worker(cget_status) is True
 
-    # The worker doing the respin is not blocked by its own respin
-    cget_status.respin_here = True
-    assert getter._respun_by_other_worker(cget_status) is False
+    # The worker doing the respin is not blocked by its own respin, in any phase
+    for own_state in (
+        cluster_getter._RespinState.CLAIMED,
+        cluster_getter._RespinState.ARMED,
+        cluster_getter._RespinState.RESPUN,
+    ):
+        cget_status.respin_state = own_state
+        assert getter._being_respun_by_other_worker(cget_status) is False
 
 
 @pytest.mark.usefixtures("db_dir")
@@ -745,34 +756,64 @@ def test_is_already_running():
 
 
 @pytest.mark.usefixtures("db_dir")
-def test_finish_respin_phases():
-    """Check the two-phase respin finishing.
+def test_respin_arm_and_cleanup():
+    """Check respin arming and the cleanup after the respin.
 
-    The first call only signals that the cluster instance is ready to be respun (the
-    actual respin runs outside of the global lock). The second call cleans up the
-    respin status records.
+    Arming only signals that the cluster instance is ready to be respun (the actual
+    respin runs outside of the global lock). The cleanup afterwards removes the respin
+    status records.
     """
     getter = _get_cluster_getter()
     cget_status = _get_cget_status(instance_num=0)
 
-    # No respin on this worker - nothing to do
-    assert getter._finish_respin(cget_status) is True
-
-    cget_status.respin_here = True
+    cget_status.respin_state = cluster_getter._RespinState.CLAIMED
     status_db.create_respin_progress(instance_num=0, worker_id="gw0")
     status_db.create_respin_needed(instance_num=0, worker_id="gw0")
 
-    # First call - ready to respin, cannot continue in this iteration
-    assert getter._finish_respin(cget_status) is False
-    assert cget_status.respin_ready is True
+    # Arm the respin - the status records must stay until the respin is performed
+    getter._arm_respin(cget_status)
+    assert cget_status.respin_state is cluster_getter._RespinState.ARMED
     assert len(status_db.list_respin_progress(instance_num=0)) == 1
+    assert len(status_db.list_respin_needed(instance_num=0)) == 1
 
-    # Second call - respin done, clean up
-    assert getter._finish_respin(cget_status) is True
-    assert cget_status.respin_ready is False
-    assert cget_status.respin_here is False
+    # The respin itself runs in `get_cluster_instance`, outside of the global lock
+    cget_status.respin_state = cluster_getter._RespinState.RESPUN
+
+    # Respin done - clean up
+    getter._cleanup_after_respin(cget_status)
+    assert cget_status.respin_state is cluster_getter._RespinState.NONE
     assert status_db.list_respin_progress(instance_num=0) == []
     assert status_db.list_respin_needed(instance_num=0) == []
+
+
+@pytest.mark.usefixtures("db_dir")
+def test_respin_wrong_state_rejected():
+    """Check that arming and cleanup fail fast when called in a wrong respin state."""
+    getter = _get_cluster_getter()
+    cget_status = _get_cget_status(instance_num=0)
+
+    # Arming is valid only for a claimed respin
+    for state in (
+        cluster_getter._RespinState.NONE,
+        cluster_getter._RespinState.ARMED,
+        cluster_getter._RespinState.RESPUN,
+    ):
+        cget_status.respin_state = state
+        with pytest.raises(RuntimeError, match="Cannot arm respin"):
+            getter._arm_respin(cget_status)
+
+    # Cleanup is valid only for a performed respin - a premature call would delete
+    # another worker's respin status records
+    status_db.create_respin_progress(instance_num=0, worker_id="gw1")
+    for state in (
+        cluster_getter._RespinState.NONE,
+        cluster_getter._RespinState.CLAIMED,
+        cluster_getter._RespinState.ARMED,
+    ):
+        cget_status.respin_state = state
+        with pytest.raises(RuntimeError, match="Cannot clean up after respin"):
+            getter._cleanup_after_respin(cget_status)
+    assert len(status_db.list_respin_progress(instance_num=0)) == 1
 
 
 @pytest.mark.usefixtures("db_dir")


### PR DESCRIPTION
Replace the `respin_here` and `respin_ready` booleans in `_ClusterGetStatus` with a `_RespinState` enum (NONE, CLAIMED, ARMED). The enum makes the illegal fourth combination (ready without here) unrepresentable and names the respin phases.

Split the two-phase `_finish_respin` method into `_arm_respin` and `_cleanup_after_respin`, with explicit dispatch on the state at the call site in `get_cluster_instance`. The old method did different work on first and second call, encoded in a boolean return value.

Document the lifecycle, the dead-cluster abort edge and the ARMED-only precondition of the cleanup. Extend the unit test for `_respun_by_other_worker` to cover both CLAIMED and ARMED.