### PR TITLE
refactor: split cluster getter blackboard

### DIFF
--- a/cardano_node_tests/cluster_management/cluster_getter.py
+++ b/cardano_node_tests/cluster_management/cluster_getter.py
@@ -67,6 +67,13 @@ MARK_STALENESS_SEC = 60
 # so pollers don't write to the database on every scheduler iteration.
 MARK_REFRESH_SEC = 15
 
+# Back-off (seconds) before the next attempt to obtain a cluster instance. The longer
+# back-off is used when the wait depends on other workers finishing their work (a cluster
+# respin, a test holding resources, a "prio" test setup), the shorter one when only the
+# scheduling of tests over the cluster instances blocks the start.
+LONG_BACKOFF_SEC = 5
+SHORT_BACKOFF_SEC = 2
+
 if configuration.IS_XDIST:
     _xdist_sleep = time.sleep
 else:
@@ -75,12 +82,11 @@ else:
         """No need to sleep if tests are running on a single worker."""
 
 
-class _RespinState(enum.Enum):
-    """State of the cluster respin lifecycle on this worker.
+class _RespinPhase(enum.Enum):
+    """Phase of a cluster respin claimed by this worker.
 
-    The respinning worker moves through the states:
+    The claim moves through the phases:
 
-    * NONE - no respin claimed by this worker.
     * CLAIMED - this worker claimed the respin of the selected cluster instance
       (`_init_respin`) and is pinned to it. The claim is armed once all other
       conditions for the respin are met - usually later in the same iteration,
@@ -88,41 +94,112 @@ class _RespinState(enum.Enum):
       mark's resources must be resolved again).
     * ARMED - the actual `_respin` will run at the start of the next iteration,
       outside of the global lock so other workers don't need to wait.
-    * RESPUN - `_respin` has finished (successfully or not). The state moves here
+    * RESPUN - `_respin` has finished (successfully or not). The phase moves here
       right after the `_respin` call, so the respin runs exactly once per claim
       even when later conditions delay the cleanup. The respin status records are
       cleaned up under the lock afterwards (`_cleanup_after_respin`), which
-      returns the state to NONE.
+      discards the claim.
 
-    When the cluster instance dies, `_cleanup_dead_cluster` resets any state
-    directly back to NONE and the respin is abandoned.
+    When the cluster instance dies, `_cleanup_dead_cluster` discards the claim in
+    any phase and the respin is abandoned.
     """
 
-    NONE = enum.auto()
     CLAIMED = enum.auto()
     ARMED = enum.auto()
     RESPUN = enum.auto()
 
 
+@dataclasses.dataclass
+class _RespinClaim:
+    """A respin of a cluster instance claimed by this worker.
+
+    The claim exists only for as long as this worker owns the respin - no claim
+    (`None`) means no respin is being done by this worker. The claim pins the worker
+    to the cluster instance it was made for, so the two are always established and
+    discarded together (`_ClusterGetStatus.claim_respin`, respectively
+    `_ClusterGetStatus.release_instance`).
+    """
+
+    instance_num: int
+    phase: _RespinPhase = _RespinPhase.CLAIMED
+
+
 class _InstanceVerdict(enum.Enum):
     """Verdict on a cluster instance for running the current test.
 
-    Returned by both `_evaluate_instance` and `_prepare_selected_instance`:
-
     * START - proceed with the instance (the checks passed, respectively the
       selection is finished).
-    * SKIP - the test cannot start on the instance in this iteration; the loop
-      moves on (possibly re-entering the pinned instance later).
+    * SKIP - the test cannot start on the instance; the loop moves on to the next
+      cluster instance.
+    * DEFER - the test cannot start yet and no other cluster instance is an option,
+      as the worker is pinned to this one; the loop returns to the top level and
+      re-enters this instance on a later iteration.
     """
 
     START = enum.auto()
     SKIP = enum.auto()
+    DEFER = enum.auto()
+
+
+@dataclasses.dataclass(frozen=True)
+class _InstanceDecision:
+    """Verdict on a cluster instance together with the back-off it asks for.
+
+    The back-off is applied to the sticky `_ClusterGetStatus.sleep_delay` by the
+    instance loop, so that the checks producing the verdict don't write the
+    cross-iteration worker state themselves.
+    """
+
+    verdict: _InstanceVerdict
+    backoff_sec: int = 0
+
+    @classmethod
+    def start(cls) -> tp.Self:
+        """Return a START decision."""
+        return cls(verdict=_InstanceVerdict.START)
+
+    @classmethod
+    def skip(cls, backoff_sec: int = 0) -> tp.Self:
+        """Return a SKIP decision, optionally asking for a back-off."""
+        return cls(verdict=_InstanceVerdict.SKIP, backoff_sec=backoff_sec)
+
+    @classmethod
+    def defer(cls) -> tp.Self:
+        """Return a DEFER decision."""
+        return cls(verdict=_InstanceVerdict.DEFER)
+
+
+@dataclasses.dataclass
+class _InstanceScratch:
+    """What the evaluation found out about a single cluster instance.
+
+    Created for one evaluation of one cluster instance (`_evaluate_instance`) and
+    discarded once the loop moves on, so findings about one instance cannot leak
+    into decisions taken about another instance or on a later iteration.
+    """
+
+    instance_num: int
+    # Tests already running on the cluster instance
+    started_tests_rows: tp.Sequence[status_db.StatusRow] = ()
+    # "marked tests" = group of tests marked with my mark
+    marked_ready_rows: tp.Sequence[status_db.StatusRow] = ()
+    # Whether the cluster instance needs a respin. Cached, as the check can be expensive.
+    cluster_needs_respin: bool = False
+    # Resources resolved for the test on this cluster instance
+    final_lock_resources: tp.Iterable[str] = ()
+    final_use_resources: tp.Iterable[str] = ()
 
 
 @dataclasses.dataclass
 class _ClusterGetStatus:
-    """Intermediate status while trying to `get` suitable cluster instance."""
+    """Worker state while trying to `get` suitable cluster instance.
 
+    Lives for the whole `get_cluster_instance` call, i.e. across all iterations of
+    its loop. Findings about a single cluster instance belong to `_InstanceScratch`
+    instead.
+    """
+
+    # Requirements of the test, set once
     mark: str
     lock_resources: resources_management.ResourcesType
     use_resources: resources_management.ResourcesType
@@ -130,20 +207,43 @@ class _ClusterGetStatus:
     cleanup: bool
     scriptsdir: ttypes.FileType
     current_test: str
+    # Cluster instance this worker is pinned to, -1 when not pinned to any
     selected_instance: int = -1
-    instance_num: int = -1
+    # Respin claimed by this worker, `None` when this worker claimed none
+    respin: _RespinClaim | None = None
     sleep_delay: int = 0
-    respin_state: _RespinState = _RespinState.NONE
-    cluster_needs_respin: bool = False
     prio_here: bool = False
     tried_all_instances: bool = False
-    instance_dir: pl.Path = pl.Path("/nonexistent")
-    final_lock_resources: tp.Iterable[str] = ()
-    final_use_resources: tp.Iterable[str] = ()
-    # Status records
-    started_tests_rows: tp.Sequence[status_db.StatusRow] = ()
-    marked_ready_rows: tp.Sequence[status_db.StatusRow] = ()
+    # Status records of my mark on any cluster instance, re-read on every iteration
     marked_running_my_anywhere: tp.Sequence[status_db.StatusRow] = ()
+
+    @property
+    def respin_phase_name(self) -> str:
+        """Return name of the respin phase, for log and error messages."""
+        return self.respin.phase.name if self.respin else "NONE"
+
+    def owns_respin(self, instance_num: int) -> bool:
+        """Return whether this worker holds a respin claim on the cluster instance."""
+        return self.respin is not None and self.respin.instance_num == instance_num
+
+    def pin_instance(self, instance_num: int) -> None:
+        """Pin this worker to the cluster instance."""
+        self.selected_instance = instance_num
+
+    def claim_respin(self, instance_num: int) -> None:
+        """Claim the respin of the cluster instance and pin this worker to it."""
+        self.respin = _RespinClaim(instance_num=instance_num)
+        self.pin_instance(instance_num)
+
+    def release_instance(self) -> None:
+        """Unpin this worker from its cluster instance, abandoning any claimed respin.
+
+        The pin and the claim are discarded together, so the worker cannot stay pinned
+        to an instance it gave up on, nor keep a claim on an instance it is not
+        pinned to.
+        """
+        self.selected_instance = -1
+        self.respin = None
 
 
 class ClusterGetter:
@@ -455,11 +555,11 @@ class ClusterGetter:
 
         return False
 
-    def _test_needs_respin(self, cget_status: _ClusterGetStatus) -> bool:
+    def _test_needs_respin(self, cget_status: _ClusterGetStatus, scratch: _InstanceScratch) -> bool:
         """Check if it is necessary to respin cluster for the test."""
         # If this is non-initial marked test, we can ignore custom start command,
         # as it was handled by the initial marked test
-        noninitial_marked_test = cget_status.mark and cget_status.marked_ready_rows
+        noninitial_marked_test = cget_status.mark and scratch.marked_ready_rows
         if noninitial_marked_test:
             return False
 
@@ -477,7 +577,7 @@ class ClusterGetter:
             self.log(f"c{instance_num}: in `_on_marked_test_stop`, creating 'respin needed' record")
             status_db.create_respin_needed(instance_num=instance_num, worker_id=self.worker_id)
 
-    def _update_marked_tests(self, cget_status: _ClusterGetStatus) -> None:
+    def _update_marked_tests(self, instance_num: int) -> None:
         """Update status about running of marked test.
 
         When marked test is finished, we can't clear the mark right away. There might be a test
