### PR TITLE
feat: lock dev cluster to a single pytest run

### DIFF
--- a/cardano_node_tests/tests/conftest.py
+++ b/cardano_node_tests/tests/conftest.py
@@ -21,6 +21,7 @@ from cardano_node_tests.utils import cluster_nodes
 from cardano_node_tests.utils import configuration
 from cardano_node_tests.utils import dbsync_conn
 from cardano_node_tests.utils import dbsync_queries
+from cardano_node_tests.utils import dev_session
 from cardano_node_tests.utils import helpers
 from cardano_node_tests.utils import locking
 from cardano_node_tests.utils import submit_utils
@@ -288,6 +289,10 @@ def testenv_setup_teardown(worker_id: str, request: FixtureRequest) -> tp.Genera
     session_basetemp = temptools.get_basetemp()
     running_session_glob = ".running_session"
 
+    # Make sure the dev cluster is not used by multiple pytest invocations at the same time
+    if configuration.DEV_CLUSTER_RUNNING:
+        dev_session.claim_session()
+
     with locking.FileLockIfXdist(f"{pytest_root_tmp}/{cluster_management.CLUSTER_LOCK}"):
         # Save environment info for Allure
         if not list(pytest_root_tmp.glob(f"{running_session_glob}_*")):
@@ -302,38 +307,56 @@ def testenv_setup_teardown(worker_id: str, request: FixtureRequest) -> tp.Genera
     yield
 
     with locking.FileLockIfXdist(f"{pytest_root_tmp}/{cluster_management.CLUSTER_LOCK}"):
-        # Remove file indicating that testing session on this worker is running
-        (pytest_root_tmp / f"{running_session_glob}_{worker_id}").unlink()
+        try:
+            # Remove file indicating that testing session on this worker is running
+            (pytest_root_tmp / f"{running_session_glob}_{worker_id}").unlink()
 
-        # Save CLI coverage to dir specified by `--cli-coverage-dir`
-        cluster_manager_obj = cluster_management.ClusterManager(
-            worker_id=worker_id, pytest_config=request.config
-        )
-        cluster_manager_obj.save_worker_cli_coverage()
+            # Save CLI coverage to dir specified by `--cli-coverage-dir`
+            cluster_manager_obj = cluster_management.ClusterManager(
+                worker_id=worker_id, pytest_config=request.config
+            )
+            cluster_manager_obj.save_worker_cli_coverage()
 
-        # Don't do any cleanup on keyboard interrupt
-        if (session_basetemp / INTERRUPTED_NAME).exists():
-            return None
+            last_worker = not list(pytest_root_tmp.glob(f"{running_session_glob}_*"))
 
-        # Perform cleanup if this is the last running pytest worker
-        if not list(pytest_root_tmp.glob(f"{running_session_glob}_*")):
-            # Perform testnet cleanup
-            _testnet_cleanup(pytest_root_tmp=pytest_root_tmp)
+            # Don't do any testnet / artifacts cleanup on keyboard interrupt (the dev
+            # cluster session is still released in the `finally` block)
+            if (session_basetemp / INTERRUPTED_NAME).exists():
+                return None
 
-            if configuration.DEV_CLUSTER_RUNNING:
-                # Save cluster artifacts only when requested - it is not desirable to
-                # save them on every pytest invocation on a dev cluster
-                if configuration.FORCE_SAVE_CLUSTER_ARTIFACTS:
-                    state_dir = cluster_nodes.get_cluster_env().state_dir
-                    artifacts.save_cluster_artifacts(save_dir=pytest_root_tmp, state_dir=state_dir)
+            # Perform cleanup if this is the last running pytest worker
+            if last_worker:
+                # Perform testnet cleanup
+                _testnet_cleanup(pytest_root_tmp=pytest_root_tmp)
+
+                if configuration.DEV_CLUSTER_RUNNING:
+                    # Save cluster artifacts only when requested - it is not desirable to
+                    # save them on every pytest invocation on a dev cluster
+                    if configuration.FORCE_SAVE_CLUSTER_ARTIFACTS:
+                        state_dir = cluster_nodes.get_cluster_env().state_dir
+                        artifacts.save_cluster_artifacts(
+                            save_dir=pytest_root_tmp, state_dir=state_dir
+                        )
+                    else:
+                        LOGGER.info("Not saving cluster artifacts of the dev cluster.")
+                elif configuration.KEEP_CLUSTERS_RUNNING:
+                    # Keep cluster instances running. Stopping them would need to be
+                    # handled manually.
+                    _save_all_cluster_instances_artifacts(cluster_manager_obj=cluster_manager_obj)
                 else:
