### PR TITLE
fix(docs): resolve package from built checkout

### DIFF
--- a/doc/leios_tests.md
+++ b/doc/leios_tests.md
@@ -94,7 +94,7 @@ On a failed testrun the workflow runs the analysis automatically and surfaces it
 
 * the **run summary** of the workflow run, and a foldable `Preliminary failure analysis`
   group in the log of the `Read failure analysis into env` step,
-* `failure_analysis.md` in the **`testrun-files`** artifact.
+* `failure_analysis.md` in the `testrun-files` artifact.
 
 ## Known Failures
 

--- a/src_docs/source/conf.py
+++ b/src_docs/source/conf.py
@@ -16,16 +16,15 @@ if not os.environ.get("CARDANO_NODE_SOCKET_PATH"):
     mockdir = Path(__file__).parent / "mocks"
     os.environ["PATH"] = f"{mockdir}:{os.environ['PATH']}"
 
-
-import cardano_node_tests
-
 # -- Path setup --------------------------------------------------------------
 
 # If extensions (or modules to document with autodoc) are in another directory,
-# add these directories to sys.path here. If the directory is relative to the
-# documentation root, use os.path.abspath to make it absolute, like shown here.
-sys.path.insert(0, os.path.abspath(".."))  # noqa: PTH100
+# add these directories to sys.path here. Prepend the repo root so that the
+# checkout this doc is built from wins over any installed (e.g. editable)
+# version of the package. Must happen before `cardano_node_tests` is imported.
+sys.path.insert(0, str(Path(__file__).parents[2]))
 
+import cardano_node_tests
 
 # -- Project information -----------------------------------------------------
 


### PR DESCRIPTION
Worktrees share one .venv via symlink, so `pip install -e .` from any worktree points the editable finder at that worktree for all of them. Sphinx runs with cwd=src_docs, so the old `sys.path` entry (src_docs) did not shadow the finder and autodoc imported the wrong checkout, reporting modules that exist here as missing.

Prepend the repo root instead, before `cardano_node_tests` is imported, since the package `__path__` bound there decides submodule lookup.

Also drop bold around inline code in leios_tests.md - m2r2 renders the nesting as rst that docutils cannot parse.