### PR TITLE
fix: quote annotations shadowed by class members

### DIFF
--- a/cardano_node_tests/cluster_management/manager.py
+++ b/cardano_node_tests/cluster_management/manager.py
@@ -96,7 +96,7 @@ class ClusterManager:
         return self._cluster_instance_num
 
     @property
-    def cache(self) -> cache.ClusterManagerCache:
+    def cache(self) -> "cache.ClusterManagerCache":
         return cache.CacheManager.get_instance_cache(instance_num=self.cluster_instance_num)
 
     @property

--- a/cardano_node_tests/utils/cluster_nodes.py
+++ b/cardano_node_tests/utils/cluster_nodes.py
@@ -75,7 +75,7 @@ class ClusterType(tp.Protocol):
     NODES: tp.ClassVar[frozenset[str]]
 
     type: ClusterKind
-    cluster_scripts: cluster_scripts.ScriptsTypes
+    cluster_scripts: "cluster_scripts.ScriptsTypes"
 
     @property
     def is_local(self) -> bool:

--- a/cardano_node_tests/utils/gh_issue.py
+++ b/cardano_node_tests/utils/gh_issue.py
@@ -22,11 +22,11 @@ class GHIssue:
 
     issue_cache: tp.ClassVar[dict[str, str]] = {}
 
-    _github_instance: tp.ClassVar[github.Github | None] = None
+    _github_instance: tp.ClassVar["github.Github | None"] = None
     _github_instance_error: tp.ClassVar[bool] = False
 
     @classmethod
-    def _get_github(cls) -> github.Github | None:
+    def _get_github(cls) -> "github.Github | None":
         """Get GitHub instance."""
         if cls._github_instance is not None:
             return cls._github_instance
@@ -51,7 +51,7 @@ class GHIssue:
         self.repo = repo
 
     @property
-    def github(self) -> github.Github | None:
+    def github(self) -> "github.Github | None":
         return self._get_github()
 
     @property


### PR DESCRIPTION
Python 3.14 (PEP 649) evaluates annotations lazily, after the class body has executed, so a class member whose name matches an imported module shadows that module when the annotation is finally resolved, e.g. `ClusterManager.cache` (property) over the `cache` module. Sphinx resolving type hints then crashed the doc build with

    AttributeError: 'property' object has no attribute 'ClusterManagerCache'

Quote the affected annotations so they resolve in module globals.