### PR TITLE
fix(test): don't calculate fee in `test_wrong_tx_era`

### DIFF
--- a/cardano_node_tests/tests/test_tx_negative.py
+++ b/cardano_node_tests/tests/test_tx_negative.py
@@ -903,6 +903,7 @@ class TestNegative:
 
         * Prepare transaction from pool_users[0] to pool_users[1] with 1.5 ADA
         * Use cluster instance configured for era > current network era
+        * Pass a hardcoded fee to skip fee calculation
         * Attempt to submit transaction built for future era
         * Check that transaction fails with era mismatch error
         """
@@ -911,13 +912,19 @@ class TestNegative:
         tx_files = clusterlib.TxFiles(signing_key_files=[pool_users[0].payment.skey_file])
         txouts = [clusterlib.TxOut(address=pool_users[1].payment.address, amount=1_500_000)]
 
-        # It should NOT be possible to submit a transaction when TX era > network era
+        # It should NOT be possible to submit a transaction when TX era > network era.
+        # The fee is hardcoded on purpose - fee calculation would make `cardano-cli` parse the
+        # protocol parameters of the current network era under the future era, and the parser
+        # of the future era can require protocol parameters that the current era doesn't emit.
+        # The transaction is expected to be rejected when it is submitted, not when its fee
+        # is calculated.
         with pytest.raises(clusterlib.CLIError) as excinfo:
             cluster_wrong_tx_era.g_transaction.send_tx(
                 src_address=pool_users[0].payment.address,
                 tx_name=temp_template,
                 txouts=txouts,
                 tx_files=tx_files,
+                fee=400_000,
             )
         exc_value = str(excinfo.value)
         with common.allow_unstable_error_messages():


### PR DESCRIPTION
The test builds a transaction for an era higher than the network era, so the transaction gets rejected on submit. Its fee calculation, however, made `cardano-cli` parse the protocol parameters of the current network era under the future era, and `cardano-cli` 11.2.3 fails to do that for a Conway network and a Dijkstra transaction:

  Error while decoding the protocol parameters ...
  Error in $: key "maxRefScriptSizePerBlock" not found

The test then failed on the fee calculation error instead of on the expected era mismatch error. Pass a hardcoded fee, so no protocol parameters are needed and the transaction reaches the submit step.