### PR TITLE
docs(readme): fix cluster start in test env

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ For workflows requiring repeated test runs on a persistent testnet cluster:
 4. Launch the local testnet cluster:
 
    ```sh
-   make start-cluster
+   ./dev_workdir/local_fast/start-cluster
    ```
 
 5. Run your tests:
@@ -142,7 +142,7 @@ For workflows requiring repeated test runs on a persistent testnet cluster:
 6. Stop the testnet cluster:
 
    ```sh
-   make stop-cluster
+   ./dev_workdir/local_fast/stop-cluster
    ```
 
 > ℹ️ **Pro Tip:** Next time, you can omit step 2 if the environment is already set up.


### PR DESCRIPTION
`make start-cluster` and `make stop-cluster` depend on `.check-venv-activated`, which requires `./.venv`. The persistent testnet workflow activates `dev_workdir/.venv` instead, so both steps failed with "Wrong virtual environment is activated" ever since the guard was added in e89afa2c.

Point them at the scripts directly, which is what `setup_test_env.sh` already prints on completion.