### PR TITLE
refactor: extract cluster instance evaluation

### DIFF
--- a/cardano_node_tests/cluster_management/cluster_getter.py
+++ b/cardano_node_tests/cluster_management/cluster_getter.py
@@ -104,6 +104,21 @@ class _RespinState(enum.Enum):
     RESPUN = enum.auto()
 
 
+class _InstanceVerdict(enum.Enum):
+    """Verdict on a cluster instance for running the current test.
+
+    Returned by both `_evaluate_instance` and `_prepare_selected_instance`:
+
+    * START - proceed with the instance (the checks passed, respectively the
+      selection is finished).
+    * SKIP - the test cannot start on the instance in this iteration; the loop
+      moves on (possibly re-entering the pinned instance later).
+    """
+
+    START = enum.auto()
+    SKIP = enum.auto()
+
+
 @dataclasses.dataclass
 class _ClusterGetStatus:
     """Intermediate status while trying to `get` suitable cluster instance."""
@@ -794,6 +809,22 @@ class ClusterGetter:
         self.log(f"c{cget_status.instance_num}: ready to respin cluster")
         cget_status.respin_state = _RespinState.ARMED
 
+    def _respin_if_armed(self, cget_status: _ClusterGetStatus) -> None:
+        """Run the armed respin and record that it was performed.
+
+        Called outside of the global lock so other workers don't need to wait.
+        The move to RESPUN right after `_respin` returns makes sure the cluster is
+        restarted exactly once per claim, even when a later iteration re-enters
+        before the cleanup. The move happens also when the respin fails - the
+        failure marks the cluster dead and the dead cluster check handles the
+        recovery on the next iteration.
+        """
+        if cget_status.respin_state is not _RespinState.ARMED:
+            return
+
+        self._respin(scriptsdir=cget_status.scriptsdir)
+        cget_status.respin_state = _RespinState.RESPUN
+
     def _cleanup_after_respin(self, cget_status: _ClusterGetStatus) -> None:
         """Clean up after the respin of this cluster instance was performed.
 
@@ -916,6 +947,155 @@ class ClusterGetter:
 
         return use_resources
 
+    def _evaluate_instance(  # noqa: PLR0911
+        self, cget_status: _ClusterGetStatus, instance_num: int
+    ) -> _InstanceVerdict:
+        """Evaluate if the cluster instance is suitable for running the current test.
+
+        Runs the checks in order and rules the instance out on the first failed one.
+        Besides the per-instance fields of `cget_status`, the checks can also modify
+        durable status records - e.g. wipe records of a dead instance, or claim a
+        needed respin. A SKIP verdict can therefore leave the worker pinned to this
+        instance with a claimed respin, to be re-evaluated on a later iteration.
+        Sets `cget_status.sleep_delay` where the blocking condition warrants
+        a back-off of the top-level loop.
+
+        Must be called under the global lock.
+
+        Returns:
+            The verdict - START when the test can start on this instance, SKIP
+            when the loop should move on to the next instance or iteration.
+        """
+        cget_status.instance_num = instance_num
+        cget_status.instance_dir = status_files.get_instance_dir(instance_num=instance_num)
+        cget_status.instance_dir.mkdir(exist_ok=True)
+
+        # Cleanup cluster instance where attempt to start cluster failed repeatedly
+        if self.snap.is_cluster_dead(instance_num=instance_num):
+            self._cleanup_dead_cluster(cget_status)
+            return _InstanceVerdict.SKIP
+
+        # Cluster respin planned or in progress, so no new tests can start
+        if self._being_respun_by_other_worker(cget_status):
+            cget_status.sleep_delay = 5
+            return _InstanceVerdict.SKIP
+
+        # If marked tests are already running, update their status.
+        # Must be done before the mark state is read below, as stale marks
+        # get cleaned up here.
+        self._update_marked_tests(cget_status=cget_status)
+
+        # Are there tests already running on this cluster instance?
+        cget_status.started_tests_rows = self.snap.list_test_running(instance_num=instance_num)
+
+        # "marked tests" = group of tests marked with my mark
+        cget_status.marked_ready_rows = self.snap.list_curr_mark(
+            instance_num=instance_num, mark=cget_status.mark
+        )
+
+        # If there would be more tests running on this cluster instance than allowed,
+        # we need to wait.
+        if (
+            self.num_of_instances > 1
+            and (tnum := len(cget_status.started_tests_rows)) >= configuration.MAX_TESTS_PER_CLUSTER
+        ):
+            cget_status.sleep_delay = 2
+            self.log(f"c{instance_num}: {tnum} tests are already running, cannot start")
+            return _InstanceVerdict.SKIP
+
+        # Does the cluster instance need respin to continue?
+        # Cache the result as the check itself can be expensive.
+        cget_status.cluster_needs_respin = self._cluster_needs_respin(instance_num)
+
+        # Select this instance for running marked tests if possible
+        if cget_status.mark and not self._marked_select_instance(cget_status):
+            cget_status.sleep_delay = 2
+            return _InstanceVerdict.SKIP
+
+        # Try next cluster instance when the current one needs respin.
+        # Respin only if:
+        # * we are already locked on this instance
+        # * respin is needed by the current test anyway
+        # * we already tried all cluster instances and there's no other option
+        if (
+            cget_status.cluster_needs_respin
+            and cget_status.selected_instance != instance_num
+            and not self._test_needs_respin(cget_status)
+            and not cget_status.tried_all_instances
+        ):
+            return _InstanceVerdict.SKIP
+
+        # We don't need to resolve resources availability if there was already a test
+        # with this mark before (the first test already resolved the resources
+        # availability).
+        # It is responsibility of tests to make sure that the same resources are
+        # requested for all the tests with the same mark (e.g. specific pool and
+        # not "any pool").
+        need_resolve_resources = not cget_status.marked_ready_rows
+
+        # Check availability of the required resources
+        if need_resolve_resources and not self._resolve_resources_availability(cget_status):
+            cget_status.sleep_delay = 5
+            return _InstanceVerdict.SKIP
+
+        # If respin is needed, indicate that the cluster will be re-spun
+        # (after all currently running tests are finished)
+        if not self._init_respin(cget_status):
+            return _InstanceVerdict.SKIP
+
+        return _InstanceVerdict.START
+
+    def _prepare_selected_instance(self, cget_status: _ClusterGetStatus) -> _InstanceVerdict:
+        """Select the evaluated cluster instance and finish respin-related actions.
+
+        Pins the worker to the instance, sets the cluster env variables, removes the
+        "prio in progress" record and creates the "current mark" record for a marked
+        test.
+
+        Must be called under the global lock.
+
+        Returns:
+            START when the selection is finished and the test can start. SKIP when
+            the claimed respin was just armed - the instance stays pinned and is
+            re-entered on a later iteration, after the respin was performed.
+        """
+        # An armed respin must run (`_respin_if_armed`) before the instance can be
+        # selected - finishing the selection here would skip the promised respin
+        if cget_status.respin_state is _RespinState.ARMED:
+            msg = f"Cannot select instance in the '{cget_status.respin_state.name}' respin state."
+            raise RuntimeError(msg)
+
+        instance_num = cget_status.instance_num
+
+        # We've found suitable cluster instance
+        cget_status.selected_instance = instance_num
+        self._cluster_instance_num = instance_num
+        self.log(f"c{instance_num}: can run test '{cget_status.current_test}'")
+        # Set environment variables that are needed when respinning the cluster
+        # and running tests
+        cluster_nodes.set_cluster_env(instance_num=instance_num)
+
+        # Remove "prio" status record
+        if cget_status.prio:
+            status_db.rm_prio_in_progress(worker_id=self.worker_id)
+
+        # Create status record for marked tests.
+        # This must be done before the cluster is re-spun, so that other marked tests
+        # don't try to prepare another cluster instance.
+        self._init_marked_test(cget_status)
+
+        # Arm the claimed respin and return to the top-level loop, where
+        # `_respin` runs outside of the global lock
+        if cget_status.respin_state is _RespinState.CLAIMED:
+            self._arm_respin(cget_status)
+            return _InstanceVerdict.SKIP
+
+        # The respin was already performed, clean up the respin status records
+        if cget_status.respin_state is _RespinState.RESPUN:
+            self._cleanup_after_respin(cget_status)
+
+        return _InstanceVerdict.START
+
     def get_cluster_instance(  # noqa: C901
         self,
         mark: str = "",
@@ -1027,11 +1207,7 @@ class ClusterGetter:
                 msg = "Timeout (hard) while waiting to obtain cluster instance."
                 raise TimeoutError(msg)
 
-            if cget_status.respin_state is _RespinState.ARMED:
-                self._respin(scriptsdir=scriptsdir)
-                # Move to RESPUN right away - re-entering this branch on a later
-                # iteration must not restart the cluster again
-                cget_status.respin_state = _RespinState.RESPUN
+            self._respin_if_armed(cget_status)
 
             # Sleep for a while to avoid too many checks in a short time
             _xdist_sleep(random.uniform(0.6, 1.2) * cget_status.sleep_delay)
@@ -1059,9 +1235,11 @@ class ClusterGetter:
 
                 self._fail_on_dead_clusters(remaining_time_sec=remaining_soft)
 
-                if mark:
+                if cget_status.mark:
                     # Check if tests with my mark are already locked to any cluster instance
-                    cget_status.marked_running_my_anywhere = self.snap.list_curr_mark(mark=mark)
+                    cget_status.marked_running_my_anywhere = self.snap.list_curr_mark(
+                        mark=cget_status.mark
+                    )
 
                 # A "prio" test has priority in obtaining cluster instance. Check if it is needed
                 # to wait until earlier "prio" test obtains a cluster instance.
@@ -1080,116 +1258,16 @@ class ClusterGetter:
                     if cget_status.selected_instance not in (-1, instance_num):
                         continue
 
-                    cget_status.instance_num = instance_num
-                    cget_status.instance_dir = status_files.get_instance_dir(
-                        instance_num=instance_num
-                    )
-                    cget_status.instance_dir.mkdir(exist_ok=True)
-
-                    # Cleanup cluster instance where attempt to start cluster failed repeatedly
-                    if self.snap.is_cluster_dead(instance_num=instance_num):
-                        self._cleanup_dead_cluster(cget_status)
+                    # Check if the test can start on this instance
+                    verdict = self._evaluate_instance(cget_status, instance_num=instance_num)
+                    if verdict is _InstanceVerdict.SKIP:
                         continue
 
-                    # Cluster respin planned or in progress, so no new tests can start
-                    if self._being_respun_by_other_worker(cget_status):
-                        cget_status.sleep_delay = 5
+                    # Select the instance. A freshly claimed respin is only armed here
+                    # and the instance is re-entered after the respin was performed.
+                    verdict = self._prepare_selected_instance(cget_status)
+                    if verdict is _InstanceVerdict.SKIP:
                         continue
-
-                    # If marked tests are already running, update their status.
-                    # Must be done before the mark state is read below, as stale marks
-                    # get cleaned up here.
-                    self._update_marked_tests(cget_status=cget_status)
-
-                    # Are there tests already running on this cluster instance?
-                    cget_status.started_tests_rows = self.snap.list_test_running(
-                        instance_num=instance_num
-                    )
-
-                    # "marked tests" = group of tests marked with my mark
-                    cget_status.marked_ready_rows = self.snap.list_curr_mark(
-                        instance_num=instance_num, mark=mark
-                    )
-
-                    # If there would be more tests running on this cluster instance than allowed,
-                    # we need to wait.
-                    if (
-                        self.num_of_instances > 1
-                        and (tnum := len(cget_status.started_tests_rows))
-                        >= configuration.MAX_TESTS_PER_CLUSTER
-                    ):
-                        cget_status.sleep_delay = 2
-                        self.log(f"c{instance_num}: {tnum} tests are already running, cannot start")
-                        continue
-
-                    # Does the cluster instance needs respin to continue?
-                    # Cache the result as the check itself can be expensive.
-                    cget_status.cluster_needs_respin = self._cluster_needs_respin(instance_num)
-
-                    # Select this instance for running marked tests if possible
-                    if mark and not self._marked_select_instance(cget_status):
-                        cget_status.sleep_delay = 2
-                        continue
-
-                    # Try next cluster instance when the current one needs respin.
-                    # Respin only if:
-                    # * we are already locked on this instance
-                    # * respin is needed by the current test anyway
-                    # * we already tried all cluster instances and there's no other option
-                    if (
-                        cget_status.cluster_needs_respin
-                        and cget_status.selected_instance != instance_num
-                        and not self._test_needs_respin(cget_status)
-                        and not cget_status.tried_all_instances
-                    ):
-                        continue
-
-                    # We don't need to resolve resources availability if there was already a test
-                    # with this mark before (the first test already resolved the resources
-                    # availability).
-                    # It is responsibility of tests to make sure that the same resources are
-                    # requested for all the tests with the same mark (e.g. specific pool and
-                    # not "any pool").
-                    need_resolve_resources = not cget_status.marked_ready_rows
-
-                    # Check availability of the required resources
-                    if need_resolve_resources and not self._resolve_resources_availability(
-                        cget_status
-                    ):
-                        cget_status.sleep_delay = 5
-                        continue
-
-                    # If respin is needed, indicate that the cluster will be re-spun
-                    # (after all currently running tests are finished)
-                    if not self._init_respin(cget_status):
-                        continue
-
-                    # We've found suitable cluster instance
-                    cget_status.selected_instance = instance_num
-                    self._cluster_instance_num = instance_num
-                    self.log(f"c{instance_num}: can run test '{cget_status.current_test}'")
-                    # Set environment variables that are needed when respinning the cluster
-                    # and running tests
-                    cluster_nodes.set_cluster_env(instance_num=instance_num)
-
-                    # Remove "prio" status record
-                    if prio:
-                        status_db.rm_prio_in_progress(worker_id=self.worker_id)
-
-                    # Create status record for marked tests.
-                    # This must be done before the cluster is re-spun, so that other marked tests
-                    # don't try to prepare another cluster instance.
-                    self._init_marked_test(cget_status)
-
-                    # Arm the claimed respin and return to the top-level loop, where
-                    # `_respin` runs outside of the global lock
-                    if cget_status.respin_state is _RespinState.CLAIMED:
-                        self._arm_respin(cget_status)
-                        continue
-
-                    # The respin was already performed, clean up the respin status records
-                    if cget_status.respin_state is _RespinState.RESPUN:
-                        self._cleanup_after_respin(cget_status)
 
                     # From this point on, all conditions needed to start the test are met
                     break
@@ -1203,4 +1281,4 @@ class ClusterGetter:
                 # Cluster instance is ready, we can start the test
                 break
 
-        return instance_num
+        return self.cluster_instance_num

--- a/framework_tests/test_cluster_getter.py
+++ b/framework_tests/test_cluster_getter.py
@@ -8,6 +8,7 @@ from cardano_node_tests.cluster_management import cluster_getter
 from cardano_node_tests.cluster_management import resources
 from cardano_node_tests.cluster_management import resources_management
 from cardano_node_tests.cluster_management import status_db
+from cardano_node_tests.utils import configuration
 
 
 def _get_cluster_getter(num_of_instances: int = 1) -> cluster_getter.ClusterGetter:
@@ -922,3 +923,401 @@ class TestDeadFraction:
         # Within the strict check window - 2 of 3 dead fails the run
         with pytest.raises(RuntimeError, match="Too many cluster instances are dead"):
             getter._fail_on_dead_clusters(remaining_time_sec=getter.strict_check_window)
+
+
+@pytest.mark.usefixtures("db_dir")
+def test_respin_if_armed(monkeypatch: pytest.MonkeyPatch):
+    """Check that the armed respin runs exactly once per claim.
+
+    The respin runs only in the ARMED phase and the move to RESPUN right after
+    the run prevents another restart when the instance loop is re-entered before
+    the cleanup.
+    """
+    getter = _get_cluster_getter()
+    cget_status = _get_cget_status(instance_num=0)
+    cget_status.scriptsdir = "custom"
+
+    respin_calls: list[str] = []
+    monkeypatch.setattr(getter, "_respin", lambda scriptsdir: respin_calls.append(scriptsdir))
+
+    # Nothing runs while the respin is not armed
+    for state in (
+        cluster_getter._RespinState.NONE,
+        cluster_getter._RespinState.CLAIMED,
+        cluster_getter._RespinState.RESPUN,
+    ):
+        cget_status.respin_state = state
+        getter._respin_if_armed(cget_status)
+        assert respin_calls == []
+        assert cget_status.respin_state is state
+
+    # The armed respin runs with the test's custom scripts and moves to RESPUN
+    cget_status.respin_state = cluster_getter._RespinState.ARMED
+    getter._respin_if_armed(cget_status)
+    assert respin_calls == ["custom"]
+    assert cget_status.respin_state is cluster_getter._RespinState.RESPUN
+
+    # Re-entering must not run the respin again
+    getter._respin_if_armed(cget_status)
+    assert respin_calls == ["custom"]
+
+
+@pytest.mark.usefixtures("db_dir")
+def test_respin_if_armed_failure(monkeypatch: pytest.MonkeyPatch):
+    """Check that a failed respin still moves to RESPUN and is not retried.
+
+    A failed `_respin` marks the cluster instance dead and the recovery is
+    handled by the dead cluster check on the next iteration - not by running
+    the respin again.
+    """
+    getter = _get_cluster_getter()
+    cget_status = _get_cget_status(instance_num=0)
+    cget_status.respin_state = cluster_getter._RespinState.ARMED
+
+    respin_calls: list[str] = []
+
+    def _failing_respin(scriptsdir: str = "") -> bool:
+        respin_calls.append(scriptsdir)
+        status_db.set_cluster_dead(instance_num=0)
+        return False
+
+    monkeypatch.setattr(getter, "_respin", _failing_respin)
+
+    getter._respin_if_armed(cget_status)
+
+    assert respin_calls == [""]
+    assert cget_status.respin_state is cluster_getter._RespinState.RESPUN
+
+    # Re-entering must not retry the failed respin
+    getter._respin_if_armed(cget_status)
+    assert respin_calls == [""]
+
+
+@pytest.mark.usefixtures("db_dir")
+class TestEvaluateInstance:
+    """Check the evaluation of a single cluster instance for the current test."""
+
+    def test_dead_instance(self):
+        """Check that a dead instance is skipped and the worker state is reset."""
+        getter = _get_cluster_getter()
+        cget_status = _get_cget_status(instance_num=-1)
+        cget_status.selected_instance = 0
+        cget_status.respin_state = cluster_getter._RespinState.RESPUN
+        status_db.set_cluster_dead(instance_num=0)
+        getter.snap.refresh()
+
+        verdict = getter._evaluate_instance(cget_status, instance_num=0)
+
+        assert verdict is cluster_getter._InstanceVerdict.SKIP
+        assert cget_status.instance_num == 0
+        assert cget_status.selected_instance == -1
+        assert cget_status.respin_state is cluster_getter._RespinState.NONE
+
+    def test_respun_elsewhere(self):
+        """Check that an instance being respun by another worker is skipped."""
+        getter = _get_cluster_getter()
+        cget_status = _get_cget_status(instance_num=-1)
+        status_db.create_respin_progress(instance_num=0, worker_id="gw1")
+        getter.snap.refresh()
+
+        verdict = getter._evaluate_instance(cget_status, instance_num=0)
+
+        assert verdict is cluster_getter._InstanceVerdict.SKIP
+        assert cget_status.sleep_delay == 5
+
+    def test_too_many_tests(self):
+        """Check that a full instance is skipped when there are more instances."""
+        getter = _get_cluster_getter(num_of_instances=2)
+        cget_status = _get_cget_status(instance_num=-1)
+        status_db.set_cluster_running(instance_num=0)
+        for tno in range(configuration.MAX_TESTS_PER_CLUSTER):
+            status_db.create_test_running(instance_num=0, worker_id=f"gw{tno}", test_id=f"t{tno}")
+        getter.snap.refresh()
+
+        verdict = getter._evaluate_instance(cget_status, instance_num=0)
+
+        assert verdict is cluster_getter._InstanceVerdict.SKIP
+        assert cget_status.sleep_delay == 2
+
+    def test_needs_respin_try_next(self):
+        """Check that an instance that needs respin is skipped while others remain untried."""
+        getter = _get_cluster_getter()
+        cget_status = _get_cget_status(instance_num=-1)
+
+        # The cluster instance was never started, so it needs respin
+        verdict = getter._evaluate_instance(cget_status, instance_num=0)
+
+        assert verdict is cluster_getter._InstanceVerdict.SKIP
+        assert cget_status.cluster_needs_respin is True
+        assert cget_status.respin_state is cluster_getter._RespinState.NONE
+
+    def test_needs_respin_claimed_last_resort(self):
+        """Check that the respin is claimed once all instances were tried."""
+        getter = _get_cluster_getter()
+        cget_status = _get_cget_status(instance_num=-1)
+        cget_status.tried_all_instances = True
+
+        verdict = getter._evaluate_instance(cget_status, instance_num=0)
+
+        assert verdict is cluster_getter._InstanceVerdict.START
+        assert cget_status.respin_state is cluster_getter._RespinState.CLAIMED
+        assert cget_status.selected_instance == 0
+        assert len(status_db.list_respin_progress(instance_num=0)) == 1
+
+    def test_resource_conflict(self, monkeypatch: pytest.MonkeyPatch):
+        """Check that an instance without free resources is skipped."""
+        getter = _get_cluster_getter()
+        cget_status = _get_cget_status(instance_num=-1)
+        cget_status.lock_resources = ["pool1"]
+        status_db.set_cluster_running(instance_num=0)
+        status_db.create_resources(
+            instance_num=0, worker_id="gw1", names=["pool1"], mode=status_db.MODE_USE
+        )
+        monkeypatch.setattr(getter, "_is_healthy", lambda _instance_num: True)
+        getter.snap.refresh()
+
+        verdict = getter._evaluate_instance(cget_status, instance_num=0)
+
+        assert verdict is cluster_getter._InstanceVerdict.SKIP
+        assert cget_status.sleep_delay == 5
+
+    def test_all_clear(self, monkeypatch: pytest.MonkeyPatch):
+        """Check that a healthy running instance with free resources can start the test."""
+        getter = _get_cluster_getter()
+        cget_status = _get_cget_status(instance_num=-1)
+        cget_status.lock_resources = ["pool1"]
+        status_db.set_cluster_running(instance_num=0)
+        monkeypatch.setattr(getter, "_is_healthy", lambda _instance_num: True)
+        getter.snap.refresh()
+
+        verdict = getter._evaluate_instance(cget_status, instance_num=0)
+
+        assert verdict is cluster_getter._InstanceVerdict.START
+        assert cget_status.respin_state is cluster_getter._RespinState.NONE
+        assert cget_status.final_lock_resources == ["pool1"]
+
+    def test_needs_respin_custom_scripts(self):
+        """Check that a test with custom scripts claims the respin right away.
+
+        The respin is needed by the test itself, so the worker doesn't try other
+        instances first.
+        """
+        getter = _get_cluster_getter()
+        cget_status = _get_cget_status(instance_num=-1)
+        cget_status.scriptsdir = "custom"
+
+        verdict = getter._evaluate_instance(cget_status, instance_num=0)
+
+        assert verdict is cluster_getter._InstanceVerdict.START
+        assert cget_status.respin_state is cluster_getter._RespinState.CLAIMED
+        assert cget_status.selected_instance == 0
+
+    def test_max_tests_single_instance(self, monkeypatch: pytest.MonkeyPatch):
+        """Check that the tests-per-cluster cap does not apply with a single instance.
+
+        With a single instance there is nowhere else to go, so the cap would only
+        deadlock the run.
+        """
+        getter = _get_cluster_getter(num_of_instances=1)
+        cget_status = _get_cget_status(instance_num=-1)
+        status_db.set_cluster_running(instance_num=0)
+        for tno in range(configuration.MAX_TESTS_PER_CLUSTER):
+            status_db.create_test_running(instance_num=0, worker_id=f"gw{tno}", test_id=f"t{tno}")
+        monkeypatch.setattr(getter, "_is_healthy", lambda _instance_num: True)
+        getter.snap.refresh()
+
+        verdict = getter._evaluate_instance(cget_status, instance_num=0)
+
+        assert verdict is cluster_getter._InstanceVerdict.START
+
+    def test_marked_ready_inherits_resources(self, monkeypatch: pytest.MonkeyPatch):
+        """Check that a non-initial marked test inherits the group's resources.
+
+        The initial test of the mark already resolved and locked the resources.
+        Re-resolving them would conflict with the group's own records and block
+        the test forever.
+        """
+        getter = _get_cluster_getter()
+        cget_status = _get_cget_status(instance_num=-1, mark="markA")
+        cget_status.lock_resources = ["pool1"]
+        status_db.set_cluster_running(instance_num=0)
+        status_db.create_curr_mark(instance_num=0, worker_id="gw1", mark="markA")
+        # The group's already-locked resource would block re-resolution
+        status_db.create_resources(
+            instance_num=0,
+            worker_id="gw1",
+            names=["pool1"],
+            mode=status_db.MODE_LOCK,
+            mark="markA",
+        )
+        monkeypatch.setattr(getter, "_is_healthy", lambda _instance_num: True)
+        getter.snap.refresh()
+
+        verdict = getter._evaluate_instance(cget_status, instance_num=0)
+
+        assert verdict is cluster_getter._InstanceVerdict.START
+        # Pinned to the instance that has the mark
+        assert cget_status.selected_instance == 0
+        # Resources were not re-resolved
+        assert cget_status.final_lock_resources == ()
+
+    def test_respin_postponed_while_tests_run(self):
+        """Check that a last-resort respin claim is postponed while tests are running."""
+        getter = _get_cluster_getter()
+        cget_status = _get_cget_status(instance_num=-1)
+        cget_status.tried_all_instances = True
+        status_db.create_test_running(instance_num=0, worker_id="gw1", test_id="test_y")
+        getter.snap.refresh()
+
+        verdict = getter._evaluate_instance(cget_status, instance_num=0)
+
+        assert verdict is cluster_getter._InstanceVerdict.SKIP
+        assert cget_status.respin_state is cluster_getter._RespinState.NONE
+        assert status_db.list_respin_progress(instance_num=0) == []
+
+    def test_mark_running_elsewhere(self):
+        """Check that a marked test waits when its mark runs on another instance."""
+        getter = _get_cluster_getter(num_of_instances=2)
+        cget_status = _get_cget_status(instance_num=-1, mark="markA")
+        status_db.create_curr_mark(instance_num=1, worker_id="gw1", mark="markA")
+        getter.snap.refresh()
+        cget_status.marked_running_my_anywhere = getter.snap.list_curr_mark(mark="markA")
+
+        verdict = getter._evaluate_instance(cget_status, instance_num=0)
+
+        assert verdict is cluster_getter._InstanceVerdict.SKIP
+        assert cget_status.sleep_delay == 2
+
+
+@pytest.mark.usefixtures("db_dir")
+class TestPrepareSelectedInstance:
+    """Check the selection of an evaluated cluster instance."""
+
+    def _get_getter_status(
+        self, monkeypatch: pytest.MonkeyPatch, mark: str = ""
+    ) -> tuple[cluster_getter.ClusterGetter, cluster_getter._ClusterGetStatus, list[int]]:
+        """Return getter, status and env setup calls record for selecting instance 0."""
+        getter = _get_cluster_getter()
+        cget_status = _get_cget_status(instance_num=0, mark=mark)
+        env_calls: list[int] = []
+        monkeypatch.setattr(
+            cluster_getter.cluster_nodes,
+            "set_cluster_env",
+            lambda instance_num: env_calls.append(instance_num),
+        )
+        return getter, cget_status, env_calls
+
+    def test_no_respin(self, monkeypatch: pytest.MonkeyPatch):
+        """Check plain selection - instance pinned, no respin-related actions."""
+        getter, cget_status, env_calls = self._get_getter_status(monkeypatch)
+
+        verdict = getter._prepare_selected_instance(cget_status)
+
+        assert verdict is cluster_getter._InstanceVerdict.START
+        assert cget_status.selected_instance == 0
+        assert getter._cluster_instance_num == 0
+        assert env_calls == [0]
+
+    def test_claimed_respin_armed(self, monkeypatch: pytest.MonkeyPatch):
+        """Check that a claimed respin is armed while the instance stays pinned.
+
+        The SKIP verdict defers the test start - the respin runs first and the
+        pinned instance is re-entered afterwards.
+        """
+        getter, cget_status, _env_calls = self._get_getter_status(monkeypatch)
+        cget_status.respin_state = cluster_getter._RespinState.CLAIMED
+
+        verdict = getter._prepare_selected_instance(cget_status)
+
+        assert verdict is cluster_getter._InstanceVerdict.SKIP
+        assert cget_status.respin_state is cluster_getter._RespinState.ARMED
+        assert cget_status.selected_instance == 0
+
+    def test_claimed_respin_marked(self, monkeypatch: pytest.MonkeyPatch):
+        """Check that the mark record is created before the claimed respin is armed.
+
+        Other tests of the marked group must see the mark on this instance during
+        the respin window, so they don't prepare another cluster instance.
+        """
+        getter, cget_status, _env_calls = self._get_getter_status(monkeypatch, mark="markA")
+        cget_status.respin_state = cluster_getter._RespinState.CLAIMED
+
+        verdict = getter._prepare_selected_instance(cget_status)
+
+        assert verdict is cluster_getter._InstanceVerdict.SKIP
+        assert cget_status.respin_state is cluster_getter._RespinState.ARMED
+        assert len(status_db.list_curr_mark(instance_num=0, mark="markA")) == 1
+
+    def test_armed_respin_rejected(self, monkeypatch: pytest.MonkeyPatch):
+        """Check that selection fails fast when the armed respin was not performed yet."""
+        getter, cget_status, _env_calls = self._get_getter_status(monkeypatch)
+        cget_status.respin_state = cluster_getter._RespinState.ARMED
+
+        with pytest.raises(RuntimeError, match="Cannot select instance"):
+            getter._prepare_selected_instance(cget_status)
+
+        # The guard precedes all mutations - nothing was selected
+        assert cget_status.selected_instance == -1
+
+    def test_respun_cleaned_up(self, monkeypatch: pytest.MonkeyPatch):
+        """Check that the performed respin is cleaned up and the selection finishes."""
+        getter, cget_status, _env_calls = self._get_getter_status(monkeypatch)
+        cget_status.respin_state = cluster_getter._RespinState.RESPUN
+        status_db.create_respin_progress(instance_num=0, worker_id="gw0")
+        status_db.create_respin_needed(instance_num=0, worker_id="gw0")
+
+        verdict = getter._prepare_selected_instance(cget_status)
+
+        assert verdict is cluster_getter._InstanceVerdict.START
+        assert cget_status.respin_state is cluster_getter._RespinState.NONE
+        assert status_db.list_respin_progress(instance_num=0) == []
+        assert status_db.list_respin_needed(instance_num=0) == []
+
+    def test_mark_and_prio_records(self, monkeypatch: pytest.MonkeyPatch):
+        """Check that selection creates the mark record and removes the prio record."""
+        getter, cget_status, _env_calls = self._get_getter_status(monkeypatch, mark="markA")
+        cget_status.prio = True
+        status_db.create_prio_in_progress(worker_id="gw0")
+
+        verdict = getter._prepare_selected_instance(cget_status)
+
+        assert verdict is cluster_getter._InstanceVerdict.START
+        assert len(status_db.list_curr_mark(instance_num=0, mark="markA")) == 1
+        assert status_db.list_prio_in_progress() == []
+
+
+@pytest.mark.usefixtures("db_dir")
+def test_get_cluster_instance_respin_cycle(monkeypatch: pytest.MonkeyPatch):
+    """Check the full respin cycle driven by `get_cluster_instance`.
+
+    The cluster instance was never started, so the worker claims the respin, arms
+    it, performs it outside of the global lock and cleans up the respin records,
+    all in successive iterations of the top-level loop, and finally starts the
+    test on the freshly started instance.
+    """
+    getter = _get_cluster_getter()
+
+    respin_calls: list[str] = []
+
+    def _fake_respin(scriptsdir: str = "") -> bool:
+        respin_calls.append(scriptsdir)
+        status_db.set_cluster_running(instance_num=0)
+        return True
+
+    monkeypatch.setattr(getter, "_respin", _fake_respin)
+    monkeypatch.setattr(getter, "_is_healthy", lambda _instance_num: True)
+    monkeypatch.setattr(cluster_getter.cluster_nodes, "set_cluster_env", lambda **_kwargs: None)
+    # Make the test independent of the environment it runs in
+    monkeypatch.setattr(configuration, "DEV_CLUSTER_RUNNING", False)
+    monkeypatch.setattr(configuration, "FORBID_RESTART", False)
+
+    instance_num = getter.get_cluster_instance()
+
+    assert instance_num == 0
+    assert getter.cluster_instance_num == 0
+    # The respin ran exactly once
+    assert respin_calls == [""]
+    # The respin records were cleaned up and the test is running
+    assert status_db.list_respin_progress(instance_num=0) == []
+    assert status_db.list_respin_needed(instance_num=0) == []
+    assert len(status_db.list_test_running(instance_num=0, worker_id="gw0")) == 1


### PR DESCRIPTION
Split the body of the instance loop in `get_cluster_instance` into three testable units:

- `_evaluate_instance` runs the eligibility checks in order and returns an `_InstanceVerdict` (START or SKIP), replacing the chain of guarded `continue` statements.
- `_prepare_selected_instance` pins the selected instance, creates the mark and prio status records and dispatches the respin arming or cleanup.
- `_respin_if_armed` runs the armed respin at the top of the outer loop and moves the state to RESPUN, making the exactly-once respin guarantee unit-testable.

The loop itself is now three dispatch statements. The checks, their order and the sleep delays are moved verbatim. The only behavior addition is a defensive RuntimeError in `_prepare_selected_instance` when the respin state is ARMED - unreachable from
`get_cluster_instance`, where `_respin_if_armed` always consumes the armed state first.

Add unit tests for all three units: verdicts for dead instance, foreign respin, full instance, needs-respin, resource conflict and mark placement; selection with mark/prio records; respin dispatch phases; exactly-once respin execution, also when the respin fails.