@@ -491,18 +591,16 @@ class ClusterGetter:
         as the cleanup deletes the mark's status records.
         """
         # No need to continue if there are no marked tests
-        curr_mark_rows = self.snap.list_curr_mark(instance_num=cget_status.instance_num)
+        curr_mark_rows = self.snap.list_curr_mark(instance_num=instance_num)
         if not curr_mark_rows:
             return
 
         # Marked tests don't need to be running yet if the cluster is being respun
-        respin_in_progress = self.snap.list_respin_progress(instance_num=cget_status.instance_num)
+        respin_in_progress = self.snap.list_respin_progress(instance_num=instance_num)
         if respin_in_progress:
             return
 
-        marks_in_progress = set(
-            self.snap.get_marks_in_progress(instance_num=cget_status.instance_num)
-        )
+        marks_in_progress = set(self.snap.get_marks_in_progress(instance_num=instance_num))
 
         # A mark can have one record per worker and the records age together - the newest
         # one tells when a test with the mark was last seen running.
@@ -517,28 +615,31 @@ class ClusterGetter:
             # reload) on every iteration.
             if mark in marks_in_progress:
                 if now_ts - newest >= MARK_REFRESH_SEC:
-                    status_db.refresh_curr_mark(instance_num=cget_status.instance_num, mark=mark)
+                    status_db.refresh_curr_mark(instance_num=instance_num, mark=mark)
                 continue
 
             # Clean the stale status records if no marked test was running for too long
             if now_ts - newest >= MARK_STALENESS_SEC:
                 self.log(
-                    f"c{cget_status.instance_num}: no '{mark}' marked tests running "
+                    f"c{instance_num}: no '{mark}' marked tests running "
                     "for a while, cleaning the mark status record"
                 )
-                self._on_marked_test_stop(instance_num=cget_status.instance_num, mark=mark)
+                self._on_marked_test_stop(instance_num=instance_num, mark=mark)
 
-    def _resolve_resources_availability(self, cget_status: _ClusterGetStatus) -> bool:
+    def _resolve_resources_availability(
+        self, cget_status: _ClusterGetStatus, scratch: _InstanceScratch
+    ) -> bool:
         """Resolve availability of required "use" and "lock" resources."""
+        instance_num = scratch.instance_num
         resources_locked = self.snap.get_resource_names(
-            mode=status_db.MODE_LOCK, instance_num=cget_status.instance_num
+            mode=status_db.MODE_LOCK, instance_num=instance_num
         )
 
         # This test wants to lock some resources, check if these are not in use
         res_lockable = []
         if cget_status.lock_resources:
             resources_used = self.snap.get_resource_names(
-                mode=status_db.MODE_USE, instance_num=cget_status.instance_num
+                mode=status_db.MODE_USE, instance_num=instance_num
             )
             unlockable_resources = {*resources_locked, *resources_used}
             res_lockable = resources_management.get_resources(
@@ -547,7 +648,7 @@ class ClusterGetter:
             )
             if not res_lockable:
                 self.log(
-                    f"c{cget_status.instance_num}: want to lock '{cget_status.lock_resources}' and "
+                    f"c{instance_num}: want to lock '{cget_status.lock_resources}' and "
                     f"'{unlockable_resources}' are unavailable, cannot start"
                 )
                 return False
@@ -561,7 +662,7 @@ class ClusterGetter:
             )
             if not res_usable:
                 self.log(
-                    f"c{cget_status.instance_num}: want to use '{cget_status.use_resources}' and "
+                    f"c{instance_num}: want to use '{cget_status.use_resources}' and "
                     f"'{resources_locked}' are locked, cannot start"
                 )
                 return False
@@ -569,11 +670,11 @@ class ClusterGetter:
         # Resources that are locked are also in use
         use_minus_lock = list(set(res_usable) - set(res_lockable))
 
-        cget_status.final_use_resources = use_minus_lock
-        cget_status.final_lock_resources = res_lockable
+        scratch.final_use_resources = use_minus_lock
+        scratch.final_lock_resources = res_lockable
 
         self.log(
-            f"c{cget_status.instance_num}: can start, resources '{use_minus_lock}' usable, "
+            f"c{instance_num}: can start, resources '{use_minus_lock}' usable, "
             f"resources '{res_lockable}' lockable"
         )
 
@@ -617,27 +718,33 @@ class ClusterGetter:
         cget_status.prio_here = True
         self.log(f"setting 'prio' for '{cget_status.current_test}'")
 
-    def _being_respun_by_other_worker(self, cget_status: _ClusterGetStatus) -> bool:
+    def _being_respun_by_other_worker(
+        self, cget_status: _ClusterGetStatus, instance_num: int
+    ) -> bool:
         """Check if the cluster is currently being respun by worker other than this one."""
-        if cget_status.respin_state is not _RespinState.NONE:
+        if cget_status.owns_respin(instance_num):
             return False
 
-        respin_in_progress = self.snap.list_respin_progress(instance_num=cget_status.instance_num)
+        respin_in_progress = self.snap.list_respin_progress(instance_num=instance_num)
         return bool(respin_in_progress)
 
-    def _marked_select_instance(self, cget_status: _ClusterGetStatus) -> bool:
+    def _marked_select_instance(
+        self, cget_status: _ClusterGetStatus, scratch: _InstanceScratch
+    ) -> bool:
         """Select this cluster instance for running marked tests if possible."""
-        if cget_status.marked_ready_rows:
-            cget_status.selected_instance = cget_status.instance_num
+        instance_num = scratch.instance_num
+
+        if scratch.marked_ready_rows:
+            cget_status.pin_instance(instance_num)
             self.log(
-                f"c{cget_status.instance_num}: locking to this cluster instance, "
+                f"c{instance_num}: locking to this cluster instance, "
                 f"it has my mark '{cget_status.mark}'"
             )
             return True
 
-        if cget_status.marked_running_my_anywhere and cget_status.respin_state is _RespinState.NONE:
+        if cget_status.marked_running_my_anywhere and not cget_status.owns_respin(instance_num):
             self.log(
-                f"c{cget_status.instance_num}: tests marked with my mark '{cget_status.mark}' "
+                f"c{instance_num}: tests marked with my mark '{cget_status.mark}' "
                 "already running on other cluster instance, cannot start"
             )
             return False
@@ -733,33 +840,43 @@ class ClusterGetter:
 
         return respin_after_mark
 
-    def _cleanup_dead_cluster(self, cget_status: _ClusterGetStatus) -> None:
+    def _cleanup_dead_cluster(self, cget_status: _ClusterGetStatus, instance_num: int) -> None:
         """Cleanup if the selected cluster instance failed to start."""
         # Move on to other cluster instance.
         # Respin status records ("respin in progress", "respin needed") may stay
         # behind on the dead instance. They are never read - dead instances are never
         # revived and workers skip them before checking the respin records.
-        cget_status.selected_instance = -1
-        cget_status.respin_state = _RespinState.NONE
+        cget_status.release_instance()
 
         # Remove status records that are checked by other workers
-        self._rm_marks(instance_num=cget_status.instance_num)
+        self._rm_marks(instance_num=instance_num)
 
-    def _init_respin(self, cget_status: _ClusterGetStatus) -> bool:
-        """Initialize respin of this cluster instance on this worker."""
+    def _init_respin(
+        self, cget_status: _ClusterGetStatus, scratch: _InstanceScratch
+    ) -> _InstanceDecision:
+        """Initialize respin of this cluster instance on this worker.
+
+        Returns:
+            The decision on the instance. START when the evaluation of the instance can
+            continue, DEFER when the respin was claimed but the instance must be
+            re-evaluated before the test can start on it, SKIP when the needed respin
+            cannot be done right now.
+        """
+        instance_num = scratch.instance_num
+
         # Respin already claimed by this worker
-        if cget_status.respin_state is not _RespinState.NONE:
-            return True
+        if cget_status.owns_respin(instance_num):
+            return _InstanceDecision.start()
 
-        if not (cget_status.cluster_needs_respin or self._test_needs_respin(cget_status)):
-            return True
+        if not (scratch.cluster_needs_respin or self._test_needs_respin(cget_status, scratch)):
+            return _InstanceDecision.start()
 
         # If tests are running on the instance, we cannot respin, therefore we cannot continue
-        if cget_status.started_tests_rows:
-            self.log(f"c{cget_status.instance_num}: tests are running, cannot respin")
-            return False
+        if scratch.started_tests_rows:
+            self.log(f"c{instance_num}: tests are running, cannot respin")
+            return _InstanceDecision.skip()
 
-        self.log(f"c{cget_status.instance_num}: setting 'respin in progress'")
+        self.log(f"c{instance_num}: setting 'respin in progress'")
 
         # Cluster respin will be performed by this worker.
         # By claiming the respin, we make sure this worker continues on this cluster instance
@@ -767,47 +884,42 @@ class ClusterGetter:
         # cluster instance might be specific for the test.
         # The durable record is created first, the in-memory state is updated only after
         # that succeeded - same convention as in `_cleanup_after_respin`.
-        status_db.create_respin_progress(
-            instance_num=cget_status.instance_num, worker_id=self.worker_id
-        )
-        cget_status.respin_state = _RespinState.CLAIMED
-        cget_status.selected_instance = cget_status.instance_num
+        status_db.create_respin_progress(instance_num=instance_num, worker_id=self.worker_id)
+        cget_status.claim_respin(instance_num)
 
         # Remove mark status records and marked resource records as these will not be
         # valid after respin
-        self._rm_marks(instance_num=cget_status.instance_num)
+        self._rm_marks(instance_num=instance_num)
 
-        if cget_status.marked_ready_rows:
+        if scratch.marked_ready_rows:
             # This test's own mark was just removed and the group's resource records went
             # with it. Return back to the retry loop, so that this cluster instance is
-            # re-evaluated and this test resolves its resources again, as the initial
+            # re-evaluated - the findings of this evaluation are discarded with the
+            # scratch object - and this test resolves its resources again, as the initial
             # test of the mark.
             # Record that the instance needs the respin: the re-evaluation happens on a
             # later iteration, after the global lock was released, and it can be delayed
             # e.g. by a resource conflict. The durable record keeps the respin scheduled
             # even when this worker doesn't get to it right away.
-            status_db.create_respin_needed(
-                instance_num=cget_status.instance_num, worker_id=self.worker_id
-            )
-            cget_status.marked_ready_rows = ()
-            return False
+            status_db.create_respin_needed(instance_num=instance_num, worker_id=self.worker_id)
+            return _InstanceDecision.defer()
 
-        return True
+        return _InstanceDecision.start()
 
-    def _arm_respin(self, cget_status: _ClusterGetStatus) -> None:
+    def _arm_respin(self, claim: _RespinClaim) -> None:
         """Arm the claimed respin so `_respin` runs on the next iteration.
 
         The actual `_respin` function will be called outside of global lock so other
         workers don't need to wait.
         """
-        if cget_status.respin_state is not _RespinState.CLAIMED:
-            msg = f"Cannot arm respin in the '{cget_status.respin_state.name}' state."
+        if claim.phase is not _RespinPhase.CLAIMED:
+            msg = f"Cannot arm respin in the '{claim.phase.name}' state."
             raise RuntimeError(msg)
 
         # NOTE: when `_respin` is called, the env variables needed for cluster start scripts need
         # to be already set (e.g. CARDANO_NODE_SOCKET_PATH)
-        self.log(f"c{cget_status.instance_num}: ready to respin cluster")
-        cget_status.respin_state = _RespinState.ARMED
+        self.log(f"c{claim.instance_num}: ready to respin cluster")
+        claim.phase = _RespinPhase.ARMED
 
     def _respin_if_armed(self, cget_status: _ClusterGetStatus) -> None:
         """Run the armed respin and record that it was performed.
@@ -819,54 +931,60 @@ class ClusterGetter:
         failure marks the cluster dead and the dead cluster check handles the
         recovery on the next iteration.
         """
-        if cget_status.respin_state is not _RespinState.ARMED:
+        claim = cget_status.respin
+        if claim is None or claim.phase is not _RespinPhase.ARMED:
             return
 
         self._respin(scriptsdir=cget_status.scriptsdir)
-        cget_status.respin_state = _RespinState.RESPUN
+        claim.phase = _RespinPhase.RESPUN
 
     def _cleanup_after_respin(self, cget_status: _ClusterGetStatus) -> None:
         """Clean up after the respin of this cluster instance was performed.
 
