### PR TITLE
fix: clean respin records of dead instance

### DIFF
--- a/cardano_node_tests/cluster_management/cluster_getter.py
+++ b/cardano_node_tests/cluster_management/cluster_getter.py
@@ -842,14 +842,17 @@ class ClusterGetter:
 
     def _cleanup_dead_cluster(self, cget_status: _ClusterGetStatus, instance_num: int) -> None:
         """Cleanup if the selected cluster instance failed to start."""
-        # Move on to other cluster instance.
-        # Respin status records ("respin in progress", "respin needed") may stay
-        # behind on the dead instance. They are never read - dead instances are never
-        # revived and workers skip them before checking the respin records.
+        # Release this worker's claim on the instance and move on to another one
         cget_status.release_instance()
 
-        # Remove status records that are checked by other workers
         self._rm_marks(instance_num=instance_num)
+
+        # Remove the respin status records of the whole instance. The instance is dead
+        # and stays dead, so the records are of no use to any worker - the respin was
+        # abandoned and no new one can be started on a dead instance. Removing records
+        # of other workers is safe for the same reason.
+        status_db.rm_respin_progress(instance_num=instance_num)
+        status_db.rm_respin_needed(instance_num=instance_num)
 
     def _init_respin(
         self, cget_status: _ClusterGetStatus, scratch: _InstanceScratch

--- a/framework_tests/test_cluster_getter.py
+++ b/framework_tests/test_cluster_getter.py
@@ -193,6 +193,29 @@ def test_cleanup_dead_cluster_removes_marks():
 
 
 @pytest.mark.usefixtures("db_dir")
+def test_cleanup_dead_cluster_removes_respin_records():
+    """Check that dead cluster instance cleanup removes respin records of all workers.
+
+    The instance is dead for good, so no worker can respin it and the records are of
+    no use to anyone. Records of other cluster instances must not be touched.
+    """
+    getter = _get_cluster_getter()
+    cget_status = _get_cget_status()
+    cget_status.selected_instance = 0
+    cget_status.respin = _get_claim(instance_num=0, phase=cluster_getter._RespinPhase.RESPUN)
+
+    status_db.create_respin_progress(instance_num=0, worker_id="gw0")
+    status_db.create_respin_needed(instance_num=0, worker_id="gw1")
+    status_db.create_respin_needed(instance_num=1, worker_id="gw1")
+
+    getter._cleanup_dead_cluster(cget_status, instance_num=0)
+
+    assert status_db.list_respin_progress(instance_num=0) == []
+    assert status_db.list_respin_needed(instance_num=0) == []
+    assert len(status_db.list_respin_needed(instance_num=1)) == 1
+
+
+@pytest.mark.usefixtures("db_dir")
 def test_init_respin_own_mark():
     """Check that a marked test that triggers respin re-resolves its resources.
 


### PR DESCRIPTION
The "respin in progress" and "respin needed" records of a cluster instance that failed to start were left behind by
`_cleanup_dead_cluster`. They were never read - the dead flag is terminal and workers check it before reading the respin records - but they made the status db state misleading.

Remove them for the whole instance. Records of other workers can be removed too: the instance stays dead, so no worker can respin it.