### PR TITLE
fix: make decoded tx metadata mutable

### DIFF
--- a/cardano_node_tests/utils/clusterlib_utils.py
+++ b/cardano_node_tests/utils/clusterlib_utils.py
@@ -11,6 +11,7 @@ import pathlib as pl
 import random
 import time
 import typing as tp
+from collections import abc
 
 import cardano_clusterlib.types as cl_types
 import cbor2
@@ -1249,8 +1250,41 @@ def wait_for_epoch_interval(
         raise RuntimeError(msg)
 
 
+def _cbor_to_mutable(data: tp.Any) -> tp.Any:
+    """Convert immutable containers created by `cbor2` into their mutable counterparts.
+
+    `cbor2` decodes the content of a CBOR tag into `frozendict`, `tuple` and `frozenset`
+    instances. Those are not JSON serializable and don't compare equal to the `dict` and
+    `list` values loaded from the original metadata files.
+
+    Map keys are left as they are, as they need to stay hashable. The metadata CDDL allows
+    a map or a list as a map key, and such a key stays immutable (and not JSON
+    serializable) even after the conversion.
+
+    Args:
+        data: Any value decoded by `cbor2`.
+
+    Returns:
+        The value with every mapping turned into a `dict` and every tuple or set into
+        a `list`.
+    """
+    if isinstance(data, cbor2.CBORTag):
+        return cbor2.CBORTag(data.tag, _cbor_to_mutable(data.value))
+    if isinstance(data, abc.Mapping):
+        return {k: _cbor_to_mutable(v) for k, v in data.items()}
+    if isinstance(data, (set, frozenset)):
+        return [_cbor_to_mutable(i) for i in data]
+    if isinstance(data, (list, tuple)):
+        return [_cbor_to_mutable(i) for i in data]
+    return data
+
+
 def load_body_metadata(*, tx_body_file: pl.Path) -> tp.Any:
-    """Load metadata from file containing transaction body."""
+    """Load metadata from file containing transaction body.
+
+    Containers are converted to their mutable counterparts, so the result can be
+    modified and serialized to JSON.
+    """
     with open(tx_body_file, encoding="utf-8") as body_fp:
         tx_body_json = json.load(body_fp)
 
@@ -1261,7 +1295,7 @@ def load_body_metadata(*, tx_body_file: pl.Path) -> tp.Any:
     if not metadata:
         return []
 
-    return metadata
+    return _cbor_to_mutable(metadata)
 
 
 def load_tx_metadata(*, tx_body_file: pl.Path) -> TxMetadata:

--- a/framework_tests/test_clusterlib_utils.py
+++ b/framework_tests/test_clusterlib_utils.py
@@ -5,6 +5,7 @@ The tests must not depend on project-specific binaries (`cardano-cli`, ...) bein
 
 import json
 import pathlib as pl
+import typing as tp
 
 import cbor2
 import pytest
@@ -21,6 +22,59 @@ def write_script(*, script: dict, dest_dir: pl.Path) -> pl.Path:
     with open(script_file, "w", encoding="utf-8") as fp_out:
         json.dump(script, fp_out, indent=4)
     return script_file
+
+
+def write_tx_body(*, aux_data: tp.Any, dest_dir: pl.Path) -> pl.Path:
+    """Write a Tx body file with the given auxiliary data and return its path."""
+    # A Tx body is a 4-element array - body, witnesses, validity flag and auxiliary data
+    cbor_body = cbor2.dumps([{}, {}, True, aux_data])
+    body_file = dest_dir / "tx.body"
+    with open(body_file, "w", encoding="utf-8") as fp_out:
+        json.dump(
+            {"type": "Unwitnessed Tx ConwayEra", "description": "", "cborHex": cbor_body.hex()},
+            fp_out,
+        )
+    return body_file
+
+
+class TestLoadTxMetadata:
+    """Tests for `load_tx_metadata`.
+
+    The metadata map is stored under CBOR tag 259, whose content `cbor2` decodes into
+    immutable containers. The loaded metadata must still be mutable and JSON serializable.
+    """
+
+    def test_metadata(self, tmp_path: pl.Path):
+        """Load metadata that nests a map and a list."""
+        metadata = {1: "foo", 2: [1, 2, {3: "bar"}]}
+        body_file = write_tx_body(aux_data=cbor2.CBORTag(259, {0: metadata}), dest_dir=tmp_path)
+
+        loaded = clusterlib_utils.load_tx_metadata(tx_body_file=body_file)
+
+        assert loaded.metadata == metadata
+        assert isinstance(loaded.metadata, dict)
+        assert isinstance(loaded.metadata[2], list)
+        assert isinstance(loaded.metadata[2][2], dict)
+        # The metadata must be JSON serializable, so keys can be converted to strings
+        assert json.loads(json.dumps(loaded.metadata)) == {"1": "foo", "2": [1, 2, {"3": "bar"}]}
+
+    def test_metadata_with_set(self, tmp_path: pl.Path):
+        """Load metadata that nests a set, which is converted to a list."""
+        body_file = write_tx_body(aux_data=cbor2.CBORTag(259, {0: {1: {"foo"}}}), dest_dir=tmp_path)
+
+        loaded = clusterlib_utils.load_tx_metadata(tx_body_file=body_file)
+
+        assert loaded.metadata == {1: ["foo"]}
+        assert json.dumps(loaded.metadata)
+
+    def test_no_metadata(self, tmp_path: pl.Path):
+        """Load metadata from a Tx body that has no auxiliary data."""
+        body_file = write_tx_body(aux_data=None, dest_dir=tmp_path)
+
+        loaded = clusterlib_utils.load_tx_metadata(tx_body_file=body_file)
+
+        assert loaded.metadata == {}
+        assert loaded.aux_data == []
 
 
 class TestGetReferenceScriptSize:


### PR DESCRIPTION
`cbor2` 6 decodes the content of a CBOR tag into `frozendict`, `tuple` and `frozenset` instances. The metadata map lives under tag 259, so the values returned by `load_tx_metadata` were no longer JSON serializable and the metadata tests broke with

  TypeError: Object of type frozendict is not JSON serializable

Convert every mapping to a `dict` and every tuple or set to a `list` in `load_body_metadata`, so all callers get mutable containers. The mapping arm matches on `abc.Mapping`, as `frozendict` is not a `dict` subclass, therefore the conversion works with both `cbor2` 5 and 6.

Add unit tests, so the behavior is pinned without a cluster.