-        Must be called only in the RESPUN state, after `_respin` has run: the respin
+        Must be called only in the RESPUN phase, after `_respin` has run: the respin
         status records are removed for the whole instance, so a premature call would
         delete another worker's records and break the cross-worker coordination.
         """
-        if cget_status.respin_state is not _RespinState.RESPUN:
-            msg = f"Cannot clean up after respin in the '{cget_status.respin_state.name}' state."
+        claim = cget_status.respin
+        if claim is None or claim.phase is not _RespinPhase.RESPUN:
+            msg = f"Cannot clean up after respin in the '{cget_status.respin_phase_name}' state."
             raise RuntimeError(msg)
 
         # Remove status records that are no longer valid after respin
-        status_db.rm_respin_progress(instance_num=cget_status.instance_num)
-        status_db.rm_respin_needed(instance_num=cget_status.instance_num)
+        status_db.rm_respin_progress(instance_num=claim.instance_num)
+        status_db.rm_respin_needed(instance_num=claim.instance_num)
 
-        cget_status.respin_state = _RespinState.NONE
+        cget_status.respin = None
 
-    def _init_marked_test(self, cget_status: _ClusterGetStatus) -> None:
+    def _init_marked_test(self, cget_status: _ClusterGetStatus, instance_num: int) -> None:
         """Create status record for marked test."""
         if not cget_status.mark:
             return
 
         status_db.create_curr_mark(
-            instance_num=cget_status.instance_num, worker_id=self.worker_id, mark=cget_status.mark
+            instance_num=instance_num, worker_id=self.worker_id, mark=cget_status.mark
         )
 
-    def _create_test_status_records(self, cget_status: _ClusterGetStatus) -> None:
+    def _create_test_status_records(
+        self, cget_status: _ClusterGetStatus, scratch: _InstanceScratch
+    ) -> None:
         """Create status records for test that is about to start on this cluster instance."""
+        instance_num = scratch.instance_num
+
         # Create status record for each in-use resource
         status_db.create_resources(
-            instance_num=cget_status.instance_num,
+            instance_num=instance_num,
             worker_id=self.worker_id,
-            names=cget_status.final_use_resources,
+            names=scratch.final_use_resources,
             mode=status_db.MODE_USE,
             mark=cget_status.mark,
         )
 
         # Create status record for each locked resource
         status_db.create_resources(
-            instance_num=cget_status.instance_num,
+            instance_num=instance_num,
             worker_id=self.worker_id,
-            names=cget_status.final_lock_resources,
+            names=scratch.final_lock_resources,
             mode=status_db.MODE_LOCK,
             mark=cget_status.mark,
         )
@@ -875,18 +993,16 @@ class ClusterGetter:
         if cget_status.cleanup:
             # Cleanup after group of test that are marked with a marker
             if cget_status.mark:
-                self.log(f"c{cget_status.instance_num}: cleanup and mark")
+                self.log(f"c{instance_num}: cleanup and mark")
                 status_db.create_respin_after_mark(
-                    instance_num=cget_status.instance_num,
+                    instance_num=instance_num,
                     worker_id=self.worker_id,
                     mark=cget_status.mark,
                 )
             # Cleanup after single test (e.g. singleton)
             else:
-                self.log(f"c{cget_status.instance_num}: cleanup and not mark")
-                status_db.create_respin_needed(
-                    instance_num=cget_status.instance_num, worker_id=self.worker_id
-                )
+                self.log(f"c{instance_num}: cleanup and not mark")
+                status_db.create_respin_needed(instance_num=instance_num, worker_id=self.worker_id)
 
         self.log(f"c{self.cluster_instance_num}: creating 'test running' status record")
         status_db.create_test_running(
@@ -949,47 +1065,46 @@ class ClusterGetter:
 
     def _evaluate_instance(  # noqa: PLR0911
         self, cget_status: _ClusterGetStatus, instance_num: int
-    ) -> _InstanceVerdict:
+    ) -> tuple[_InstanceDecision, _InstanceScratch]:
         """Evaluate if the cluster instance is suitable for running the current test.
 
         Runs the checks in order and rules the instance out on the first failed one.
-        Besides the per-instance fields of `cget_status`, the checks can also modify
-        durable status records - e.g. wipe records of a dead instance, or claim a
-        needed respin. A SKIP verdict can therefore leave the worker pinned to this
-        instance with a claimed respin, to be re-evaluated on a later iteration.
-        Sets `cget_status.sleep_delay` where the blocking condition warrants
-        a back-off of the top-level loop.
+        Besides recording what they found out in the returned scratch object, the checks
+        can also modify durable status records - e.g. wipe records of a dead instance, or
+        claim a needed respin - as well as the worker state. A non-START verdict can
+        therefore leave the worker pinned to this instance with a claimed respin, to be
+        re-evaluated on a later iteration.
 
         Must be called under the global lock.
 
         Returns:
-            The verdict - START when the test can start on this instance, SKIP
-            when the loop should move on to the next instance or iteration.
+            The decision on the instance and the findings of the evaluation. The
+            decision is START when the test can start on this instance, SKIP when the
+            loop should move on to the next instance, DEFER when it should return to the
+            top-level loop and re-enter this pinned instance later.
         """
-        cget_status.instance_num = instance_num
-        cget_status.instance_dir = status_files.get_instance_dir(instance_num=instance_num)
-        cget_status.instance_dir.mkdir(exist_ok=True)
+        scratch = _InstanceScratch(instance_num=instance_num)
+        status_files.get_instance_dir(instance_num=instance_num).mkdir(exist_ok=True)
 
         # Cleanup cluster instance where attempt to start cluster failed repeatedly
         if self.snap.is_cluster_dead(instance_num=instance_num):
-            self._cleanup_dead_cluster(cget_status)
-            return _InstanceVerdict.SKIP
+            self._cleanup_dead_cluster(cget_status, instance_num=instance_num)
+            return _InstanceDecision.skip(), scratch
 
         # Cluster respin planned or in progress, so no new tests can start
-        if self._being_respun_by_other_worker(cget_status):
-            cget_status.sleep_delay = 5
-            return _InstanceVerdict.SKIP
+        if self._being_respun_by_other_worker(cget_status, instance_num=instance_num):
+            return _InstanceDecision.skip(LONG_BACKOFF_SEC), scratch
 
         # If marked tests are already running, update their status.
         # Must be done before the mark state is read below, as stale marks
         # get cleaned up here.
-        self._update_marked_tests(cget_status=cget_status)
+        self._update_marked_tests(instance_num=instance_num)
 
         # Are there tests already running on this cluster instance?
-        cget_status.started_tests_rows = self.snap.list_test_running(instance_num=instance_num)
+        scratch.started_tests_rows = self.snap.list_test_running(instance_num=instance_num)
 
         # "marked tests" = group of tests marked with my mark
-        cget_status.marked_ready_rows = self.snap.list_curr_mark(
+        scratch.marked_ready_rows = self.snap.list_curr_mark(
             instance_num=instance_num, mark=cget_status.mark
         )
 
@@ -997,20 +1112,18 @@ class ClusterGetter:
         # we need to wait.
         if (
             self.num_of_instances > 1
-            and (tnum := len(cget_status.started_tests_rows)) >= configuration.MAX_TESTS_PER_CLUSTER
+            and (tnum := len(scratch.started_tests_rows)) >= configuration.MAX_TESTS_PER_CLUSTER
         ):
-            cget_status.sleep_delay = 2
             self.log(f"c{instance_num}: {tnum} tests are already running, cannot start")
-            return _InstanceVerdict.SKIP
+            return _InstanceDecision.skip(SHORT_BACKOFF_SEC), scratch
 
         # Does the cluster instance need respin to continue?
         # Cache the result as the check itself can be expensive.
-        cget_status.cluster_needs_respin = self._cluster_needs_respin(instance_num)
+        scratch.cluster_needs_respin = self._cluster_needs_respin(instance_num)
 
         # Select this instance for running marked tests if possible
-        if cget_status.mark and not self._marked_select_instance(cget_status):
-            cget_status.sleep_delay = 2
-            return _InstanceVerdict.SKIP
+        if cget_status.mark and not self._marked_select_instance(cget_status, scratch):
+            return _InstanceDecision.skip(SHORT_BACKOFF_SEC), scratch
 
         # Try next cluster instance when the current one needs respin.
         # Respin only if:
@@ -1018,12 +1131,12 @@ class ClusterGetter:
         # * respin is needed by the current test anyway
         # * we already tried all cluster instances and there's no other option
         if (
-            cget_status.cluster_needs_respin
+            scratch.cluster_needs_respin
             and cget_status.selected_instance != instance_num
-            and not self._test_needs_respin(cget_status)
+            and not self._test_needs_respin(cget_status, scratch)
             and not cget_status.tried_all_instances
         ):
-            return _InstanceVerdict.SKIP
+            return _InstanceDecision.skip(), scratch
 
         # We don't need to resolve resources availability if there was already a test
         # with this mark before (the first test already resolved the resources
@@ -1031,21 +1144,21 @@ class ClusterGetter:
         # It is responsibility of tests to make sure that the same resources are
         # requested for all the tests with the same mark (e.g. specific pool and
         # not "any pool").
-        need_resolve_resources = not cget_status.marked_ready_rows
+        need_resolve_resources = not scratch.marked_ready_rows
 
         # Check availability of the required resources
-        if need_resolve_resources and not self._resolve_resources_availability(cget_status):
-            cget_status.sleep_delay = 5
-            return _InstanceVerdict.SKIP
+        if need_resolve_resources and not self._resolve_resources_availability(
+            cget_status, scratch
+        ):
+            return _InstanceDecision.skip(LONG_BACKOFF_SEC), scratch
 
         # If respin is needed, indicate that the cluster will be re-spun
         # (after all currently running tests are finished)
-        if not self._init_respin(cget_status):
-            return _InstanceVerdict.SKIP
+        return self._init_respin(cget_status, scratch), scratch
 
-        return _InstanceVerdict.START
-
-    def _prepare_selected_instance(self, cget_status: _ClusterGetStatus) -> _InstanceVerdict:
+    def _prepare_selected_instance(
+        self, cget_status: _ClusterGetStatus, scratch: _InstanceScratch
+    ) -> _InstanceDecision:
         """Select the evaluated cluster instance and finish respin-related actions.
 
         Pins the worker to the instance, sets the cluster env variables, removes the
@@ -1055,20 +1168,22 @@ class ClusterGetter:
         Must be called under the global lock.
 
         Returns:
