### PR TITLE
fix(lint): run mypy as single pre-commit process

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -50,3 +50,12 @@ repos:
     entry: mypy
     language: system
     types: [python]
+    # Run mypy once on all sources instead of letting pre-commit shard the files
+    # over parallel processes. mypy 2.x enables the SQLite cache by default,
+    # and concurrent processes sharing `.mypy_cache` fail to acquire its lock:
+    # `sqlite3.OperationalError: database is locked` surfaces as an intermittent
+    # mypy `INTERNAL ERROR`. Sharding is also slower, as every shard re-analyzes
+    # the full dependency graph.
+    pass_filenames: false
+    require_serial: true
+    args: [cardano_node_tests, framework_tests, scripts/count_test_results.py, src_docs/source/conf.py]


### PR DESCRIPTION
The local mypy hook passed filenames without `require_serial`, so pre-commit sharded all 188 Python files across 24 concurrent mypy processes (8 files each).

Since the bump to mypy 2.3.1 this fails intermittently: `sqlite_cache` now defaults to True (it was False in 1.19.0), so every process opens the same `.mypy_cache` SQLite database and runs `PRAGMA journal_mode=WAL`, which needs an exclusive lock. Under contention sqlite raises `OperationalError: database is locked`, which mypy does not handle and reports as `INTERNAL ERROR`. Measured 3 failures over 15 cold-cache runs. The old filesystem cache backend tolerated this because it wrote one JSON file per module via atomic rename.

Sharding was also wasteful, as every shard re-analyzed the whole dependency graph: 22s before, 13s after on a cold cache.

Set `pass_filenames: false` and `require_serial: true`, and pass the source paths explicitly. `types: [python]` still gates the hook on a Python file having changed.