-                    LOGGER.info("Not saving cluster artifacts of the dev cluster.")
-            elif configuration.KEEP_CLUSTERS_RUNNING:
-                # Keep cluster instances running. Stopping them would need to be handled manually.
-                _save_all_cluster_instances_artifacts(cluster_manager_obj=cluster_manager_obj)
-            else:
-                _save_all_cluster_instances_artifacts(cluster_manager_obj=cluster_manager_obj)
-                _stop_all_cluster_instances(cluster_manager_obj=cluster_manager_obj)
+                    _save_all_cluster_instances_artifacts(cluster_manager_obj=cluster_manager_obj)
+                    _stop_all_cluster_instances(cluster_manager_obj=cluster_manager_obj)
+        finally:
+            # Release the dev cluster only after all cleanup is done (this pytest invocation
+            # is still using the cluster while saving its artifacts). Runs also on graceful
+            # interrupt (the `return` above) and when the teardown fails. If the process dies
+            # without reaching teardown, the stale-PID check in `dev_session.claim_session`
+            # unblocks the cluster. The "last worker" state is checked here and not reused
+            # from the `try` block, as the block may fail before computing it.
+            if configuration.DEV_CLUSTER_RUNNING and not list(
+                pytest_root_tmp.glob(f"{running_session_glob}_*")
+            ):
+                dev_session.release_session()
 
 
 @pytest.fixture(scope="session", autouse=True)