-            START when the selection is finished and the test can start. SKIP when
+            START when the selection is finished and the test can start. DEFER when
             the claimed respin was just armed - the instance stays pinned and is
             re-entered on a later iteration, after the respin was performed.
         """
+        claim = cget_status.respin
+
         # An armed respin must run (`_respin_if_armed`) before the instance can be
         # selected - finishing the selection here would skip the promised respin
-        if cget_status.respin_state is _RespinState.ARMED:
-            msg = f"Cannot select instance in the '{cget_status.respin_state.name}' respin state."
+        if claim is not None and claim.phase is _RespinPhase.ARMED:
+            msg = f"Cannot select instance in the '{claim.phase.name}' respin state."
             raise RuntimeError(msg)
 
-        instance_num = cget_status.instance_num
+        instance_num = scratch.instance_num
 
         # We've found suitable cluster instance
-        cget_status.selected_instance = instance_num
+        cget_status.pin_instance(instance_num)
         self._cluster_instance_num = instance_num
         self.log(f"c{instance_num}: can run test '{cget_status.current_test}'")
         # Set environment variables that are needed when respinning the cluster
@@ -1082,19 +1197,65 @@ class ClusterGetter:
         # Create status record for marked tests.
         # This must be done before the cluster is re-spun, so that other marked tests
         # don't try to prepare another cluster instance.
-        self._init_marked_test(cget_status)
+        self._init_marked_test(cget_status, instance_num=instance_num)
 
         # Arm the claimed respin and return to the top-level loop, where
         # `_respin` runs outside of the global lock
-        if cget_status.respin_state is _RespinState.CLAIMED:
-            self._arm_respin(cget_status)
-            return _InstanceVerdict.SKIP
+        if claim is not None and claim.phase is _RespinPhase.CLAIMED:
+            self._arm_respin(claim)
+            return _InstanceDecision.defer()
 
         # The respin was already performed, clean up the respin status records
-        if cget_status.respin_state is _RespinState.RESPUN:
+        if claim is not None and claim.phase is _RespinPhase.RESPUN:
             self._cleanup_after_respin(cget_status)
 
-        return _InstanceVerdict.START
+        return _InstanceDecision.start()
+
+    def _try_instances(
+        self, cget_status: _ClusterGetStatus, instances_order: tp.Iterable[int]
+    ) -> _InstanceDecision:
+        """Try the cluster instances in the given order until the test can start on one.
+
+        Sets up the test on the first suitable cluster instance. Records that all
+        instances were tried when none of them is usable in this iteration.
+
+        Must be called under the global lock.
+
+        Returns:
+            START when the test was set up and can start, SKIP or DEFER when the
+            top-level loop needs to wait and try again.
+        """
+        for instance_num in instances_order:
+            # If instance to run the test on was already decided, skip all other instances
+            if cget_status.selected_instance not in (-1, instance_num):
+                continue
+
+            # Check if the test can start on this instance
+            decision, scratch = self._evaluate_instance(cget_status, instance_num=instance_num)
+
+            # Select the instance. A freshly claimed respin is only armed here
+            # and the instance is re-entered after the respin was performed.
+            if decision.verdict is _InstanceVerdict.START:
+                decision = self._prepare_selected_instance(cget_status, scratch)
+
+            if decision.verdict is _InstanceVerdict.START:
+                # From this point on, all conditions needed to start the test are met
+                self._create_test_status_records(cget_status, scratch)
+                return decision
+
+            # The worker is pinned to this instance, no other one is an option
+            if decision.verdict is _InstanceVerdict.DEFER:
+                return decision
+
+            # Back off before the next attempt as the verdict asks. The delay is sticky -
+            # it stays in effect until another verdict asks for a different one - and this
+            # is the only place where a verdict on an instance sets it.
+            if decision.backoff_sec:
+                cget_status.sleep_delay = decision.backoff_sec
+
+        # The test cannot start on any instance, return to the top-level loop
+        cget_status.tried_all_instances = True
+        return _InstanceDecision.skip()
 
     def get_cluster_instance(  # noqa: C901
         self,
@@ -1244,7 +1405,7 @@ class ClusterGetter:
                 # A "prio" test has priority in obtaining cluster instance. Check if it is needed
                 # to wait until earlier "prio" test obtains a cluster instance.
                 if self._wait_for_prio(cget_status):
-                    cget_status.sleep_delay = 5
+                    cget_status.sleep_delay = LONG_BACKOFF_SEC
                     continue
 
                 # Set "prio" for this test if indicated
@@ -1253,30 +1414,9 @@ class ClusterGetter:
                 self._cluster_instance_num = -1
 
                 # Try all existing cluster instances in the precomputed order
-                for instance_num in instances_order:
-                    # If instance to run the test on was already decided, skip all other instances
-                    if cget_status.selected_instance not in (-1, instance_num):
-                        continue
-
-                    # Check if the test can start on this instance
-                    verdict = self._evaluate_instance(cget_status, instance_num=instance_num)
-                    if verdict is _InstanceVerdict.SKIP:
-                        continue
-
-                    # Select the instance. A freshly claimed respin is only armed here
-                    # and the instance is re-entered after the respin was performed.
-                    verdict = self._prepare_selected_instance(cget_status)
-                    if verdict is _InstanceVerdict.SKIP:
-                        continue
-
-                    # From this point on, all conditions needed to start the test are met
-                    break
-                else:
-                    # If the test cannot start on any instance, return to top-level loop
-                    cget_status.tried_all_instances = True
+                decision = self._try_instances(cget_status, instances_order=instances_order)
+                if decision.verdict is not _InstanceVerdict.START:
                     continue
-
-                self._create_test_status_records(cget_status)
 
                 # Cluster instance is ready, we can start the test
                 break

--- a/framework_tests/test_cluster_getter.py
+++ b/framework_tests/test_cluster_getter.py
@@ -24,7 +24,7 @@ def _get_cluster_getter(num_of_instances: int = 1) -> cluster_getter.ClusterGett
     )
 
 
-def _get_cget_status(instance_num: int, mark: str = "") -> cluster_getter._ClusterGetStatus:
+def _get_cget_status(mark: str = "") -> cluster_getter._ClusterGetStatus:
     """Return a `_ClusterGetStatus` instance suitable for unit testing."""
     return cluster_getter._ClusterGetStatus(
         mark=mark,
@@ -34,8 +34,20 @@ def _get_cget_status(instance_num: int, mark: str = "") -> cluster_getter._Clust
         cleanup=False,
         scriptsdir="",
         current_test="test_x",
-        instance_num=instance_num,
     )
+
+
+def _get_scratch(instance_num: int = 0) -> cluster_getter._InstanceScratch:
+    """Return an `_InstanceScratch` instance suitable for unit testing."""
+    return cluster_getter._InstanceScratch(instance_num=instance_num)
+
+
+def _get_claim(
+    instance_num: int = 0,
+    phase: cluster_getter._RespinPhase = cluster_getter._RespinPhase.CLAIMED,
+) -> cluster_getter._RespinClaim:
+    """Return a `_RespinClaim` instance suitable for unit testing."""
+    return cluster_getter._RespinClaim(instance_num=instance_num, phase=phase)
 
 
 def _populate_marked(instance_num: int = 0, mark: str = "markA") -> None:
@@ -164,17 +176,17 @@ def test_on_marked_test_stop_no_respin_promise():
 def test_cleanup_dead_cluster_removes_marks():
     """Check that dead cluster instance cleanup removes marks and marked resources."""
     getter = _get_cluster_getter()
-    cget_status = _get_cget_status(instance_num=0)
+    cget_status = _get_cget_status()
     cget_status.selected_instance = 0
     # The state a worker is in when its respin attempt failed and killed the instance
-    cget_status.respin_state = cluster_getter._RespinState.RESPUN
+    cget_status.respin = _get_claim(instance_num=0, phase=cluster_getter._RespinPhase.RESPUN)
 
     _populate_marked(instance_num=0, mark="markA")
 
-    getter._cleanup_dead_cluster(cget_status)
+    getter._cleanup_dead_cluster(cget_status, instance_num=0)
 
     assert cget_status.selected_instance == -1
-    assert cget_status.respin_state is cluster_getter._RespinState.NONE
+    assert cget_status.respin is None
     assert status_db.list_curr_mark(instance_num=0) == []
     assert status_db.get_resource_names(mode=status_db.MODE_LOCK, instance_num=0) == []
     assert status_db.get_resource_names(mode=status_db.MODE_USE, instance_num=0) == []
@@ -191,19 +203,22 @@ def test_init_respin_own_mark():
     gets re-created) while holding no resource records at all.
     """
     getter = _get_cluster_getter()
-    cget_status = _get_cget_status(instance_num=0, mark="markA")
-    cget_status.cluster_needs_respin = True
+    cget_status = _get_cget_status(mark="markA")
+    scratch = _get_scratch(instance_num=0)
+    scratch.cluster_needs_respin = True
 
     _populate_marked(instance_num=0, mark="markA")
-    cget_status.marked_ready_rows = status_db.list_curr_mark(instance_num=0, mark="markA")
-    assert cget_status.marked_ready_rows
+    scratch.marked_ready_rows = status_db.list_curr_mark(instance_num=0, mark="markA")
+    assert scratch.marked_ready_rows
 
     # The test cannot continue in this iteration - it must re-evaluate the instance
-    # as the initial test of the mark
-    assert getter._init_respin(cget_status) is False
+    # as the initial test of the mark. The findings of this evaluation, incl. the
+    # mark's records, are discarded together with the scratch object.
+    decision = getter._init_respin(cget_status, scratch)
+    assert decision.verdict is cluster_getter._InstanceVerdict.DEFER
 
-    assert cget_status.marked_ready_rows == ()
-    assert cget_status.respin_state is cluster_getter._RespinState.CLAIMED
+    assert cget_status.respin is not None
+    assert cget_status.respin.phase is cluster_getter._RespinPhase.CLAIMED
     assert cget_status.selected_instance == 0
     assert len(status_db.list_respin_progress(instance_num=0)) == 1
     # The respin stays scheduled even when the re-evaluation gets delayed
@@ -216,13 +231,14 @@ def test_init_respin_own_mark():
     # must short-circuit on the owned respin and not wipe them again. The short-circuit
     # must hold in every owning phase, incl. the post-respin re-entry.
     _populate_marked(instance_num=0, mark="markA")
-    for own_state in (
-        cluster_getter._RespinState.CLAIMED,
-        cluster_getter._RespinState.ARMED,
-        cluster_getter._RespinState.RESPUN,
-    ):
-        cget_status.respin_state = own_state
-        assert getter._init_respin(cget_status) is True
+    for own_phase in cluster_getter._RespinPhase:
+        cget_status.respin = _get_claim(instance_num=0, phase=own_phase)
+        reeval_scratch = _get_scratch(instance_num=0)
+        # Without the short-circuit, the instance still needing a respin would make
+        # the claim - and the wipe of the mark's records - run again
+        reeval_scratch.cluster_needs_respin = True
+        decision = getter._init_respin(cget_status, reeval_scratch)
+        assert decision.verdict is cluster_getter._InstanceVerdict.START
         assert len(status_db.list_curr_mark(instance_num=0)) == 1
         assert status_db.get_resource_names(mode=status_db.MODE_LOCK, instance_num=0) != []
         assert len(status_db.list_respin_progress(instance_num=0)) == 1
@@ -238,18 +254,22 @@ def test_marked_select_instance_respinner_not_blocked():
     of the mark instead of waiting for the other instance forever.
     """
     getter = _get_cluster_getter()
-    cget_status = _get_cget_status(instance_num=0, mark="markA")
+    cget_status = _get_cget_status(mark="markA")
+    scratch = _get_scratch(instance_num=0)
     status_db.create_curr_mark(instance_num=1, worker_id="gw1", mark="markA")
     cget_status.marked_running_my_anywhere = status_db.list_curr_mark(mark="markA")
     assert cget_status.marked_running_my_anywhere
 
     # Without the pending respin, the mark on the other instance blocks this worker
-    assert getter._marked_select_instance(cget_status) is False
+    assert getter._marked_select_instance(cget_status, scratch) is False
 
     # The respinning worker proceeds as the first test of the mark
-    cget_status.respin_state = cluster_getter._RespinState.CLAIMED
-    cget_status.selected_instance = 0  # A claimed respin always comes with the pinned instance
-    assert getter._marked_select_instance(cget_status) is True
+    cget_status.claim_respin(0)
+    assert getter._marked_select_instance(cget_status, scratch) is True
+
+    # A claim on another cluster instance doesn't unblock this one
+    cget_status.claim_respin(1)
+    assert getter._marked_select_instance(cget_status, scratch) is False
 
 
 @pytest.mark.usefixtures("db_dir")
@@ -260,16 +280,18 @@ def test_init_respin_tests_running():
     running tests to finish first.
     """
     getter = _get_cluster_getter()
-    cget_status = _get_cget_status(instance_num=0, mark="markA")
-    cget_status.cluster_needs_respin = True
+    cget_status = _get_cget_status(mark="markA")
+    scratch = _get_scratch(instance_num=0)
+    scratch.cluster_needs_respin = True
 
     _populate_marked(instance_num=0, mark="markA")
     status_db.create_test_running(instance_num=0, worker_id="gw1", test_id="test_x")
-    cget_status.started_tests_rows = status_db.list_test_running(instance_num=0)
+    scratch.started_tests_rows = status_db.list_test_running(instance_num=0)
 
-    assert getter._init_respin(cget_status) is False
+    decision = getter._init_respin(cget_status, scratch)
+    assert decision.verdict is cluster_getter._InstanceVerdict.SKIP
 
-    assert cget_status.respin_state is cluster_getter._RespinState.NONE
+    assert cget_status.respin is None
     assert status_db.list_respin_progress(instance_num=0) == []
     assert len(status_db.list_curr_mark(instance_num=0)) == 1
     assert status_db.get_resource_names(mode=status_db.MODE_LOCK, instance_num=0) != []
