### PR TITLE
feat(ci): report nightly test history to tcache

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -15,7 +15,10 @@ jobs:
     uses: ./.github/workflows/regression_reusable.yaml
     with:
       env-path: runner/env_nightly
+      history_name: nightly
     secrets:
+      TCACHE_BASIC_AUTH: ${{ secrets.TCACHE_BASIC_AUTH }}
+      TCACHE_URL: ${{ secrets.TCACHE_URL }}
       CI_FAIL_MAILS: ${{ secrets.NIGHTLY_FAIL_MAILS }}
       GMAIL_USERNAME: ${{ secrets.GMAIL_USERNAME }}
       GMAIL_PASSWORD: ${{ secrets.GMAIL_PASSWORD }}

--- a/.github/workflows/nightly_cli.yaml
+++ b/.github/workflows/nightly_cli.yaml
@@ -15,7 +15,10 @@ jobs:
     uses: ./.github/workflows/regression_reusable.yaml
     with:
       env-path: runner/env_nightly_cli
+      history_name: nightly-cli
     secrets:
+      TCACHE_BASIC_AUTH: ${{ secrets.TCACHE_BASIC_AUTH }}
+      TCACHE_URL: ${{ secrets.TCACHE_URL }}
       CI_FAIL_MAILS: ${{ secrets.NIGHTLY_FAIL_MAILS }}
       GMAIL_USERNAME: ${{ secrets.GMAIL_USERNAME }}
       GMAIL_PASSWORD: ${{ secrets.GMAIL_PASSWORD }}

--- a/.github/workflows/nightly_dbsync.yaml
+++ b/.github/workflows/nightly_dbsync.yaml
@@ -15,7 +15,10 @@ jobs:
     uses: ./.github/workflows/regression_reusable.yaml
     with:
       env-path: runner/env_nightly_dbsync
+      history_name: nightly-dbsync
     secrets:
+      TCACHE_BASIC_AUTH: ${{ secrets.TCACHE_BASIC_AUTH }}
+      TCACHE_URL: ${{ secrets.TCACHE_URL }}
       CI_FAIL_MAILS: ${{ secrets.NIGHTLY_FAIL_MAILS }}
       GMAIL_USERNAME: ${{ secrets.GMAIL_USERNAME }}
       GMAIL_PASSWORD: ${{ secrets.GMAIL_PASSWORD }}

--- a/.github/workflows/regression_reusable.yaml
+++ b/.github/workflows/regression_reusable.yaml
@@ -55,6 +55,12 @@ on:
         required: false
         type: boolean
         default: false
+      history_name:
+        # Deliberately not `testrun_name`: that one also switches on the
+        # `/results` import below, which nightly runs must stay out of.
+        required: false
+        type: string
+        default: ""
     secrets:
       TCACHE_BASIC_AUTH:
         required: false
@@ -254,6 +260,28 @@ jobs:
           if [ -n "$TCACHE_BASIC_AUTH" ] && [ -n "$TCACHE_URL" ] && [ -e run_workdir/testrun-report.xml ]; then
             testrun_name_strip="${CI_TESTRUN_NAME//[!a-zA-Z0-9_-]/}"
             curl -s -X PUT --fail-with-body -u "$TCACHE_BASIC_AUTH" "$TCACHE_URL/${testrun_name_strip}/${{ github.run_number }}/import" -F "junitxml=@run_workdir/testrun-report.xml"
+          fi
+      - name: Report nightly history
+        # Keeps a failed nightly's XML for the failure analysis to compare against.
+        if: (success() || failure()) && steps.testing-step.outcome != 'success' && inputs.history_name
+        env:
+          TCACHE_BASIC_AUTH: ${{ secrets.TCACHE_BASIC_AUTH }}
+          TCACHE_URL: ${{ secrets.TCACHE_URL }}
+          HISTORY_NAME: ${{ inputs.history_name }}
+          RUN_NUMBER: ${{ github.run_number }}
+        run: |
+          report=run_workdir/testrun-report.xml
+          if [ -n "$TCACHE_BASIC_AUTH" ] && [ -n "$TCACHE_URL" ] && [ -f "$report" ]; then
+            # `TCACHE_URL` ends in `/results`; `/history` is a sibling route.
+            root="${TCACHE_URL%/}"
+            entry="${root%/results}/history/${HISTORY_NAME}/${RUN_NUMBER}"
+            curl -s -X PUT --fail-with-body -u "$TCACHE_BASIC_AUTH" "$entry" -F "junitxml=@$report"
+            # A proxy with no `/history` route answers 200 with an empty body.
+            stored="$(curl -s -o /dev/null -w '%{size_download}' -u "$TCACHE_BASIC_AUTH" "$entry/xml")"
+            if [ "$stored" != "$(stat -c%s "$report")" ]; then
+              echo "::error::The tcache holds $stored bytes for run $RUN_NUMBER; is /history routed?"
+              exit 1
+            fi
           fi
       - name: ↟ Upload testing artifacts on failure
         uses: actions/upload-artifact@v7


### PR DESCRIPTION
Store a failed nightly's JUnit XML in tcache's `/history`, so the failure
analysis can tell a new failure from a recurring one. A new `history_name`
input turns it on, and only the three nightlies set it.

Not `testrun_name`, because that input also gates the `/import` step above, and
nightlies must stay out of it.

`TCACHE_URL` ends in `/results`, so the suffix is stripped before appending
`/history`. Without that, every upload returns 404.

The step then compares the bytes tcache serves back against the bytes sent. A
200 alone is not enough, because Caddy answers an unrouted path with 200 and an
empty body.

This needs the `history` table migration and a `reverse_proxy /history/*` line
on the tcache host. If either is missing the step fails and says so.

Tested locally against tcache at master behind a real Caddy, on a database
migrated from the old schema. A real node test's report uploaded and read back
byte-identical, with its failure intact. The `if:` gate is the one part that
needs a real run.
