### PR TITLE
docs: link sync results to tag testing

### DIFF
--- a/src_docs/source/test_results/sync_tests.rst
+++ b/src_docs/source/test_results/sync_tests.rst
@@ -8,3 +8,6 @@ The sync tests evaluate the performance of syncing the Cardano mainnet from gene
 - **Node resource usage** – including CPU and memory utilization
 
 The source code for these tests is available in the `cardano-sync-tests <https://github.com/IntersectMBO/cardano-sync-tests>`__ repository.
+
+Results for each `cardano-node` release are linked from the corresponding report in
+:doc:`tag_tests`.


### PR DESCRIPTION
Point to the per-release reports in Tag Testing, where the sync results now live, using a Sphinx cross-reference.