@@ -283,14 +305,18 @@ def test_init_respin_foreign_marks():
     instance, the marks are removed and the respin continues in the same iteration.
     """
     getter = _get_cluster_getter()
-    cget_status = _get_cget_status(instance_num=0)
-    cget_status.cluster_needs_respin = True
+    cget_status = _get_cget_status()
+    scratch = _get_scratch(instance_num=0)
+    scratch.cluster_needs_respin = True
 
     _populate_marked(instance_num=0, mark="markA")
 
-    assert getter._init_respin(cget_status) is True
+    decision = getter._init_respin(cget_status, scratch)
+    assert decision.verdict is cluster_getter._InstanceVerdict.START
 
-    assert cget_status.respin_state is cluster_getter._RespinState.CLAIMED
+    assert cget_status.respin is not None
+    assert cget_status.respin.phase is cluster_getter._RespinPhase.CLAIMED
+    assert cget_status.selected_instance == 0
     assert status_db.list_curr_mark(instance_num=0) == []
     assert status_db.get_resource_names(mode=status_db.MODE_LOCK, instance_num=0) == []
 
@@ -412,18 +438,17 @@ def test_test_needs_respin():
     """
     getter = _get_cluster_getter()
 
-    cget_status = _get_cget_status(instance_num=0)
-    assert getter._test_needs_respin(cget_status) is False
+    cget_status = _get_cget_status()
+    scratch = _get_scratch(instance_num=0)
+    assert getter._test_needs_respin(cget_status, scratch) is False
 
     cget_status.scriptsdir = "/custom/scripts"
-    assert getter._test_needs_respin(cget_status) is True
+    assert getter._test_needs_respin(cget_status, scratch) is True
 
     # Non-initial marked test - respin was already done by the initial marked test
     cget_status.mark = "markA"
-    cget_status.marked_ready_rows = [
-        status_db.StatusRow(instance_num=0, worker_id="gw0", mark="markA")
-    ]
-    assert getter._test_needs_respin(cget_status) is False
+    scratch.marked_ready_rows = [status_db.StatusRow(instance_num=0, worker_id="gw0", mark="markA")]
+    assert getter._test_needs_respin(cget_status, scratch) is False
 
 
 @pytest.mark.usefixtures("db_dir")
@@ -455,7 +480,7 @@ class TestUpdateMarkedTests:
         status_db.create_test_running(instance_num=0, worker_id="gw1", test_id="test_x")
         gen_before = status_db._write_generation
 
-        getter._update_marked_tests(cget_status=_get_cget_status(instance_num=0))
+        getter._update_marked_tests(instance_num=0)
 
         assert status_db._write_generation == gen_before
 
@@ -470,7 +495,7 @@ class TestUpdateMarkedTests:
         self._set_mark_age(cluster_getter.MARK_STALENESS_SEC + 1)
         getter.snap.refresh()
 
-        getter._update_marked_tests(cget_status=_get_cget_status(instance_num=0))
+        getter._update_marked_tests(instance_num=0)
 
         assert status_db.list_curr_mark(instance_num=0) == []
         assert status_db.get_resource_names(mode=status_db.MODE_LOCK, instance_num=0) == []
@@ -484,7 +509,7 @@ class TestUpdateMarkedTests:
         self._set_mark_age(cluster_getter.MARK_STALENESS_SEC + 1)
         getter.snap.refresh()
 
-        getter._update_marked_tests(cget_status=_get_cget_status(instance_num=0))
+        getter._update_marked_tests(instance_num=0)
 
         assert len(status_db.list_curr_mark(instance_num=0)) == 1
 
@@ -495,7 +520,7 @@ class TestUpdateMarkedTests:
         self._set_mark_age(cluster_getter.MARK_STALENESS_SEC - 10)
         getter.snap.refresh()
 
-        getter._update_marked_tests(cget_status=_get_cget_status(instance_num=0))
+        getter._update_marked_tests(instance_num=0)
 
         assert len(status_db.list_curr_mark(instance_num=0)) == 1
 
@@ -509,7 +534,7 @@ class TestUpdateMarkedTests:
         created_at = self._set_mark_age(cluster_getter.MARK_REFRESH_SEC + 1)
         getter.snap.refresh()
 
-        getter._update_marked_tests(cget_status=_get_cget_status(instance_num=0))
+        getter._update_marked_tests(instance_num=0)
 
         rows = status_db.list_curr_mark(instance_num=0)
         assert len(rows) == 1
@@ -525,7 +550,7 @@ class TestUpdateMarkedTests:
         created_at = self._set_mark_age(cluster_getter.MARK_REFRESH_SEC - 5)
         getter.snap.refresh()
 
-        getter._update_marked_tests(cget_status=_get_cget_status(instance_num=0))
+        getter._update_marked_tests(instance_num=0)
 
         rows = status_db.list_curr_mark(instance_num=0)
         assert len(rows) == 1
@@ -539,7 +564,7 @@ class TestUpdateMarkedTests:
         status_db.create_curr_mark(instance_num=0, worker_id="gw1", mark="markA")
         getter.snap.refresh()
 
-        getter._update_marked_tests(cget_status=_get_cget_status(instance_num=0))
+        getter._update_marked_tests(instance_num=0)
 
         assert len(status_db.list_curr_mark(instance_num=0)) == 2
 
@@ -558,7 +583,7 @@ class TestUpdateMarkedTests:
         self._set_mark_age(cluster_getter.MARK_STALENESS_SEC + 1, mark="markA")
         getter.snap.refresh()
 
-        getter._update_marked_tests(cget_status=_get_cget_status(instance_num=0))
+        getter._update_marked_tests(instance_num=0)
 
         assert status_db.list_curr_mark(instance_num=0, mark="markA") == []
         assert len(status_db.list_curr_mark(instance_num=0, mark="markB")) == 1
@@ -578,7 +603,7 @@ class TestUpdateMarkedTests:
         created_at = self._set_mark_age(cluster_getter.MARK_STALENESS_SEC + 100)
         getter.snap.refresh()
 
-        getter._update_marked_tests(cget_status=_get_cget_status(instance_num=0))
+        getter._update_marked_tests(instance_num=0)
 
         rows = status_db.list_curr_mark(instance_num=0, mark="markA")
         assert len(rows) == 1
@@ -597,13 +622,14 @@ class TestResolveResources:
         status_db.create_resources(
             instance_num=0, worker_id="gw1", names=["pool1"], mode=status_db.MODE_LOCK
         )
-        cget_status = _get_cget_status(instance_num=0)
+        cget_status = _get_cget_status()
         cget_status.lock_resources = ["pool1"]
+        scratch = _get_scratch(instance_num=0)
 
-        assert getter._resolve_resources_availability(cget_status) is False
+        assert getter._resolve_resources_availability(cget_status, scratch) is False
         # Resolved resources are recorded only on success
-        assert list(cget_status.final_lock_resources) == []
-        assert list(cget_status.final_use_resources) == []
+        assert list(scratch.final_lock_resources) == []
+        assert list(scratch.final_use_resources) == []
 
     def test_lock_conflict_with_used(self):
         """Check that a resource in use by another test cannot be locked."""
@@ -611,10 +637,10 @@ class TestResolveResources:
         status_db.create_resources(
             instance_num=0, worker_id="gw1", names=["pool1"], mode=status_db.MODE_USE
         )
-        cget_status = _get_cget_status(instance_num=0)
+        cget_status = _get_cget_status()
         cget_status.lock_resources = ["pool1"]
 
-        assert getter._resolve_resources_availability(cget_status) is False
+        assert getter._resolve_resources_availability(cget_status, _get_scratch()) is False
 
     def test_use_conflict_with_locked(self):
         """Check that a resource locked by another test cannot be used."""
@@ -622,10 +648,10 @@ class TestResolveResources:
         status_db.create_resources(
             instance_num=0, worker_id="gw1", names=["pool1"], mode=status_db.MODE_LOCK
         )
-        cget_status = _get_cget_status(instance_num=0)
+        cget_status = _get_cget_status()
         cget_status.use_resources = ["pool1"]
 
-        assert getter._resolve_resources_availability(cget_status) is False
+        assert getter._resolve_resources_availability(cget_status, _get_scratch()) is False
 
     def test_use_not_blocked_by_used(self):
         """Check that a resource in use by another test can still be used."""
@@ -633,23 +659,25 @@ class TestResolveResources:
         status_db.create_resources(
             instance_num=0, worker_id="gw1", names=["pool1"], mode=status_db.MODE_USE
         )
-        cget_status = _get_cget_status(instance_num=0)
+        cget_status = _get_cget_status()
         cget_status.use_resources = ["pool1"]
+        scratch = _get_scratch(instance_num=0)
 
-        assert getter._resolve_resources_availability(cget_status) is True
-        assert list(cget_status.final_use_resources) == ["pool1"]
+        assert getter._resolve_resources_availability(cget_status, scratch) is True
+        assert list(scratch.final_use_resources) == ["pool1"]
 
     def test_resolved_resources(self):
         """Check that resolved resources are recorded, with locked implying in-use."""
         getter = _get_cluster_getter()
-        cget_status = _get_cget_status(instance_num=0)
+        cget_status = _get_cget_status()
         cget_status.lock_resources = ["pool1"]
         cget_status.use_resources = ["pool1", "pool2"]
+        scratch = _get_scratch(instance_num=0)
 
-        assert getter._resolve_resources_availability(cget_status) is True
-        assert list(cget_status.final_lock_resources) == ["pool1"]
+        assert getter._resolve_resources_availability(cget_status, scratch) is True
+        assert list(scratch.final_lock_resources) == ["pool1"]
         # Locked resources are in use implicitly, only the rest is recorded as "use"
-        assert list(cget_status.final_use_resources) == ["pool2"]
+        assert list(scratch.final_use_resources) == ["pool2"]
 
     def test_one_of_filter(self):
         """Check that a `OneOf` filter picks an available resource."""
@@ -657,11 +685,12 @@ class TestResolveResources:
         status_db.create_resources(
             instance_num=0, worker_id="gw1", names=["pool1"], mode=status_db.MODE_LOCK
         )
-        cget_status = _get_cget_status(instance_num=0)
+        cget_status = _get_cget_status()
         cget_status.lock_resources = [resources_management.OneOf(resources=["pool1", "pool2"])]
+        scratch = _get_scratch(instance_num=0)
 
-        assert getter._resolve_resources_availability(cget_status) is True
-        assert list(cget_status.final_lock_resources) == ["pool2"]
+        assert getter._resolve_resources_availability(cget_status, scratch) is True
+        assert list(scratch.final_lock_resources) == ["pool2"]
 
 
 @pytest.mark.usefixtures("db_dir")
@@ -671,7 +700,7 @@ class TestPrio:
     def test_init_prio(self):
         """Check that "prio" status record is created only for priority tests."""
         getter = _get_cluster_getter()
-        cget_status = _get_cget_status(instance_num=0)
+        cget_status = _get_cget_status()
 
         getter._init_prio(cget_status)
         assert cget_status.prio_here is False
@@ -686,7 +715,7 @@ class TestPrio:
         """Check that a test waits when a priority test setup is in progress."""
         getter = _get_cluster_getter()
         status_db.create_prio_in_progress(worker_id="gw1")
-        cget_status = _get_cget_status(instance_num=0)
+        cget_status = _get_cget_status()
 
         assert getter._wait_for_prio(cget_status) is True
 
@@ -699,15 +728,15 @@ class TestPrio:
         getter = _get_cluster_getter()
         status_db.create_prio_in_progress(worker_id="gw1")
 
-        cget_status = _get_cget_status(instance_num=0)
+        cget_status = _get_cget_status()
         cget_status.prio_here = True
         assert getter._wait_for_prio(cget_status) is False
 
-        cget_status = _get_cget_status(instance_num=0)
+        cget_status = _get_cget_status()
         cget_status.selected_instance = 0
         assert getter._wait_for_prio(cget_status) is False
 