--- a/cardano_node_tests/utils/dev_session.py
+++ b/cardano_node_tests/utils/dev_session.py
@@ -1,0 +1,170 @@
+"""Exclusive use of a dev cluster by a single pytest invocation.
+
+With `DEV_CLUSTER_RUNNING`, multiple concurrent pytest invocations (possibly from different
+git worktrees) can target the same dev cluster instance. The cluster management locks live
+under the invocation-specific pytest temp dir, so they cannot coordinate across invocations.
+Instead, each invocation records its identity in a claim file next to the dev cluster state
+dir, and refuses to run when the cluster is already claimed by another live invocation.
+"""
+
+import json
+import logging
+import os
+import pathlib as pl
+
+from cardano_node_tests.utils import configuration
+from cardano_node_tests.utils import locking
+from cardano_node_tests.utils import temptools
+
+LOGGER = logging.getLogger(__name__)
+
+SESSION_PREFIX = ".pytest_session"
+LOCK_TIMEOUT = 30
+
+
+def _get_state_dir() -> pl.Path:
+    """Return path to the state dir of the dev cluster."""
+    return configuration.STARTUP_CARDANO_NODE_SOCKET_PATH.parent
+
+
+def _get_session_file() -> pl.Path:
+    """Return path to the file that records the pytest invocation using the dev cluster.
+
+    The file cannot live in the cluster state dir, as the state dir is recreated when
+    the devnet is started. It cannot live under the pytest temp dir (invocation-specific)
+    or `TMPDIR` (worktree-specific) either. Use the parent of the state dir (the dev
+    cluster work dir) instead - it is shared by all pytest invocations that target the
+    same dev cluster instance and it survives devnet restarts.
+    """
+    state_dir = _get_state_dir()
+    return state_dir.parent / f"{SESSION_PREFIX}_{state_dir.name}"
+
+
+def _get_session_id() -> dict:
+    """Return identity of this pytest invocation recorded in the dev session file."""
+    return {
+        "root_tmp": str(temptools.get_pytest_root_tmp()),
+        # All xdist workers of a single pytest invocation are children of the same
+        # controller process
+        "pid": os.getppid() if configuration.IS_XDIST else os.getpid(),
+    }
+
+
+def _is_pid_running(pid: int) -> bool:
+    """Check whether a process with the given PID is running."""
+    if pid <= 0:
+        return False
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    return True
+
+
+def _get_recorded_pid(session_data: dict) -> int:
+    """Return the PID recorded in the session data, or 0 when missing or invalid."""
+    try:
+        return int(session_data.get("pid") or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _load_session_data(session_file: pl.Path) -> dict:
+    """Load recorded dev session data, treating a corrupt file as empty."""
+    try:
+        session_data = json.loads(session_file.read_text())
+    # OSError e.g. when the file was deleted after the `exists()` check, ValueError covers
+    # both invalid JSON and a torn write that is not valid UTF-8
+    except (OSError, ValueError):
+        session_data = None
+
+    if not isinstance(session_data, dict):
+        LOGGER.warning(f"Corrupt dev cluster session file '{session_file}'.")
+        return {}
+
+    return session_data
+
+
+def claim_session() -> None:
+    """Claim exclusive use of the dev cluster for this pytest invocation.
+
+    Raises:
+        RuntimeError: When the dev cluster is already used by another live pytest invocation,
+            or when the session lock cannot be acquired.
+    """
+    session_file = _get_session_file()
+    session_file.parent.mkdir(exist_ok=True)
+    session_id = _get_session_id()
+    lock_file = f"{session_file}.lock"
+
+    try:
+        # `locking.Timeout` cannot originate from the `with` block body, as there is no other
+        # lock acquisition inside - only the acquisition on `with` entry can raise it
+        with locking.FileLock(lock_file, timeout=LOCK_TIMEOUT):
+            if session_file.exists():
+                session_data = _load_session_data(session_file=session_file)
+
+                other_root_tmp = session_data.get("root_tmp")
+                other_pid = _get_recorded_pid(session_data=session_data)
+
+                if other_root_tmp == session_id["root_tmp"] and other_pid == session_id["pid"]:
+                    # Another xdist worker of this pytest invocation already claimed the cluster
+                    return
+
+                # A recorded PID that matches this invocation but with a different `root_tmp`
+                # can only be a recycled PID - a live claim by this invocation matches on both
+                # fields.
+                if other_pid != session_id["pid"] and _is_pid_running(pid=other_pid):
+                    msg = (
+                        f"The dev cluster in '{_get_state_dir()}' is already used by another "
+                        f"pytest invocation (PID {other_pid}, temp dir '{other_root_tmp}'). "
+                        f"Wait for it to finish first, or delete '{session_file}' "
+                        f"if the record is stale."
+                    )
+                    raise RuntimeError(msg)
+
+                if other_pid == session_id["pid"]:
+                    reason = f"PID {other_pid} was recycled and is now this invocation"
+                elif other_pid:
+                    reason = f"PID {other_pid} not running"
+                else:
+                    reason = "no valid PID recorded"
+
+                LOGGER.warning(
+                    f"Ignoring stale dev cluster session file '{session_file}' ({reason})."
+                )
+
+            session_file.write_text(json.dumps(session_id))
+    except locking.Timeout as excp:
+        msg = (
+            f"Could not acquire the dev cluster session lock '{lock_file}' "
+            f"in {LOCK_TIMEOUT}s - another pytest invocation may be stuck."
+        )
+        raise RuntimeError(msg) from excp
+
+
+def release_session() -> None:
+    """Release the dev cluster claimed by this pytest invocation.
+
+    Best-effort - failures are logged but never raised, so a failed release cannot mask
+    cleanup errors in the session teardown.
+    """
+    session_file: pl.Path | None = None
+    try:
+        session_file = _get_session_file()
+        session_id = _get_session_id()
+
+        with locking.FileLock(f"{session_file}.lock", timeout=LOCK_TIMEOUT):
+            if not session_file.exists():
+                return
+
+            session_data = _load_session_data(session_file=session_file)
+            if (
+                session_data.get("root_tmp") == session_id["root_tmp"]
+                and _get_recorded_pid(session_data=session_data) == session_id["pid"]
+            ):
+                session_file.unlink(missing_ok=True)
+    except Exception:
+        LOGGER.exception(f"Failed to release dev cluster session file '{session_file}'.")

--- a/cardano_node_tests/utils/locking.py
+++ b/cardano_node_tests/utils/locking.py
@@ -1,18 +1,25 @@
+"""File-based locking.
+
+`FileLock` is a real lock that works regardless of how pytest is invoked - use it when
+coordination is needed even outside pytest-xdist, e.g. across pytest invocations.
+`FileLockIfXdist` degrades to a no-op when not running with pytest-xdist workers.
+"""
+
 import contextlib
 import logging
 import typing as tp
 
+from filelock import FileLock
+from filelock import Timeout
+
 from cardano_node_tests.utils import configuration
+
+# Suppress messages from filelock
+logging.getLogger("filelock").setLevel(logging.WARNING)
 
 # Use dummy locking if not executing with multiple workers.
 # When running with multiple workers, operations with shared resources (like faucet addresses)
 # need to be locked to single worker (otherwise e.g. balances would not check).
-if configuration.IS_XDIST:
-    from filelock import FileLock
+FileLockIfXdist: tp.Any = FileLock if configuration.IS_XDIST else contextlib.nullcontext
 
-    # Suppress messages from filelock
-    logging.getLogger("filelock").setLevel(logging.WARNING)
-
-    FileLockIfXdist: tp.Any = FileLock
-else:
-    FileLockIfXdist = contextlib.nullcontext
+__all__ = ["FileLock", "FileLockIfXdist", "Timeout"]

--- a/framework_tests/test_dev_session.py
+++ b/framework_tests/test_dev_session.py
@@ -1,0 +1,179 @@
+"""Unit tests for `cardano_node_tests.utils.dev_session`.
+
+The session file location, the invocation identity and the PID-liveness check are
+monkeypatched, so the tests don't depend on a configured cluster environment, on pytest
+temp dirs, or on the set of processes running on the machine.
+"""
+
+import json
+import os
+import pathlib as pl
+
+import pytest
+
+from cardano_node_tests.utils import dev_session
+
+LIVE_PIDS = {111, 222}
+
+
+@pytest.fixture
+def session_file(tmp_path: pl.Path, monkeypatch: pytest.MonkeyPatch) -> pl.Path:
+    """Return a session file path in a temp work dir; patch its lookup and PID liveness."""
+    work_dir = tmp_path / "work"
+    work_dir.mkdir()
+    s_file = work_dir / f"{dev_session.SESSION_PREFIX}_state-cluster0"
+    monkeypatch.setattr(dev_session, "_get_session_file", lambda: s_file)
+    monkeypatch.setattr(dev_session, "_is_pid_running", lambda pid: pid in LIVE_PIDS)
+    return s_file
+
+
+def _set_invocation(monkeypatch: pytest.MonkeyPatch, root_tmp: str, pid: int) -> None:
+    """Patch the identity of the "current" pytest invocation."""
+    monkeypatch.setattr(dev_session, "_get_session_id", lambda: {"root_tmp": root_tmp, "pid": pid})
+
+
+class TestClaimRelease:
+    """Tests for `claim_session` and `release_session`."""
+
+    def test_claim_and_release(self, session_file: pl.Path, monkeypatch: pytest.MonkeyPatch):
+        """Claim the cluster, re-claim from another worker, release it."""
+        _set_invocation(monkeypatch, root_tmp="run1", pid=111)
+        dev_session.claim_session()
+        assert json.loads(session_file.read_text()) == {"root_tmp": "run1", "pid": 111}
+
+        # Another xdist worker of the same invocation re-claims without error
+        dev_session.claim_session()
+
+        dev_session.release_session()
+        assert not session_file.exists()
+
+    def test_second_invocation_blocked(
+        self, session_file: pl.Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        """Refuse to claim the cluster used by another live invocation."""
+        _set_invocation(monkeypatch, root_tmp="run1", pid=111)
+        dev_session.claim_session()
+
+        _set_invocation(monkeypatch, root_tmp="run2", pid=222)
+        with pytest.raises(RuntimeError, match="already used by another"):
+            dev_session.claim_session()
+
+        # The rejected claim must not modify the original owner's record
+        assert json.loads(session_file.read_text()) == {"root_tmp": "run1", "pid": 111}
+
+    def test_release_by_non_owner(self, session_file: pl.Path, monkeypatch: pytest.MonkeyPatch):
+        """Keep the session file when released by an invocation that doesn't own it."""
+        _set_invocation(monkeypatch, root_tmp="run1", pid=111)
+        dev_session.claim_session()
+
+        _set_invocation(monkeypatch, root_tmp="run2", pid=222)
+        dev_session.release_session()
+        assert session_file.exists()
+
+    def test_release_without_session_file(
+        self, session_file: pl.Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        """Do nothing when there is no session file to release."""
+        _set_invocation(monkeypatch, root_tmp="run1", pid=111)
+        dev_session.release_session()
+        assert not session_file.exists()
+
+    def test_claim_lock_timeout(self, session_file: pl.Path, monkeypatch: pytest.MonkeyPatch):
+        """Raise a helpful error when the session lock cannot be acquired in time."""
+        _set_invocation(monkeypatch, root_tmp="run1", pid=111)
+        monkeypatch.setattr(dev_session, "LOCK_TIMEOUT", 0.1)
+
+        with (
+            dev_session.locking.FileLock(f"{session_file}.lock"),
+            pytest.raises(RuntimeError, match="Could not acquire"),
+        ):
+            dev_session.claim_session()
+
+    def test_release_never_raises(self, session_file: pl.Path, monkeypatch: pytest.MonkeyPatch):
+        """Log and swallow unexpected errors during release instead of raising."""
+        _set_invocation(monkeypatch, root_tmp="run1", pid=111)
+        dev_session.claim_session()
+
+        def _broken_lock(*_args: object, **_kwargs: object) -> None:
+            err = "Lock is broken"
+            raise RuntimeError(err)
+
+        monkeypatch.setattr(dev_session.locking, "FileLock", _broken_lock)
+        dev_session.release_session()
+        # The claim is left behind when release fails
+        assert session_file.exists()
+
+
+class TestStaleClaims:
+    """Tests for handling stale or corrupt session files."""
+
+    def test_dead_pid_takeover(self, session_file: pl.Path, monkeypatch: pytest.MonkeyPatch):
+        """Take over a session file that records a PID that is no longer running."""
+        session_file.write_text(json.dumps({"root_tmp": "run1", "pid": 999}))
+        _set_invocation(monkeypatch, root_tmp="run2", pid=222)
+        dev_session.claim_session()
+        assert json.loads(session_file.read_text()) == {"root_tmp": "run2", "pid": 222}
+
+    def test_recycled_pid_takeover(self, session_file: pl.Path, monkeypatch: pytest.MonkeyPatch):
+        """Treat a recorded PID that matches this invocation but different temp dir as stale."""
+        session_file.write_text(json.dumps({"root_tmp": "runX", "pid": 222}))
+        _set_invocation(monkeypatch, root_tmp="run2", pid=222)
+        dev_session.claim_session()
+        assert json.loads(session_file.read_text()) == {"root_tmp": "run2", "pid": 222}
+
+    @pytest.mark.parametrize(
+        "content",
+        ["{not json", "42", json.dumps({"root_tmp": "runX", "pid": "bogus"})],
+        ids=["garbage", "non_dict", "bogus_pid"],
+    )
+    def test_corrupt_file_takeover(
+        self, session_file: pl.Path, monkeypatch: pytest.MonkeyPatch, content: str
+    ):
+        """Take over a session file with corrupt or invalid content."""
+        session_file.write_text(content)
+        _set_invocation(monkeypatch, root_tmp="run1", pid=111)
+        dev_session.claim_session()
+        assert json.loads(session_file.read_text()) == {"root_tmp": "run1", "pid": 111}
+
+    def test_corrupt_file_release(self, session_file: pl.Path, monkeypatch: pytest.MonkeyPatch):
+        """Never crash on release when the session file is corrupt."""
+        session_file.write_text("{not json")
+        _set_invocation(monkeypatch, root_tmp="run1", pid=111)
+        dev_session.release_session()
+        assert session_file.exists()
+
+
+class TestHelpers:
+    """Tests for the module helpers."""
+
+    def test_is_pid_running(self):
+        """Report PID liveness, rejecting non-positive PIDs."""
+        assert dev_session._is_pid_running(os.getpid())
+        assert not dev_session._is_pid_running(0)
+        assert not dev_session._is_pid_running(-1)
+        assert not dev_session._is_pid_running(2**22 + 10000)  # Above default pid_max
+
+    def test_session_file_location(self, monkeypatch: pytest.MonkeyPatch):
+        """Derive the session file path from the startup socket path."""
+        monkeypatch.setattr(
+            dev_session.configuration,
+            "STARTUP_CARDANO_NODE_SOCKET_PATH",
+            pl.Path("/workdir/state-cluster0/bft1.socket"),
+        )
+        assert dev_session._get_session_file() == pl.Path(
+            f"/workdir/{dev_session.SESSION_PREFIX}_state-cluster0"
+        )
+
+    def test_session_id(self, monkeypatch: pytest.MonkeyPatch):
+        """Record the pytest root temp dir and the controller PID."""
+        monkeypatch.setattr(
+            dev_session.temptools, "get_pytest_root_tmp", lambda: pl.Path("/tmp/pytest-run")
+        )
+        monkeypatch.setattr(dev_session.configuration, "IS_XDIST", False)
+        assert dev_session._get_session_id() == {
+            "root_tmp": "/tmp/pytest-run",
+            "pid": os.getpid(),
+        }
+
+        monkeypatch.setattr(dev_session.configuration, "IS_XDIST", True)
+        assert dev_session._get_session_id()["pid"] == os.getppid()


### PR DESCRIPTION
Cluster management locks live under the invocation-specific pytest temp dir, so concurrent pytest invocations (e.g. from different git worktrees) could target the same dev cluster instance and fail in strange ways.

Record a claim file next to the dev cluster state dir - the location is shared by all invocations and survives devnet restarts. Claim the cluster on session setup and refuse to run when another live invocation holds the claim; stale claims are detected via the recorded controller PID. Release in session teardown only after cluster artifacts are saved.