### PR TITLE
fix(spend_negative): update expected error for no-script build

### DIFF
--- a/cardano_node_tests/tests/tests_plutus/test_spend_negative_build.py
+++ b/cardano_node_tests/tests/tests_plutus/test_spend_negative_build.py
@@ -159,7 +159,13 @@ class TestNegative:
             )
         exc_value = str(excinfo.value)
         with common.allow_unstable_error_messages():
-            assert "(MissingScriptWitnessesUTXOW" in exc_value, exc_value
+            # cardano-cli >= 11.2.1.0 rejects a Plutus-less tx with collateral already
+            # during `transaction build`, before the ledger gets to raise
+            # `MissingScriptWitnessesUTXOW`.
+            assert (
+                "collateral inputs, but no Plutus scripts" in exc_value  # cardano-cli >= 11.2.1.0
+                or "(MissingScriptWitnessesUTXOW" in exc_value
+            ), exc_value
 
     @allure.link(helpers.get_vcs_link())
     @common.PARAM_PLUTUS3_VERSION


### PR DESCRIPTION
cardano-cli >= 11.2.1.0 rejects transaction build when collateral inputs are given but no Plutus script is used, instead of building the tx and letting the ledger raise MissingScriptWitnessesUTXOW at submit time.