-        cget_status = _get_cget_status(instance_num=0, mark="markA")
+        cget_status = _get_cget_status(mark="markA")
         cget_status.marked_running_my_anywhere = [
             status_db.StatusRow(instance_num=1, worker_id="gw1", mark="markA")
         ]
@@ -716,29 +745,29 @@ class TestPrio:
     def test_no_prio_no_wait(self):
         """Check that nothing blocks when no priority test is in progress."""
         getter = _get_cluster_getter()
-        assert getter._wait_for_prio(_get_cget_status(instance_num=0)) is False
+        assert getter._wait_for_prio(_get_cget_status()) is False
 
 
 @pytest.mark.usefixtures("db_dir")
 def test_being_respun_by_other_worker():
     """Check the detection of a respin done by another worker."""
     getter = _get_cluster_getter()
-    cget_status = _get_cget_status(instance_num=0)
+    cget_status = _get_cget_status()
 
-    assert getter._being_respun_by_other_worker(cget_status) is False
+    assert getter._being_respun_by_other_worker(cget_status, instance_num=0) is False
 
     status_db.create_respin_progress(instance_num=0, worker_id="gw1")
     getter.snap.refresh()
-    assert getter._being_respun_by_other_worker(cget_status) is True
+    assert getter._being_respun_by_other_worker(cget_status, instance_num=0) is True
 
     # The worker doing the respin is not blocked by its own respin, in any phase
-    for own_state in (
-        cluster_getter._RespinState.CLAIMED,
-        cluster_getter._RespinState.ARMED,
-        cluster_getter._RespinState.RESPUN,
-    ):
-        cget_status.respin_state = own_state
-        assert getter._being_respun_by_other_worker(cget_status) is False
+    for own_phase in cluster_getter._RespinPhase:
+        cget_status.respin = _get_claim(instance_num=0, phase=own_phase)
+        assert getter._being_respun_by_other_worker(cget_status, instance_num=0) is False
+
+    # A claim on another cluster instance doesn't hide the respin done here
+    cget_status.respin = _get_claim(instance_num=1)
+    assert getter._being_respun_by_other_worker(cget_status, instance_num=0) is True
 
 
 @pytest.mark.usefixtures("db_dir")
@@ -765,24 +794,25 @@ def test_respin_arm_and_cleanup():
     status records.
     """
     getter = _get_cluster_getter()
-    cget_status = _get_cget_status(instance_num=0)
+    cget_status = _get_cget_status()
 
-    cget_status.respin_state = cluster_getter._RespinState.CLAIMED
+    cget_status.claim_respin(0)
+    assert cget_status.respin is not None
     status_db.create_respin_progress(instance_num=0, worker_id="gw0")
     status_db.create_respin_needed(instance_num=0, worker_id="gw0")
 
     # Arm the respin - the status records must stay until the respin is performed
-    getter._arm_respin(cget_status)
-    assert cget_status.respin_state is cluster_getter._RespinState.ARMED
+    getter._arm_respin(cget_status.respin)
+    assert cget_status.respin.phase is cluster_getter._RespinPhase.ARMED
     assert len(status_db.list_respin_progress(instance_num=0)) == 1
     assert len(status_db.list_respin_needed(instance_num=0)) == 1
 
     # The respin itself runs in `get_cluster_instance`, outside of the global lock
-    cget_status.respin_state = cluster_getter._RespinState.RESPUN
+    cget_status.respin.phase = cluster_getter._RespinPhase.RESPUN
 
     # Respin done - clean up
     getter._cleanup_after_respin(cget_status)
-    assert cget_status.respin_state is cluster_getter._RespinState.NONE
+    assert cget_status.respin is None
     assert status_db.list_respin_progress(instance_num=0) == []
     assert status_db.list_respin_needed(instance_num=0) == []
 
@@ -791,27 +821,22 @@ def test_respin_arm_and_cleanup():
 def test_respin_wrong_state_rejected():
     """Check that arming and cleanup fail fast when called in a wrong respin state."""
     getter = _get_cluster_getter()
-    cget_status = _get_cget_status(instance_num=0)
+    cget_status = _get_cget_status()
 
     # Arming is valid only for a claimed respin
-    for state in (
-        cluster_getter._RespinState.NONE,
-        cluster_getter._RespinState.ARMED,
-        cluster_getter._RespinState.RESPUN,
-    ):
-        cget_status.respin_state = state
+    for phase in (cluster_getter._RespinPhase.ARMED, cluster_getter._RespinPhase.RESPUN):
         with pytest.raises(RuntimeError, match="Cannot arm respin"):
-            getter._arm_respin(cget_status)
+            getter._arm_respin(_get_claim(instance_num=0, phase=phase))
 
     # Cleanup is valid only for a performed respin - a premature call would delete
     # another worker's respin status records
     status_db.create_respin_progress(instance_num=0, worker_id="gw1")
-    for state in (
-        cluster_getter._RespinState.NONE,
-        cluster_getter._RespinState.CLAIMED,
-        cluster_getter._RespinState.ARMED,
+    for claim in (
+        None,
+        _get_claim(instance_num=0, phase=cluster_getter._RespinPhase.CLAIMED),
+        _get_claim(instance_num=0, phase=cluster_getter._RespinPhase.ARMED),
     ):
-        cget_status.respin_state = state
+        cget_status.respin = claim
         with pytest.raises(RuntimeError, match="Cannot clean up after respin"):
             getter._cleanup_after_respin(cget_status)
     assert len(status_db.list_respin_progress(instance_num=0)) == 1
@@ -823,22 +848,27 @@ class TestCreateTestStatusRecords:
 
     def _get_getter_status(
         self, mark: str = "", cleanup: bool = False
-    ) -> tuple[cluster_getter.ClusterGetter, cluster_getter._ClusterGetStatus]:
-        """Return getter and status prepared for creating status records on instance 0."""
+    ) -> tuple[
+        cluster_getter.ClusterGetter,
+        cluster_getter._ClusterGetStatus,
+        cluster_getter._InstanceScratch,
+    ]:
+        """Return getter, status and scratch for creating status records on instance 0."""
         getter = _get_cluster_getter()
         getter._cluster_instance_num = 0
-        cget_status = _get_cget_status(instance_num=0, mark=mark)
+        cget_status = _get_cget_status(mark=mark)
         cget_status.cleanup = cleanup
         cget_status.current_test = "test_x (setup)"
-        cget_status.final_lock_resources = ["pool1"]
-        cget_status.final_use_resources = [resources.Resources.CLUSTER]
-        return getter, cget_status
+        scratch = _get_scratch(instance_num=0)
+        scratch.final_lock_resources = ["pool1"]
+        scratch.final_use_resources = [resources.Resources.CLUSTER]
+        return getter, cget_status, scratch
 
     def test_plain_test(self):
         """Check records of a test without mark and cleanup."""
-        getter, cget_status = self._get_getter_status()
+        getter, cget_status, scratch = self._get_getter_status()
 
-        getter._create_test_status_records(cget_status)
+        getter._create_test_status_records(cget_status, scratch)
 
         assert status_db.get_resource_names(mode=status_db.MODE_LOCK, instance_num=0) == ["pool1"]
         assert status_db.get_resource_names(mode=status_db.MODE_USE, instance_num=0) == [
@@ -851,9 +881,9 @@ class TestCreateTestStatusRecords:
 
     def test_marked_cleanup(self):
         """Check that marked test with cleanup schedules respin after the whole group."""
-        getter, cget_status = self._get_getter_status(mark="markA", cleanup=True)
+        getter, cget_status, scratch = self._get_getter_status(mark="markA", cleanup=True)
 
-        getter._create_test_status_records(cget_status)
+        getter._create_test_status_records(cget_status, scratch)
 
         assert len(status_db.list_respin_after_mark(instance_num=0, mark="markA")) == 1
         assert status_db.list_respin_needed(instance_num=0) == []
@@ -864,9 +894,9 @@ class TestCreateTestStatusRecords:
 
     def test_unmarked_cleanup(self):
         """Check that unmarked test with cleanup schedules respin right after the test."""
-        getter, cget_status = self._get_getter_status(cleanup=True)
+        getter, cget_status, scratch = self._get_getter_status(cleanup=True)
 
-        getter._create_test_status_records(cget_status)
+        getter._create_test_status_records(cget_status, scratch)
 
         assert len(status_db.list_respin_needed(instance_num=0)) == 1
         assert status_db.list_respin_after_mark(instance_num=0) == []
@@ -934,28 +964,29 @@ def test_respin_if_armed(monkeypatch: pytest.MonkeyPatch):
     the cleanup.
     """
     getter = _get_cluster_getter()
-    cget_status = _get_cget_status(instance_num=0)
+    cget_status = _get_cget_status()
     cget_status.scriptsdir = "custom"
 
     respin_calls: list[str] = []
     monkeypatch.setattr(getter, "_respin", lambda scriptsdir: respin_calls.append(scriptsdir))
 
-    # Nothing runs while the respin is not armed
-    for state in (
-        cluster_getter._RespinState.NONE,
-        cluster_getter._RespinState.CLAIMED,
-        cluster_getter._RespinState.RESPUN,
-    ):
-        cget_status.respin_state = state
+    # Nothing runs while no respin is claimed
+    getter._respin_if_armed(cget_status)
+    assert respin_calls == []
+    assert cget_status.respin is None
+
+    # Nothing runs while the claimed respin is not armed
+    for phase in (cluster_getter._RespinPhase.CLAIMED, cluster_getter._RespinPhase.RESPUN):
+        cget_status.respin = _get_claim(instance_num=0, phase=phase)
         getter._respin_if_armed(cget_status)
         assert respin_calls == []
-        assert cget_status.respin_state is state
+        assert cget_status.respin.phase is phase
 
     # The armed respin runs with the test's custom scripts and moves to RESPUN
-    cget_status.respin_state = cluster_getter._RespinState.ARMED
+    cget_status.respin = _get_claim(instance_num=0, phase=cluster_getter._RespinPhase.ARMED)
     getter._respin_if_armed(cget_status)
     assert respin_calls == ["custom"]
-    assert cget_status.respin_state is cluster_getter._RespinState.RESPUN
+    assert cget_status.respin.phase is cluster_getter._RespinPhase.RESPUN
 
     # Re-entering must not run the respin again
     getter._respin_if_armed(cget_status)
@@ -971,8 +1002,8 @@ def test_respin_if_armed_failure(monkeypatch: pytest.MonkeyPatch):
     the respin again.
     """
     getter = _get_cluster_getter()
-    cget_status = _get_cget_status(instance_num=0)
-    cget_status.respin_state = cluster_getter._RespinState.ARMED
+    cget_status = _get_cget_status()
+    cget_status.respin = _get_claim(instance_num=0, phase=cluster_getter._RespinPhase.ARMED)
 
     respin_calls: list[str] = []
 
@@ -986,7 +1017,8 @@ def test_respin_if_armed_failure(monkeypatch: pytest.MonkeyPatch):
     getter._respin_if_armed(cget_status)
 
     assert respin_calls == [""]
-    assert cget_status.respin_state is cluster_getter._RespinState.RESPUN
+    assert cget_status.respin is not None
+    assert cget_status.respin.phase is cluster_getter._RespinPhase.RESPUN
 
     # Re-entering must not retry the failed respin
     getter._respin_if_armed(cget_status)
@@ -1000,74 +1032,75 @@ class TestEvaluateInstance:
     def test_dead_instance(self):
         """Check that a dead instance is skipped and the worker state is reset."""
         getter = _get_cluster_getter()
-        cget_status = _get_cget_status(instance_num=-1)
+        cget_status = _get_cget_status()
         cget_status.selected_instance = 0
-        cget_status.respin_state = cluster_getter._RespinState.RESPUN
+        cget_status.respin = _get_claim(instance_num=0, phase=cluster_getter._RespinPhase.RESPUN)
         status_db.set_cluster_dead(instance_num=0)
         getter.snap.refresh()
 
-        verdict = getter._evaluate_instance(cget_status, instance_num=0)
+        decision, scratch = getter._evaluate_instance(cget_status, instance_num=0)
 
-        assert verdict is cluster_getter._InstanceVerdict.SKIP
-        assert cget_status.instance_num == 0
+        assert decision.verdict is cluster_getter._InstanceVerdict.SKIP
+        assert scratch.instance_num == 0
         assert cget_status.selected_instance == -1
-        assert cget_status.respin_state is cluster_getter._RespinState.NONE
+        assert cget_status.respin is None
 
     def test_respun_elsewhere(self):
         """Check that an instance being respun by another worker is skipped."""
         getter = _get_cluster_getter()
-        cget_status = _get_cget_status(instance_num=-1)
+        cget_status = _get_cget_status()
         status_db.create_respin_progress(instance_num=0, worker_id="gw1")
         getter.snap.refresh()
 
-        verdict = getter._evaluate_instance(cget_status, instance_num=0)
+        decision, _scratch = getter._evaluate_instance(cget_status, instance_num=0)
 
-        assert verdict is cluster_getter._InstanceVerdict.SKIP
-        assert cget_status.sleep_delay == 5
+        assert decision.verdict is cluster_getter._InstanceVerdict.SKIP
+        assert decision.backoff_sec == 5
 
     def test_too_many_tests(self):
         """Check that a full instance is skipped when there are more instances."""
         getter = _get_cluster_getter(num_of_instances=2)
-        cget_status = _get_cget_status(instance_num=-1)
+        cget_status = _get_cget_status()
         status_db.set_cluster_running(instance_num=0)
         for tno in range(configuration.MAX_TESTS_PER_CLUSTER):
             status_db.create_test_running(instance_num=0, worker_id=f"gw{tno}", test_id=f"t{tno}")
         getter.snap.refresh()
 
-        verdict = getter._evaluate_instance(cget_status, instance_num=0)
+        decision, _scratch = getter._evaluate_instance(cget_status, instance_num=0)
 
-        assert verdict is cluster_getter._InstanceVerdict.SKIP
-        assert cget_status.sleep_delay == 2
+        assert decision.verdict is cluster_getter._InstanceVerdict.SKIP
+        assert decision.backoff_sec == 2
 
     def test_needs_respin_try_next(self):
         """Check that an instance that needs respin is skipped while others remain untried."""
         getter = _get_cluster_getter()
-        cget_status = _get_cget_status(instance_num=-1)
+        cget_status = _get_cget_status()
 
         # The cluster instance was never started, so it needs respin
-        verdict = getter._evaluate_instance(cget_status, instance_num=0)
+        decision, scratch = getter._evaluate_instance(cget_status, instance_num=0)
 
-        assert verdict is cluster_getter._InstanceVerdict.SKIP
-        assert cget_status.cluster_needs_respin is True
-        assert cget_status.respin_state is cluster_getter._RespinState.NONE
+        assert decision.verdict is cluster_getter._InstanceVerdict.SKIP
+        assert scratch.cluster_needs_respin is True
+        assert cget_status.respin is None
 
     def test_needs_respin_claimed_last_resort(self):
         """Check that the respin is claimed once all instances were tried."""
         getter = _get_cluster_getter()
-        cget_status = _get_cget_status(instance_num=-1)
+        cget_status = _get_cget_status()
         cget_status.tried_all_instances = True
 
-        verdict = getter._evaluate_instance(cget_status, instance_num=0)
+        decision, _scratch = getter._evaluate_instance(cget_status, instance_num=0)
 
-        assert verdict is cluster_getter._InstanceVerdict.START
-        assert cget_status.respin_state is cluster_getter._RespinState.CLAIMED
+        assert decision.verdict is cluster_getter._InstanceVerdict.START
+        assert cget_status.respin is not None
+        assert cget_status.respin.phase is cluster_getter._RespinPhase.CLAIMED
         assert cget_status.selected_instance == 0
         assert len(status_db.list_respin_progress(instance_num=0)) == 1
 
     def test_resource_conflict(self, monkeypatch: pytest.MonkeyPatch):
         """Check that an instance without free resources is skipped."""
         getter = _get_cluster_getter()
-        cget_status = _get_cget_status(instance_num=-1)
+        cget_status = _get_cget_status()
         cget_status.lock_resources = ["pool1"]
         status_db.set_cluster_running(instance_num=0)
         status_db.create_resources(
@@ -1076,25 +1109,25 @@ class TestEvaluateInstance:
         monkeypatch.setattr(getter, "_is_healthy", lambda _instance_num: True)
         getter.snap.refresh()
 
-        verdict = getter._evaluate_instance(cget_status, instance_num=0)
+        decision, _scratch = getter._evaluate_instance(cget_status, instance_num=0)
 
-        assert verdict is cluster_getter._InstanceVerdict.SKIP
-        assert cget_status.sleep_delay == 5
+        assert decision.verdict is cluster_getter._InstanceVerdict.SKIP
+        assert decision.backoff_sec == 5
 
     def test_all_clear(self, monkeypatch: pytest.MonkeyPatch):
         """Check that a healthy running instance with free resources can start the test."""
         getter = _get_cluster_getter()
-        cget_status = _get_cget_status(instance_num=-1)
+        cget_status = _get_cget_status()
         cget_status.lock_resources = ["pool1"]
         status_db.set_cluster_running(instance_num=0)
         monkeypatch.setattr(getter, "_is_healthy", lambda _instance_num: True)
         getter.snap.refresh()
 
-        verdict = getter._evaluate_instance(cget_status, instance_num=0)
+        decision, scratch = getter._evaluate_instance(cget_status, instance_num=0)
 
-        assert verdict is cluster_getter._InstanceVerdict.START
-        assert cget_status.respin_state is cluster_getter._RespinState.NONE
-        assert cget_status.final_lock_resources == ["pool1"]
+        assert decision.verdict is cluster_getter._InstanceVerdict.START
+        assert cget_status.respin is None
+        assert scratch.final_lock_resources == ["pool1"]
 
     def test_needs_respin_custom_scripts(self):
         """Check that a test with custom scripts claims the respin right away.
@@ -1103,13 +1136,14 @@ class TestEvaluateInstance:
         instances first.
         """
         getter = _get_cluster_getter()
-        cget_status = _get_cget_status(instance_num=-1)
+        cget_status = _get_cget_status()
         cget_status.scriptsdir = "custom"
 
-        verdict = getter._evaluate_instance(cget_status, instance_num=0)
+        decision, _scratch = getter._evaluate_instance(cget_status, instance_num=0)
 
-        assert verdict is cluster_getter._InstanceVerdict.START
-        assert cget_status.respin_state is cluster_getter._RespinState.CLAIMED
+        assert decision.verdict is cluster_getter._InstanceVerdict.START
+        assert cget_status.respin is not None
+        assert cget_status.respin.phase is cluster_getter._RespinPhase.CLAIMED
         assert cget_status.selected_instance == 0
 
     def test_max_tests_single_instance(self, monkeypatch: pytest.MonkeyPatch):
@@ -1119,16 +1153,16 @@ class TestEvaluateInstance:
         deadlock the run.
         """
         getter = _get_cluster_getter(num_of_instances=1)
-        cget_status = _get_cget_status(instance_num=-1)
+        cget_status = _get_cget_status()
         status_db.set_cluster_running(instance_num=0)
         for tno in range(configuration.MAX_TESTS_PER_CLUSTER):
             status_db.create_test_running(instance_num=0, worker_id=f"gw{tno}", test_id=f"t{tno}")
         monkeypatch.setattr(getter, "_is_healthy", lambda _instance_num: True)
         getter.snap.refresh()
 
-        verdict = getter._evaluate_instance(cget_status, instance_num=0)
+        decision, _scratch = getter._evaluate_instance(cget_status, instance_num=0)
 
-        assert verdict is cluster_getter._InstanceVerdict.START
+        assert decision.verdict is cluster_getter._InstanceVerdict.START
 
     def test_marked_ready_inherits_resources(self, monkeypatch: pytest.MonkeyPatch):
         """Check that a non-initial marked test inherits the group's resources.
@@ -1138,7 +1172,7 @@ class TestEvaluateInstance:
         the test forever.
         """
         getter = _get_cluster_getter()
-        cget_status = _get_cget_status(instance_num=-1, mark="markA")
+        cget_status = _get_cget_status(mark="markA")
         cget_status.lock_resources = ["pool1"]
         status_db.set_cluster_running(instance_num=0)
         status_db.create_curr_mark(instance_num=0, worker_id="gw1", mark="markA")
@@ -1153,40 +1187,58 @@ class TestEvaluateInstance:
         monkeypatch.setattr(getter, "_is_healthy", lambda _instance_num: True)
         getter.snap.refresh()
 
-        verdict = getter._evaluate_instance(cget_status, instance_num=0)
+        decision, scratch = getter._evaluate_instance(cget_status, instance_num=0)
 
-        assert verdict is cluster_getter._InstanceVerdict.START
+        assert decision.verdict is cluster_getter._InstanceVerdict.START
         # Pinned to the instance that has the mark
         assert cget_status.selected_instance == 0
         # Resources were not re-resolved
-        assert cget_status.final_lock_resources == ()
+        assert scratch.final_lock_resources == ()
 
     def test_respin_postponed_while_tests_run(self):
         """Check that a last-resort respin claim is postponed while tests are running."""
         getter = _get_cluster_getter()
-        cget_status = _get_cget_status(instance_num=-1)
+        cget_status = _get_cget_status()
         cget_status.tried_all_instances = True
         status_db.create_test_running(instance_num=0, worker_id="gw1", test_id="test_y")
         getter.snap.refresh()
 
-        verdict = getter._evaluate_instance(cget_status, instance_num=0)
+        decision, _scratch = getter._evaluate_instance(cget_status, instance_num=0)
 
-        assert verdict is cluster_getter._InstanceVerdict.SKIP
-        assert cget_status.respin_state is cluster_getter._RespinState.NONE
+        assert decision.verdict is cluster_getter._InstanceVerdict.SKIP
+        assert cget_status.respin is None
         assert status_db.list_respin_progress(instance_num=0) == []
+
+    def test_marked_ready_respin_deferred(self):
+        """Check that a marked test claiming a respin defers instead of skipping.
+
+        The claim pins the worker to this instance, so trying the other instances
+        would be pointless - the instance is re-evaluated on a later iteration.
+        """
+        getter = _get_cluster_getter(num_of_instances=2)
+        cget_status = _get_cget_status(mark="markA")
+        cget_status.scriptsdir = "custom"
+        _populate_marked(instance_num=0, mark="markA")
+        getter.snap.refresh()
+
+        decision, _scratch = getter._evaluate_instance(cget_status, instance_num=0)
+
+        assert decision.verdict is cluster_getter._InstanceVerdict.DEFER
+        assert cget_status.respin is not None
+        assert cget_status.selected_instance == 0
 
     def test_mark_running_elsewhere(self):
         """Check that a marked test waits when its mark runs on another instance."""
         getter = _get_cluster_getter(num_of_instances=2)
-        cget_status = _get_cget_status(instance_num=-1, mark="markA")
+        cget_status = _get_cget_status(mark="markA")
         status_db.create_curr_mark(instance_num=1, worker_id="gw1", mark="markA")
         getter.snap.refresh()
         cget_status.marked_running_my_anywhere = getter.snap.list_curr_mark(mark="markA")
 
-        verdict = getter._evaluate_instance(cget_status, instance_num=0)
+        decision, _scratch = getter._evaluate_instance(cget_status, instance_num=0)
 
-        assert verdict is cluster_getter._InstanceVerdict.SKIP
-        assert cget_status.sleep_delay == 2
+        assert decision.verdict is cluster_getter._InstanceVerdict.SKIP
+        assert decision.backoff_sec == 2
 
 
 @pytest.mark.usefixtures("db_dir")
@@ -1195,25 +1247,31 @@ class TestPrepareSelectedInstance:
 
     def _get_getter_status(
         self, monkeypatch: pytest.MonkeyPatch, mark: str = ""
-    ) -> tuple[cluster_getter.ClusterGetter, cluster_getter._ClusterGetStatus, list[int]]:
-        """Return getter, status and env setup calls record for selecting instance 0."""
+    ) -> tuple[
+        cluster_getter.ClusterGetter,
+        cluster_getter._ClusterGetStatus,
+        cluster_getter._InstanceScratch,
+        list[int],
+    ]:
+        """Return getter, status, scratch and env setup calls for selecting instance 0."""
         getter = _get_cluster_getter()
-        cget_status = _get_cget_status(instance_num=0, mark=mark)
+        cget_status = _get_cget_status(mark=mark)
+        scratch = _get_scratch(instance_num=0)
         env_calls: list[int] = []
         monkeypatch.setattr(
             cluster_getter.cluster_nodes,
             "set_cluster_env",
             lambda instance_num: env_calls.append(instance_num),
         )
-        return getter, cget_status, env_calls
+        return getter, cget_status, scratch, env_calls
 
     def test_no_respin(self, monkeypatch: pytest.MonkeyPatch):
         """Check plain selection - instance pinned, no respin-related actions."""
-        getter, cget_status, env_calls = self._get_getter_status(monkeypatch)
+        getter, cget_status, scratch, env_calls = self._get_getter_status(monkeypatch)
 
-        verdict = getter._prepare_selected_instance(cget_status)
+        decision = getter._prepare_selected_instance(cget_status, scratch)
 
-        assert verdict is cluster_getter._InstanceVerdict.START
+        assert decision.verdict is cluster_getter._InstanceVerdict.START
         assert cget_status.selected_instance == 0
         assert getter._cluster_instance_num == 0
         assert env_calls == [0]
@@ -1221,16 +1279,17 @@ class TestPrepareSelectedInstance:
     def test_claimed_respin_armed(self, monkeypatch: pytest.MonkeyPatch):
         """Check that a claimed respin is armed while the instance stays pinned.
 
-        The SKIP verdict defers the test start - the respin runs first and the
+        The DEFER verdict defers the test start - the respin runs first and the
         pinned instance is re-entered afterwards.
         """
-        getter, cget_status, _env_calls = self._get_getter_status(monkeypatch)
-        cget_status.respin_state = cluster_getter._RespinState.CLAIMED
+        getter, cget_status, scratch, _env_calls = self._get_getter_status(monkeypatch)
+        cget_status.claim_respin(0)
 
-        verdict = getter._prepare_selected_instance(cget_status)
+        decision = getter._prepare_selected_instance(cget_status, scratch)
 
-        assert verdict is cluster_getter._InstanceVerdict.SKIP
-        assert cget_status.respin_state is cluster_getter._RespinState.ARMED
+        assert decision.verdict is cluster_getter._InstanceVerdict.DEFER
+        assert cget_status.respin is not None
+        assert cget_status.respin.phase is cluster_getter._RespinPhase.ARMED
         assert cget_status.selected_instance == 0
 
     def test_claimed_respin_marked(self, monkeypatch: pytest.MonkeyPatch):
@@ -1239,51 +1298,114 @@ class TestPrepareSelectedInstance:
         Other tests of the marked group must see the mark on this instance during
         the respin window, so they don't prepare another cluster instance.
         """
-        getter, cget_status, _env_calls = self._get_getter_status(monkeypatch, mark="markA")
-        cget_status.respin_state = cluster_getter._RespinState.CLAIMED
+        getter, cget_status, scratch, _env_calls = self._get_getter_status(
+            monkeypatch, mark="markA"
+        )
+        cget_status.claim_respin(0)
 
-        verdict = getter._prepare_selected_instance(cget_status)
+        decision = getter._prepare_selected_instance(cget_status, scratch)
 
-        assert verdict is cluster_getter._InstanceVerdict.SKIP
-        assert cget_status.respin_state is cluster_getter._RespinState.ARMED
+        assert decision.verdict is cluster_getter._InstanceVerdict.DEFER
+        assert cget_status.respin is not None
+        assert cget_status.respin.phase is cluster_getter._RespinPhase.ARMED
         assert len(status_db.list_curr_mark(instance_num=0, mark="markA")) == 1
 
     def test_armed_respin_rejected(self, monkeypatch: pytest.MonkeyPatch):
         """Check that selection fails fast when the armed respin was not performed yet."""
-        getter, cget_status, _env_calls = self._get_getter_status(monkeypatch)
-        cget_status.respin_state = cluster_getter._RespinState.ARMED
+        getter, cget_status, scratch, _env_calls = self._get_getter_status(monkeypatch)
+        cget_status.respin = _get_claim(instance_num=0, phase=cluster_getter._RespinPhase.ARMED)
 
         with pytest.raises(RuntimeError, match="Cannot select instance"):
-            getter._prepare_selected_instance(cget_status)
+            getter._prepare_selected_instance(cget_status, scratch)
 
         # The guard precedes all mutations - nothing was selected
         assert cget_status.selected_instance == -1
 
     def test_respun_cleaned_up(self, monkeypatch: pytest.MonkeyPatch):
         """Check that the performed respin is cleaned up and the selection finishes."""
-        getter, cget_status, _env_calls = self._get_getter_status(monkeypatch)
-        cget_status.respin_state = cluster_getter._RespinState.RESPUN
+        getter, cget_status, scratch, _env_calls = self._get_getter_status(monkeypatch)
+        cget_status.respin = _get_claim(instance_num=0, phase=cluster_getter._RespinPhase.RESPUN)
         status_db.create_respin_progress(instance_num=0, worker_id="gw0")
         status_db.create_respin_needed(instance_num=0, worker_id="gw0")
 
-        verdict = getter._prepare_selected_instance(cget_status)
+        decision = getter._prepare_selected_instance(cget_status, scratch)
 
-        assert verdict is cluster_getter._InstanceVerdict.START
-        assert cget_status.respin_state is cluster_getter._RespinState.NONE
+        assert decision.verdict is cluster_getter._InstanceVerdict.START
+        assert cget_status.respin is None
         assert status_db.list_respin_progress(instance_num=0) == []
         assert status_db.list_respin_needed(instance_num=0) == []
 
     def test_mark_and_prio_records(self, monkeypatch: pytest.MonkeyPatch):
         """Check that selection creates the mark record and removes the prio record."""
-        getter, cget_status, _env_calls = self._get_getter_status(monkeypatch, mark="markA")
+        getter, cget_status, scratch, _env_calls = self._get_getter_status(
+            monkeypatch, mark="markA"
+        )
         cget_status.prio = True
         status_db.create_prio_in_progress(worker_id="gw0")
 
-        verdict = getter._prepare_selected_instance(cget_status)
+        decision = getter._prepare_selected_instance(cget_status, scratch)
 
-        assert verdict is cluster_getter._InstanceVerdict.START
+        assert decision.verdict is cluster_getter._InstanceVerdict.START
         assert len(status_db.list_curr_mark(instance_num=0, mark="markA")) == 1
         assert status_db.list_prio_in_progress() == []
+
+
+@pytest.mark.usefixtures("db_dir")
+class TestTryInstances:
+    """Check the iteration over the cluster instances."""
+
+    def test_start_creates_records(self, monkeypatch: pytest.MonkeyPatch):
+        """Check that the test is set up on a suitable cluster instance."""
+        getter = _get_cluster_getter()
+        cget_status = _get_cget_status()
+        status_db.set_cluster_running(instance_num=0)
+        monkeypatch.setattr(getter, "_is_healthy", lambda _instance_num: True)
+        monkeypatch.setattr(cluster_getter.cluster_nodes, "set_cluster_env", lambda **_kwargs: None)
+        getter.snap.refresh()
+
+        decision = getter._try_instances(cget_status, instances_order=(0,))
+
+        assert decision.verdict is cluster_getter._InstanceVerdict.START
+        assert len(status_db.list_test_running(instance_num=0, worker_id="gw0")) == 1
+        # Nothing asked for a back-off
+        assert cget_status.sleep_delay == 0
+
+    def test_no_usable_instance(self):
+        """Check that trying all instances in vain records it and asks for a back-off."""
+        getter = _get_cluster_getter(num_of_instances=2)
+        cget_status = _get_cget_status()
+        for instance_num in (0, 1):
+            status_db.create_respin_progress(instance_num=instance_num, worker_id="gw1")
+        getter.snap.refresh()
+
+        decision = getter._try_instances(cget_status, instances_order=(0, 1))
+
+        assert decision.verdict is cluster_getter._InstanceVerdict.SKIP
+        assert cget_status.tried_all_instances is True
+        # The back-off asked for by the last verdict is in effect
+        assert cget_status.sleep_delay == 5
+
+    def test_deferred_instance_stays_pinned(self, monkeypatch: pytest.MonkeyPatch):
+        """Check that a deferred instance ends the iteration with the pin kept.
+
+        The worker is pinned to the instance by the claimed respin, so the other
+        instances must not be tried - and they were not all tried, so a later
+        iteration can still fall back to them if the pin is released.
+        """
+        getter = _get_cluster_getter(num_of_instances=2)
+        cget_status = _get_cget_status()
+        cget_status.scriptsdir = "custom"
+        monkeypatch.setattr(cluster_getter.cluster_nodes, "set_cluster_env", lambda **_kwargs: None)
+
+        decision = getter._try_instances(cget_status, instances_order=(0, 1))
+
+        assert decision.verdict is cluster_getter._InstanceVerdict.DEFER
+        assert cget_status.selected_instance == 0
+        assert cget_status.respin is not None
+        assert cget_status.respin.phase is cluster_getter._RespinPhase.ARMED
+        assert cget_status.tried_all_instances is False
+        # The test was not set up yet
+        assert status_db.list_test_running(instance_num=0) == []
 
 
 @pytest.mark.usefixtures("db_dir")


### PR DESCRIPTION
Separate the per-instance findings from the cross-iteration worker state in `cluster_getter`:

* `_InstanceScratch` holds what one evaluation found out about one cluster instance. It is created by `_evaluate_instance` and discarded when the loop moves on, so findings cannot leak into decisions about another instance or a later iteration.
* `_ClusterGetStatus` keeps only the state that lives for the whole `get_cluster_instance` call. The write-only `instance_dir` field is gone, the `mkdir` side effect stays.
* `respin: _RespinClaim | None` replaces the `_RespinState` enum. The claim carries the instance it was made for, so `_arm_respin` and `_cleanup_after_respin` no longer read the instance from per-instance state, and abandoning a respin is discarding the object. The NONE state becomes `None`, the remaining phases are strictly linear.
* `claim_respin` / `release_instance` / `owns_respin` keep the claim and the instance pin - which are always established and dropped together
  - aligned in one place each.
* `_InstanceDecision` pairs the verdict with the back-off it asks for. The checks no longer write the sticky `sleep_delay`; the instance loop applies it in one place. The two back-off values get names.
* A DEFER verdict replaces the SKIP the armed respin used to return. The instance loop returns right away instead of draining over instances the pin excludes anyway, so `tried_all_instances` is no longer set by a worker that tried a single pinned instance.
* The instance loop moves to `_try_instances`.